### PR TITLE
fix: add global container padding at all viewport sizes

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -134,13 +134,6 @@
     padding-right: 1rem;
   }
 
-  @media (width >= 768px) {
-    .container {
-      padding-left: 0;
-      padding-right: 0;
-    }
-  }
-
   /* Grid texture patterns for landing page */
   .bg-dot-grid {
     background-image: radial-gradient(


### PR DESCRIPTION
## Summary

Follow-up to #329 — at medium viewport sizes (e.g. 800px, 1024px) the container max-width matched the viewport exactly, causing content to stick to the edges.

## Change

Removed the `@media (width >= 768px)` query that zeroed out container padding. Now `px-4` (16px) applies at **all** breakpoints so content never touches the viewport edges regardless of window size.

## Screenshots verified at
- 800px ✓
- 1024px ✓  
- 1280px ✓
- 375px mobile ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated container spacing behavior on larger viewports to maintain consistent horizontal padding across all screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->