### PR TITLE
feat: Add USD value toggle for accrued interest

### DIFF
--- a/src/stores/usePositionsPreferences.ts
+++ b/src/stores/usePositionsPreferences.ts
@@ -3,10 +3,12 @@ import { persist } from 'zustand/middleware';
 
 type PositionsPreferencesState = {
   showCollateralExposure: boolean;
+  showEarningsInUsd: boolean;
 };
 
 type PositionsPreferencesActions = {
   setShowCollateralExposure: (show: boolean) => void;
+  setShowEarningsInUsd: (show: boolean) => void;
 
   // Bulk update for migration
   setAll: (state: Partial<PositionsPreferencesState>) => void;
@@ -27,9 +29,11 @@ export const usePositionsPreferences = create<PositionsPreferencesStore>()(
     (set) => ({
       // Default state
       showCollateralExposure: true,
+      showEarningsInUsd: false,
 
       // Actions
       setShowCollateralExposure: (show) => set({ showCollateralExposure: show }),
+      setShowEarningsInUsd: (show) => set({ showEarningsInUsd: show }),
       setAll: (state) => set(state),
     }),
     {


### PR DESCRIPTION
Adds a toggle in the positions table settings to display accrued interest in USD. Handles small values (< $1) by showing 4 decimal places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View accrued position earnings in USD when market price is available.
  * New "Show Earnings in USD" toggle in settings to enable/disable USD value display.
  * Preference is persisted so the USD display setting is remembered across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->