### PR TITLE
feat: add liquidations table to market page

### DIFF
--- a/app/market/[chainId]/[marketid]/components/LiquidationsTable.tsx
+++ b/app/market/[chainId]/[marketid]/components/LiquidationsTable.tsx
@@ -9,6 +9,7 @@ import AccountWithAvatar from '@/components/Account/AccountWithAvatar';
 import { MarketLiquidationTransaction } from '@/hooks/useMarketLiquidations';
 import { getExplorerTxURL, getExplorerURL } from '@/utils/external';
 import { findToken } from '@/utils/tokens';
+import { Market } from '@/utils/types';
 
 // Helper functions to format data
 const formatAddress = (address: string) => {
@@ -20,7 +21,7 @@ type LiquidationsTableProps = {
   liquidations: MarketLiquidationTransaction[];
   loading: boolean;
   error: string | null;
-  market: any; // Using any for now, would be better to type this properly
+  market: Market;
 };
 
 export function LiquidationsTable({
@@ -114,14 +115,14 @@ export function LiquidationsTable({
               <TableCell className="text-right">
                 {formatUnits(
                   BigInt(liquidation.data.repaidAssets),
-                  market?.loanAsset?.decimals || 6,
+                  loanToken?.decimals || 6,
                 )}
                 {market?.loanAsset?.symbol && (
                   <span className="ml-1 inline-flex items-center">
                     {loanToken?.img && (
                       <Image
                         src={loanToken.img}
-                        alt={market.loanAsset.symbol}
+                        alt={market.loanAsset.symbol || ''}
                         width={16}
                         height={16}
                         className="rounded-full"
@@ -133,14 +134,14 @@ export function LiquidationsTable({
               <TableCell className="text-right">
                 {formatUnits(
                   BigInt(liquidation.data.seizedAssets),
-                  market?.collateralAsset?.decimals || 18,
+                  collateralToken?.decimals || 18,
                 )}
                 {market?.collateralAsset?.symbol && (
                   <span className="ml-1 inline-flex items-center">
                     {collateralToken?.img && (
                       <Image
                         src={collateralToken.img}
-                        alt={market.collateralAsset.symbol}
+                        alt={market.collateralAsset.symbol || ''}
                         width={16}
                         height={16}
                         className="rounded-full"

--- a/app/market/[chainId]/[marketid]/components/LiquidationsTable.tsx
+++ b/app/market/[chainId]/[marketid]/components/LiquidationsTable.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useState } from 'react';
+import { Link, Pagination } from '@nextui-org/react';
+import { Table, TableHeader, TableBody, TableColumn, TableRow, TableCell } from '@nextui-org/table';
+import { ExternalLinkIcon } from '@radix-ui/react-icons';
+import moment from 'moment';
+import Image from 'next/image';
+import { Address, formatUnits } from 'viem';
+import AccountWithAvatar from '@/components/Account/AccountWithAvatar';
+import { MarketLiquidationTransaction } from '@/hooks/useMarketLiquidations';
+import { getExplorerTxURL, getExplorerURL } from '@/utils/external';
+import { findToken } from '@/utils/tokens';
+
+// Helper functions to format data
+const formatAddress = (address: string) => {
+  return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
+};
+
+type LiquidationsTableProps = {
+  chainId: number;
+  liquidations: MarketLiquidationTransaction[];
+  loading: boolean;
+  error: string | null;
+  market: any; // Using any for now, would be better to type this properly
+};
+
+export function LiquidationsTable({
+  chainId,
+  liquidations,
+  loading,
+  error,
+  market,
+}: LiquidationsTableProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 8;
+  const totalPages = Math.ceil(liquidations.length / pageSize);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const paginatedLiquidations = useMemo(() => {
+    const sliced = liquidations.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+    return sliced;
+  }, [currentPage, liquidations, pageSize]);
+
+  const tableKey = `liquidations-table-${currentPage}`;
+
+  const collateralToken = useMemo(() => {
+    if (!market) return null;
+    return findToken(market.collateralAsset.address, chainId);
+  }, [market, chainId]);
+
+  const loanToken = useMemo(() => {
+    if (!market) return null;
+    return findToken(market.loanAsset.address, chainId);
+  }, [market, chainId]);
+
+  if (error) {
+    return <p className="text-danger">Error loading liquidations: {error}</p>;
+  }
+
+  return (
+    <div className="mt-8">
+      <h4 className="mb-4 text-xl font-semibold">Liquidations</h4>
+
+      <Table
+        key={tableKey}
+        aria-label="Liquidations history"
+        bottomContent={
+          totalPages > 1 ? (
+            <div className="flex w-full justify-center">
+              <Pagination
+                isCompact
+                showControls
+                color="primary"
+                page={currentPage}
+                total={totalPages}
+                onChange={handlePageChange}
+              />
+            </div>
+          ) : null
+        }
+      >
+        <TableHeader>
+          <TableColumn>Liquidator</TableColumn>
+          <TableColumn align="end">Repaid ({market?.loanAsset?.symbol || 'USDC'})</TableColumn>
+          <TableColumn align="end">
+            Seized{' '}
+            {market?.collateralAsset?.symbol && (
+              <span className="inline-flex items-center">{market.collateralAsset.symbol}</span>
+            )}
+          </TableColumn>
+          <TableColumn>Time</TableColumn>
+          <TableColumn className="font-mono">Transaction</TableColumn>
+        </TableHeader>
+        <TableBody
+          className="font-zen"
+          emptyContent={loading ? 'Loading...' : 'No liquidations found for this market'}
+          isLoading={loading}
+        >
+          {paginatedLiquidations.map((liquidation) => (
+            <TableRow key={liquidation.hash}>
+              <TableCell>
+                <Link
+                  href={getExplorerURL(liquidation.data.liquidator, chainId)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center text-primary"
+                >
+                  <AccountWithAvatar address={liquidation.data.liquidator as Address} />
+                  <ExternalLinkIcon className="ml-1" />
+                </Link>
+              </TableCell>
+              <TableCell className="text-right">
+                {formatUnits(
+                  BigInt(liquidation.data.repaidAssets),
+                  market?.loanAsset?.decimals || 6,
+                )}
+                {market?.loanAsset?.symbol && (
+                  <span className="ml-1 inline-flex items-center">
+                    {loanToken?.img && (
+                      <Image
+                        src={loanToken.img}
+                        alt={market.loanAsset.symbol}
+                        width={16}
+                        height={16}
+                        className="rounded-full"
+                      />
+                    )}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell className="text-right">
+                {formatUnits(
+                  BigInt(liquidation.data.seizedAssets),
+                  market?.collateralAsset?.decimals || 18,
+                )}
+                {market?.collateralAsset?.symbol && (
+                  <span className="ml-1 inline-flex items-center">
+                    {collateralToken?.img && (
+                      <Image
+                        src={collateralToken.img}
+                        alt={market.collateralAsset.symbol}
+                        width={16}
+                        height={16}
+                        className="rounded-full"
+                      />
+                    )}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell>{moment.unix(liquidation.timestamp).fromNow()}</TableCell>
+              <TableCell className="font-zen ">
+                <Link
+                  href={getExplorerTxURL(liquidation.hash, chainId)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center text-sm text-secondary"
+                >
+                  {formatAddress(liquidation.hash)}
+                  <ExternalLinkIcon className="ml-1" />
+                </Link>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/app/market/[chainId]/[marketid]/components/LiquidationsTable.tsx
+++ b/app/market/[chainId]/[marketid]/components/LiquidationsTable.tsx
@@ -84,7 +84,7 @@ export function LiquidationsTable({
       >
         <TableHeader>
           <TableColumn>Liquidator</TableColumn>
-          <TableColumn align="end">Repaid ({market?.loanAsset?.symbol || 'USDC'})</TableColumn>
+          <TableColumn align="end">Repaid ({market?.loanAsset?.symbol ?? 'USDC'})</TableColumn>
           <TableColumn align="end">
             Seized{' '}
             {market?.collateralAsset?.symbol && (
@@ -113,10 +113,7 @@ export function LiquidationsTable({
                 </Link>
               </TableCell>
               <TableCell className="text-right">
-                {formatUnits(
-                  BigInt(liquidation.data.repaidAssets),
-                  loanToken?.decimals || 6,
-                )}
+                {formatUnits(BigInt(liquidation.data.repaidAssets), loanToken?.decimals ?? 6)}
                 {market?.loanAsset?.symbol && (
                   <span className="ml-1 inline-flex items-center">
                     {loanToken?.img && (
@@ -134,14 +131,14 @@ export function LiquidationsTable({
               <TableCell className="text-right">
                 {formatUnits(
                   BigInt(liquidation.data.seizedAssets),
-                  collateralToken?.decimals || 18,
+                  collateralToken?.decimals ?? 18,
                 )}
                 {market?.collateralAsset?.symbol && (
                   <span className="ml-1 inline-flex items-center">
                     {collateralToken?.img && (
                       <Image
                         src={collateralToken.img}
-                        alt={market.collateralAsset.symbol || ''}
+                        alt={market.collateralAsset.symbol}
                         width={16}
                         height={16}
                         className="rounded-full"

--- a/app/market/[chainId]/[marketid]/content.tsx
+++ b/app/market/[chainId]/[marketid]/content.tsx
@@ -14,12 +14,14 @@ import Header from '@/components/layout/header/Header';
 import OracleVendorBadge from '@/components/OracleVendorBadge';
 import { SupplyModal } from '@/components/supplyModal';
 import { useMarket, useMarketHistoricalData } from '@/hooks/useMarket';
+import useMarketLiquidations from '@/hooks/useMarketLiquidations';
 import MORPHO_LOGO from '@/imgs/tokens/morpho.svg';
 import { getExplorerURL, getMarketURL } from '@/utils/external';
 import { getIRMTitle } from '@/utils/morpho';
 import { getNetworkImg, getNetworkName, SupportedNetworks } from '@/utils/networks';
 import { findToken } from '@/utils/tokens';
 import { TimeseriesOptions } from '@/utils/types';
+import { LiquidationsTable } from './components/LiquidationsTable';
 import RateChart from './RateChart';
 import VolumeChart from './VolumeChart';
 
@@ -55,11 +57,18 @@ function MarketContent() {
     isLoading: isMarketLoading,
     error: marketError,
   } = useMarket(marketid as string, network);
+
   const {
     data: historicalData,
     isLoading: isHistoricalLoading,
     refetch: refetchHistoricalData,
   } = useMarketHistoricalData(marketid as string, network, rateTimeRange, volumeTimeRange);
+
+  const {
+    liquidations,
+    loading: liquidationsLoading,
+    error: liquidationsError,
+  } = useMarketLiquidations(market?.uniqueKey);
 
   const setTimeRangeAndRefetch = useCallback(
     (days: number, type: 'rate' | 'volume') => {
@@ -320,6 +329,14 @@ function MarketContent() {
           apyTimeframe={apyTimeframe}
           setApyTimeframe={setApyTimeframe}
           setTimeRangeAndRefetch={setTimeRangeAndRefetch}
+        />
+
+        <LiquidationsTable
+          chainId={network}
+          liquidations={liquidations || []}
+          loading={liquidationsLoading}
+          error={liquidationsError}
+          market={market}
         />
       </div>
     </>

--- a/docs/Styling.md
+++ b/docs/Styling.md
@@ -7,7 +7,6 @@ Use these shared components instead of raw HTML elements:
 - `Button`: Import from `@/components/common/Button` for all clickable actions
 - `Modal`: For all modal dialogs
 - `Card`: For contained content sections
-- `Typography`: For text elements
 
 ## Component Guidelines
 

--- a/src/components/Account/AccountWithAvatar.tsx
+++ b/src/components/Account/AccountWithAvatar.tsx
@@ -4,7 +4,7 @@ import { getSlicedAddress } from '@/utils/address';
 
 type AccountWithAvatarProps = {
   address: Address;
-}
+};
 
 function AccountWithSmallAvatar({ address }: AccountWithAvatarProps) {
   return (

--- a/src/components/Account/AccountWithAvatar.tsx
+++ b/src/components/Account/AccountWithAvatar.tsx
@@ -1,0 +1,20 @@
+import { Address } from 'viem';
+import { Avatar } from '@/components/Avatar/Avatar';
+import { getSlicedAddress } from '@/utils/address';
+
+type AccountWithAvatarProps = {
+  address: Address;
+}
+
+function AccountWithSmallAvatar({ address }: AccountWithAvatarProps) {
+  return (
+    <div className="inline-flex items-center gap-2">
+      <Avatar address={address as `0x${string}`} size={16} />
+      <span className="font-inter text-sm font-medium text-primary">
+        {getSlicedAddress(address as `0x${string}`)}
+      </span>
+    </div>
+  );
+}
+
+export default AccountWithSmallAvatar;

--- a/src/components/Account/AccountWithENS.tsx
+++ b/src/components/Account/AccountWithENS.tsx
@@ -1,0 +1,26 @@
+import { Address } from 'viem';
+import { Avatar } from '@/components/Avatar/Avatar';
+import { getSlicedAddress } from '@/utils/address';
+import { Name } from '../common/Name';
+
+type AccountWithENSProps = {
+  address: Address;
+};
+
+function AccountWithENS({ address }: AccountWithENSProps) {
+  return (
+    <div className="inline-flex items-center justify-start gap-2">
+      <Avatar address={address} />
+      <div className="inline-flex flex-col items-start justify-center gap-1">
+        <div className="font-inter text-sm font-medium text-primary">
+          <Name address={address} />
+        </div>
+        <span className="font-inter text-xs font-medium text-zinc-400">
+          {getSlicedAddress(address)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default AccountWithENS;

--- a/src/components/layout/header/AccountDropdown.tsx
+++ b/src/components/layout/header/AccountDropdown.tsx
@@ -5,6 +5,7 @@ import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem } from '@nextui-o
 import { ExitIcon, ExternalLinkIcon, CopyIcon } from '@radix-ui/react-icons';
 import { clsx } from 'clsx';
 import { useAccount, useDisconnect } from 'wagmi';
+import AccountWithENS from '@/components/Account/AccountWithENS';
 import { Avatar } from '@/components/Avatar/Avatar';
 import { Name } from '@/components/common/Name';
 import { useStyledToast } from '@/hooks/useStyledToast';
@@ -56,17 +57,7 @@ export function AccountDropdown() {
       >
         <DropdownItem className="border-b border-primary/10 pb-4" isReadOnly showDivider={false}>
           <div className="flex w-full flex-col gap-2">
-            <div className="inline-flex items-center justify-start gap-2">
-              <Avatar address={address} />
-              <div className="inline-flex flex-col items-start justify-center gap-1">
-                <div className="font-inter text-sm font-medium text-primary">
-                  <Name address={address} />
-                </div>
-                <span className="font-inter text-xs font-medium text-zinc-400">
-                  {getSlicedAddress(address)}
-                </span>
-              </div>
-            </div>
+            <AccountWithENS address={address} />
           </div>
         </DropdownItem>
 

--- a/src/components/layout/header/AccountDropdown.tsx
+++ b/src/components/layout/header/AccountDropdown.tsx
@@ -7,9 +7,7 @@ import { clsx } from 'clsx';
 import { useAccount, useDisconnect } from 'wagmi';
 import AccountWithENS from '@/components/Account/AccountWithENS';
 import { Avatar } from '@/components/Avatar/Avatar';
-import { Name } from '@/components/common/Name';
 import { useStyledToast } from '@/hooks/useStyledToast';
-import { getSlicedAddress } from '@/utils/address';
 import { getExplorerURL } from '@/utils/external';
 
 export function AccountDropdown() {

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -271,3 +271,35 @@ export const userTransactionsQuery = `
     }
   }
 `;
+
+export const marketLiquidationsQuery = `
+  query getMarketLiquidations($uniqueKey: String!, $first: Int, $skip: Int) {
+  transactions (where: {
+    marketUniqueKey_in: [$uniqueKey],
+    type_in: [MarketLiquidation]
+  },
+  first: $first,
+  skip: $skip
+  ) {
+      items {
+        hash
+        timestamp
+        type
+        data {
+          ... on MarketLiquidationTransactionData {
+            repaidAssets
+            seizedAssets
+            liquidator
+          }
+        }
+      }
+      pageInfo {
+        countTotal
+        count
+        limit
+        skip
+      }
+    }   
+  }
+
+`;

--- a/src/hooks/useMarketLiquidations.ts
+++ b/src/hooks/useMarketLiquidations.ts
@@ -52,7 +52,9 @@ const useMarketLiquidations = (marketUniqueKey: string | undefined) => {
         throw new Error('Failed to fetch market liquidations');
       }
 
-      const result = await response.json();
+      const result = (await response.json()) as {
+        data: { transactions: { items: MarketLiquidationTransaction[] } };
+      };
 
       if (result.data?.transactions?.items) {
         setLiquidations(result.data.transactions.items);
@@ -68,7 +70,7 @@ const useMarketLiquidations = (marketUniqueKey: string | undefined) => {
   }, [marketUniqueKey]);
 
   useEffect(() => {
-    fetchLiquidations();
+    void fetchLiquidations();
   }, [fetchLiquidations]);
 
   return {

--- a/src/hooks/useMarketLiquidations.ts
+++ b/src/hooks/useMarketLiquidations.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from 'react';
+import { marketLiquidationsQuery } from '@/graphql/queries';
+import { URLS } from '@/utils/urls';
+
+export type MarketLiquidationTransaction = {
+  hash: string;
+  timestamp: number;
+  type: string;
+  data: {
+    repaidAssets: string;
+    seizedAssets: string;
+    liquidator: string;
+  };
+};
+
+/**
+ * Hook to fetch all liquidations for a specific market
+ * @param marketUniqueKey The unique key of the market
+ * @returns List of all liquidation transactions for the market
+ */
+const useMarketLiquidations = (marketUniqueKey: string | undefined) => {
+  const [liquidations, setLiquidations] = useState<MarketLiquidationTransaction[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLiquidations = useCallback(async () => {
+    if (!marketUniqueKey) {
+      setLiquidations([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const variables = {
+        uniqueKey: marketUniqueKey,
+      };
+
+      const response = await fetch(`${URLS.MORPHO_BLUE_API}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: marketLiquidationsQuery,
+          variables,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch market liquidations');
+      }
+
+      const result = await response.json();
+
+      if (result.data?.transactions?.items) {
+        setLiquidations(result.data.transactions.items);
+      } else {
+        setLiquidations([]);
+      }
+    } catch (err) {
+      console.error('Error fetching market liquidations:', err);
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, [marketUniqueKey]);
+
+  useEffect(() => {
+    fetchLiquidations();
+  }, [fetchLiquidations]);
+
+  return {
+    liquidations,
+    loading,
+    error,
+  };
+};
+
+export default useMarketLiquidations;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new paginated table on market pages that displays liquidation transaction details—such as liquidator info, repaid amounts, seized assets, timestamps, and external links.
  - Added new components for displaying account information with avatars, including support for Ethereum Name Service (ENS).
  
- **Bug Fixes**
  - Ensured the liquidation table can render without errors even when no liquidation events are available.

- **Documentation**
  - Updated styling guidelines to reflect current best practices by removing outdated component recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->