### PR TITLE
feat: allow showing non-whitelisted assets in asset filters

### DIFF
--- a/app/markets/components/AssetFilter.tsx
+++ b/app/markets/components/AssetFilter.tsx
@@ -3,14 +3,14 @@ import { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { ChevronDownIcon, TrashIcon } from '@radix-ui/react-icons';
 import { motion, AnimatePresence } from 'framer-motion';
 import Image from 'next/image';
-import { ERC20Token, infoToKey } from '@/utils/tokens';
+import { ERC20Token, UnknownERC20Token, infoToKey } from '@/utils/tokens';
 
 type FilterProps = {
   label: string;
   placeholder: string;
   selectedAssets: string[];
   setSelectedAssets: (assets: string[]) => void;
-  items: ERC20Token[];
+  items: (ERC20Token | UnknownERC20Token)[];
   loading: boolean;
   updateFromSearch?: string[];
 };
@@ -103,8 +103,17 @@ export default function AssetFilter({
                   (item) =>
                     item.networks.map((n) => infoToKey(n.address, n.chain.id)).join('|') === asset,
                 );
-                return token?.img ? (
-                  <Image key={asset} src={token.img} alt={token.symbol} width={18} height={18} />
+                return token ? (
+                  token.img ? (
+                    <Image key={asset} src={token.img} alt={token.symbol} width={18} height={18} />
+                  ) : (
+                    <div
+                      key={asset}
+                      className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-gray-200 text-xs dark:bg-gray-700"
+                    >
+                      ?
+                    </div>
+                  )
                 ) : null;
               })}
             </div>
@@ -156,9 +165,15 @@ export default function AssetFilter({
                     )}
                     tabIndex={0}
                   >
-                    <span>{token.symbol}</span>
-                    {token.img && (
+                    <span title={token.symbol}>
+                      {token.symbol.length > 8 ? `${token.symbol.slice(0, 8)}...` : token.symbol}
+                    </span>
+                    {token.img ? (
                       <Image src={token.img} alt={token.symbol} width={18} height={18} />
+                    ) : (
+                      <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-gray-200 text-xs dark:bg-gray-700">
+                        ?
+                      </div>
                     )}
                   </li>
                 ))}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,19 +1,16 @@
 'use client';
 
-import { useCallback } from 'react';
 import { Switch } from '@nextui-org/react';
 import Header from '@/components/layout/header/Header';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 export default function SettingsPage() {
   const [usePermit2, setUsePermit2] = useLocalStorage('usePermit2', true);
-
-  const handlePermit2Toggle = useCallback(
-    (checked: boolean) => {
-      setUsePermit2(checked);
-    },
-    [setUsePermit2],
+  const [includeUnknownTokens, setIncludeUnknownTokens] = useLocalStorage(
+    'includeUnknownTokens',
+    false,
   );
+  const [showUnknownOracle, setShowUnknownOracle] = useLocalStorage('showUnknownOracle', false);
 
   return (
     <div className="flex w-full flex-col justify-between font-zen">
@@ -41,7 +38,57 @@ export default function SettingsPage() {
                 </div>
                 <Switch
                   defaultSelected={usePermit2}
-                  onValueChange={handlePermit2Toggle}
+                  onValueChange={setUsePermit2}
+                  size="sm"
+                  color="primary"
+                  className="min-w-[64px]"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Filter Settings Section */}
+          <div className="flex flex-col gap-4">
+            <h2 className="text-xl font-semibold text-primary">Filter Settings</h2>
+
+            <div className="bg-surface flex flex-col gap-6 rounded p-6">
+              {/* Group related settings with a subtle separator */}
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <h3 className="text-lg font-medium text-primary">Show Unknown Tokens</h3>
+                  <p className="text-sm text-secondary">
+                    Display tokens that aren't in our recognized token list. These will appear with
+                    a question mark icon.
+                  </p>
+                  <p className="mt-2 text-xs text-secondary opacity-80">
+                    Warning: Unknown tokens should be approached with caution as they haven't been
+                    verified.
+                  </p>
+                </div>
+                <Switch
+                  defaultSelected={includeUnknownTokens}
+                  onValueChange={setIncludeUnknownTokens}
+                  size="sm"
+                  color="primary"
+                  className="min-w-[64px]"
+                />
+              </div>
+
+              <div className="my-2 border-t border-gray-200 dark:border-gray-700" />
+
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <h3 className="text-lg font-medium text-primary">Show Unknown Oracles</h3>
+                  <p className="text-sm text-secondary">
+                    Display markets using oracle implementations that haven't been verified yet.
+                  </p>
+                  <p className="mt-2 text-xs text-secondary opacity-80">
+                    Warning: Markets with unknown oracles may have additional risks.
+                  </p>
+                </div>
+                <Switch
+                  defaultSelected={showUnknownOracle}
+                  onValueChange={setShowUnknownOracle}
                   size="sm"
                   color="primary"
                   className="min-w-[64px]"

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -11,6 +11,14 @@ export type ERC20Token = {
   };
 };
 
+export type UnknownERC20Token = {
+  symbol: string;
+  img: undefined;
+  decimals: number;
+  networks: { chain: Chain; address: string }[];
+  isUnknown?: boolean;
+};
+
 const MORPHOTokenAddress = '0x9994E35Db50125E0DF82e4c2dde62496CE330999';
 
 const supportedTokens = [

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -360,20 +360,3 @@ export type MarketHistoricalData = {
   rates: MarketRates;
   volumes: MarketVolumes;
 };
-
-// Add this near your other types
-export type UnknownERC20Token = {
-  address: string;
-  chainId: number;
-  symbol: string;
-  img?: string;
-  isUnknown?: boolean; // Flag to identify unknown tokens
-};
-
-// Update the existing type to be more specific
-export type ERC20Token = {
-  address: string;
-  chainId: number;
-  symbol: string;
-  img: string; // Now required for known tokens
-};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -360,3 +360,20 @@ export type MarketHistoricalData = {
   rates: MarketRates;
   volumes: MarketVolumes;
 };
+
+// Add this near your other types
+export type UnknownERC20Token = {
+  address: string;
+  chainId: number;
+  symbol: string;
+  img?: string;
+  isUnknown?: boolean; // Flag to identify unknown tokens
+};
+
+// Update the existing type to be more specific
+export type ERC20Token = {
+  address: string;
+  chainId: number;
+  symbol: string;
+  img: string; // Now required for known tokens
+};


### PR DESCRIPTION
* This require manually allow in settings
* After enabling, these assets will be treated similarly to other assets, also appearing in filters

## Impacts
* Remove the advanced options on the main layout, moved to settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced token filtering capabilities to include unknown tokens.
  - New settings for managing visibility of unknown tokens and oracle verification on the Settings page.
  - Tooltip guidance added for improved user experience.

- **Bug Fixes**
  - Improved rendering logic for token images with fallbacks for missing images.

- **Refactor**
  - Streamlined state management in the Markets component using local storage.
  - Simplified control flow by removing unnecessary functions in the Settings page.

- **Documentation**
  - Updated hints in the EmptyScreen component to reflect new filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->