### PR TITLE
feat(markets): add daily APY columns (24h supply/borrow)

### DIFF
--- a/src/data-sources/subgraph/market.ts
+++ b/src/data-sources/subgraph/market.ts
@@ -188,7 +188,9 @@ const transformSubgraphMarketToMarket = (
       timestamp,
       apyAtTarget: 0,
       rateAtTarget: '0',
-      // Subgraph doesn't support weekly/monthly APY - return null
+      // Subgraph doesn't support daily/weekly/monthly APY - return null
+      dailySupplyApy: null,
+      dailyBorrowApy: null,
       weeklySupplyApy: null,
       weeklyBorrowApy: null,
       monthlySupplyApy: null,

--- a/src/features/markets/components/column-visibility.ts
+++ b/src/features/markets/components/column-visibility.ts
@@ -9,6 +9,8 @@ export type ColumnVisibility = {
   rateAtTarget: boolean;
   trustedBy: boolean;
   utilizationRate: boolean;
+  dailySupplyAPY: boolean;
+  dailyBorrowAPY: boolean;
   weeklySupplyAPY: boolean;
   weeklyBorrowAPY: boolean;
   monthlySupplyAPY: boolean;
@@ -24,6 +26,8 @@ export const DEFAULT_COLUMN_VISIBILITY: ColumnVisibility = {
   rateAtTarget: false,
   trustedBy: false,
   utilizationRate: false,
+  dailySupplyAPY: false,
+  dailyBorrowAPY: false,
   weeklySupplyAPY: false,
   weeklyBorrowAPY: false,
   monthlySupplyAPY: false,
@@ -39,6 +43,8 @@ export const COLUMN_LABELS: Record<keyof ColumnVisibility, string> = {
   rateAtTarget: 'Target Rate',
   trustedBy: 'Trusted By',
   utilizationRate: 'Utilization',
+  dailySupplyAPY: '24h Supply APY',
+  dailyBorrowAPY: '24h Borrow APY',
   weeklySupplyAPY: '7d Supply APY',
   weeklyBorrowAPY: '7d Borrow APY',
   monthlySupplyAPY: '30d Supply APY',
@@ -54,6 +60,8 @@ export const COLUMN_DESCRIPTIONS: Record<keyof ColumnVisibility, string> = {
   rateAtTarget: 'Interest rate at target utilization',
   trustedBy: 'Highlights your trusted vaults that currently supply this market',
   utilizationRate: 'Percentage of supplied assets currently borrowed',
+  dailySupplyAPY: '24-hour average supply APY',
+  dailyBorrowAPY: '24-hour average borrow APY',
   weeklySupplyAPY: '7-day average supply APY',
   weeklyBorrowAPY: '7-day average borrow APY',
   monthlySupplyAPY: '30-day average supply APY',

--- a/src/features/markets/components/constants.ts
+++ b/src/features/markets/components/constants.ts
@@ -12,10 +12,12 @@ export enum SortColumn {
   TrustedBy = 11,
   UtilizationRate = 12,
   Trend = 13,
-  WeeklySupplyAPY = 14,
-  WeeklyBorrowAPY = 15,
-  MonthlySupplyAPY = 16,
-  MonthlyBorrowAPY = 17,
+  DailySupplyAPY = 14,
+  DailyBorrowAPY = 15,
+  WeeklySupplyAPY = 16,
+  WeeklyBorrowAPY = 17,
+  MonthlySupplyAPY = 18,
+  MonthlyBorrowAPY = 19,
 }
 
 // Gas cost to simplify tx flow: do not need to estimate gas for transactions

--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -45,6 +45,8 @@ export function MarketTableBody({ currentEntries, expandedRowId, setExpandedRowI
     (columnVisibility.rateAtTarget ? 1 : 0) +
     (columnVisibility.trustedBy ? 1 : 0) +
     (columnVisibility.utilizationRate ? 1 : 0) +
+    (columnVisibility.dailySupplyAPY ? 1 : 0) +
+    (columnVisibility.dailyBorrowAPY ? 1 : 0) +
     (columnVisibility.weeklySupplyAPY ? 1 : 0) +
     (columnVisibility.weeklyBorrowAPY ? 1 : 0) +
     (columnVisibility.monthlySupplyAPY ? 1 : 0) +
@@ -231,6 +233,28 @@ export function MarketTableBody({ currentEntries, expandedRowId, setExpandedRowI
                   style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
                 >
                   <p className="text-sm">{`${(item.state.utilization * 100).toFixed(2)}%`}</p>
+                </TableCell>
+              )}
+              {columnVisibility.dailySupplyAPY && (
+                <TableCell
+                  data-label="24h Supply"
+                  className="z-50 text-center"
+                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                >
+                  <p className="text-sm">
+                    {item.state.dailySupplyApy != null ? <RateFormatted value={item.state.dailySupplyApy} /> : '—'}
+                  </p>
+                </TableCell>
+              )}
+              {columnVisibility.dailyBorrowAPY && (
+                <TableCell
+                  data-label="24h Borrow"
+                  className="z-50 text-center"
+                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                >
+                  <p className="text-sm">
+                    {item.state.dailyBorrowApy != null ? <RateFormatted value={item.state.dailyBorrowApy} /> : '—'}
+                  </p>
                 </TableCell>
               )}
               {columnVisibility.weeklySupplyAPY && (

--- a/src/features/markets/components/table/markets-table.tsx
+++ b/src/features/markets/components/table/markets-table.tsx
@@ -239,6 +239,24 @@ function MarketsTable({ currentPage, setCurrentPage, className, tableClassName, 
                     targetColumn={SortColumn.UtilizationRate}
                   />
                 )}
+                {columnVisibility.dailySupplyAPY && (
+                  <HTSortable
+                    label="24h Supply"
+                    sortColumn={sortColumn}
+                    titleOnclick={titleOnclick}
+                    sortDirection={sortDirection}
+                    targetColumn={SortColumn.DailySupplyAPY}
+                  />
+                )}
+                {columnVisibility.dailyBorrowAPY && (
+                  <HTSortable
+                    label="24h Borrow"
+                    sortColumn={sortColumn}
+                    titleOnclick={titleOnclick}
+                    sortDirection={sortDirection}
+                    targetColumn={SortColumn.DailyBorrowAPY}
+                  />
+                )}
                 {columnVisibility.weeklySupplyAPY && (
                   <HTSortable
                     label="7d Supply"

--- a/src/graphql/morpho-api-queries.ts
+++ b/src/graphql/morpho-api-queries.ts
@@ -108,6 +108,8 @@ state {
   timestamp
   apyAtTarget
   rateAtTarget
+  dailySupplyApy
+  dailyBorrowApy
   weeklySupplyApy
   weeklyBorrowApy
   monthlySupplyApy
@@ -220,6 +222,8 @@ export const marketsQuery = `
       timestamp
       apyAtTarget
       rateAtTarget
+      dailySupplyApy
+      dailyBorrowApy
       weeklySupplyApy
       weeklyBorrowApy
       monthlySupplyApy

--- a/src/hooks/useFilteredMarkets.ts
+++ b/src/hooks/useFilteredMarkets.ts
@@ -112,6 +112,8 @@ export const useFilteredMarkets = (): Market[] => {
       [SortColumn.TrustedBy]: '',
       [SortColumn.UtilizationRate]: 'state.utilization',
       [SortColumn.Trend]: '', // Trend is a filter mode, not a sort
+      [SortColumn.DailySupplyAPY]: 'state.dailySupplyApy',
+      [SortColumn.DailyBorrowAPY]: 'state.dailyBorrowApy',
       [SortColumn.WeeklySupplyAPY]: 'state.weeklySupplyApy',
       [SortColumn.WeeklyBorrowAPY]: 'state.weeklyBorrowApy',
       [SortColumn.MonthlySupplyAPY]: 'state.monthlySupplyApy',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -322,7 +322,9 @@ export type Market = {
     apyAtTarget: number;
     rateAtTarget: string;
 
-    // Weekly and monthly APY averages (may be null for new markets or backup subgraph)
+    // Daily, weekly and monthly APY averages (may be null for new markets or backup subgraph)
+    dailySupplyApy: number | null;
+    dailyBorrowApy: number | null;
     weeklySupplyApy: number | null;
     weeklyBorrowApy: number | null;
     monthlySupplyApy: number | null;


### PR DESCRIPTION
## Summary
Add `dailySupplyApy` and `dailyBorrowApy` fields to the markets list, following the exact pattern from PR #355 (weekly/monthly APY).

## Changes
Following the same structure as #355:

1. **`src/graphql/morpho-api-queries.ts`** — add `dailySupplyApy`, `dailyBorrowApy` to state query
2. **`src/utils/types.ts`** — add nullable daily APY fields to `Market.state` type
3. **`src/features/markets/components/column-visibility.ts`** — add 24h Supply APY and 24h Borrow APY columns (off by default)
4. **`src/features/markets/components/constants.ts`** — add `DailySupplyAPY` and `DailyBorrowAPY` sort enum values
5. **`src/hooks/useFilteredMarkets.ts`** — add sort property mappings
6. **`src/features/markets/components/table/markets-table.tsx`** — add sortable headers
7. **`src/features/markets/components/table/market-table-body.tsx`** — add cells with null handling ("—")
8. **`src/data-sources/subgraph/market.ts`** — return null for backup subgraph (not supported)

## GraphQL Fields
```graphql
state {
  dailyBorrowApy
  dailySupplyApy
}
```

## Related
- Pattern reference: #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 24-hour average supply and borrow APY columns to the markets table
  * Enabled column visibility toggles for daily APY metrics
  * Added sorting functionality by daily APY values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->