### PR TITLE
fix: star page reset

### DIFF
--- a/app/markets/components/markets.tsx
+++ b/app/markets/components/markets.tsx
@@ -368,7 +368,6 @@ export default function Markets({
     }
 
     setFilteredMarkets(sorted);
-    resetPage();
   }, [
     rawMarkets,
     sortColumn,
@@ -387,13 +386,31 @@ export default function Markets({
     minLiquidityEnabled,
     trustedVaultsOnly,
     searchQuery,
-    resetPage,
     hasTrustedVault,
   ]);
 
   useEffect(() => {
     applyFiltersAndSort();
   }, [applyFiltersAndSort]);
+
+  // Reset page only when filters change (not when sorting or starring changes)
+  useEffect(() => {
+    resetPage();
+  }, [
+    selectedNetwork,
+    includeUnknownTokens,
+    showUnknownOracle,
+    selectedCollaterals,
+    selectedLoanAssets,
+    selectedOracles,
+    usdFilters,
+    minSupplyEnabled,
+    minBorrowEnabled,
+    minLiquidityEnabled,
+    trustedVaultsOnly,
+    searchQuery,
+    resetPage,
+  ]);
 
   const titleOnclick = useCallback(
     (column: number) => {


### PR DESCRIPTION
fix #188 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination behavior: page no longer resets when sorting or starring items, only when applying filters are changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->