### PR TITLE
feat: add 7-day position change indicators to suppliers table

### DIFF
--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -241,9 +241,7 @@ export function MarketTableBody({ currentEntries, expandedRowId, setExpandedRowI
                   className="z-50 text-center"
                   style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
                 >
-                  <p className="text-sm">
-                    {item.state.dailySupplyApy != null ? <RateFormatted value={item.state.dailySupplyApy} /> : '—'}
-                  </p>
+                  <p className="text-sm">{item.state.dailySupplyApy != null ? <RateFormatted value={item.state.dailySupplyApy} /> : '—'}</p>
                 </TableCell>
               )}
               {columnVisibility.dailyBorrowAPY && (
@@ -252,9 +250,7 @@ export function MarketTableBody({ currentEntries, expandedRowId, setExpandedRowI
                   className="z-50 text-center"
                   style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
                 >
-                  <p className="text-sm">
-                    {item.state.dailyBorrowApy != null ? <RateFormatted value={item.state.dailyBorrowApy} /> : '—'}
-                  </p>
+                  <p className="text-sm">{item.state.dailyBorrowApy != null ? <RateFormatted value={item.state.dailyBorrowApy} /> : '—'}</p>
                 </TableCell>
               )}
               {columnVisibility.weeklySupplyAPY && (

--- a/src/hooks/useSupplierPositionChanges.ts
+++ b/src/hooks/useSupplierPositionChanges.ts
@@ -1,0 +1,150 @@
+import { useQuery } from '@tanstack/react-query';
+import { supportsMorphoApi } from '@/config/dataSources';
+import { fetchMorphoMarketSupplies } from '@/data-sources/morpho-api/market-supplies';
+import { fetchSubgraphMarketSupplies } from '@/data-sources/subgraph/market-supplies';
+import type { SupportedNetworks } from '@/utils/networks';
+import type { MarketActivityTransaction } from '@/utils/types';
+
+const SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60;
+
+export type SupplierPositionChange = {
+  userAddress: string;
+  netChange: bigint; // positive = net supply, negative = net withdraw
+  supplyTotal: bigint;
+  withdrawTotal: bigint;
+  transactionCount: number;
+};
+
+export type SupplierPositionChangesMap = Map<string, SupplierPositionChange>;
+
+/**
+ * Calculate net position changes from transactions
+ */
+function calculatePositionChanges(transactions: MarketActivityTransaction[]): SupplierPositionChangesMap {
+  const changes = new Map<string, SupplierPositionChange>();
+
+  for (const tx of transactions) {
+    const address = tx.userAddress.toLowerCase();
+    const amount = BigInt(tx.amount);
+
+    let existing = changes.get(address);
+    if (!existing) {
+      existing = {
+        userAddress: address,
+        netChange: 0n,
+        supplyTotal: 0n,
+        withdrawTotal: 0n,
+        transactionCount: 0,
+      };
+    }
+
+    if (tx.type === 'MarketSupply') {
+      existing.netChange += amount;
+      existing.supplyTotal += amount;
+    } else if (tx.type === 'MarketWithdraw') {
+      existing.netChange -= amount;
+      existing.withdrawTotal += amount;
+    }
+    existing.transactionCount += 1;
+
+    changes.set(address, existing);
+  }
+
+  return changes;
+}
+
+/**
+ * Hook to fetch 7-day supply/withdraw transactions and calculate net position changes per user.
+ * Returns a map of userAddress (lowercase) -> position change data.
+ *
+ * @param marketId The unique key of the market.
+ * @param loanAssetId The address of the loan asset.
+ * @param network The blockchain network.
+ * @returns Map of position changes keyed by lowercase user address.
+ */
+export const useSupplierPositionChanges = (
+  marketId: string | undefined,
+  loanAssetId: string | undefined,
+  network: SupportedNetworks | undefined,
+) => {
+  const queryKey = ['supplierPositionChanges', marketId, loanAssetId, network];
+
+  const queryFn = async (): Promise<SupplierPositionChangesMap> => {
+    if (!marketId || !loanAssetId || !network) {
+      return new Map();
+    }
+
+    const sevenDaysAgo = Math.floor(Date.now() / 1000) - SEVEN_DAYS_IN_SECONDS;
+    const allTransactions: MarketActivityTransaction[] = [];
+
+    // Fetch transactions in batches until we have all from the last 7 days
+    // or reach a reasonable limit
+    const pageSize = 100;
+    const maxPages = 10; // Max 1000 transactions
+    let currentPage = 1;
+    let hasMore = true;
+
+    while (hasMore && currentPage <= maxPages) {
+      const skip = (currentPage - 1) * pageSize;
+      let result = null;
+
+      // Try Morpho API first if supported
+      if (supportsMorphoApi(network)) {
+        try {
+          result = await fetchMorphoMarketSupplies(marketId, '0', pageSize, skip);
+        } catch (morphoError) {
+          console.error('Failed to fetch supplies via Morpho API:', morphoError);
+        }
+      }
+
+      // Fallback to Subgraph
+      if (!result) {
+        try {
+          result = await fetchSubgraphMarketSupplies(marketId, loanAssetId, network, '0', pageSize, skip);
+        } catch (subgraphError) {
+          console.error('Failed to fetch supplies via Subgraph:', subgraphError);
+          break;
+        }
+      }
+
+      if (!result || result.items.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      // Filter to only transactions from last 7 days
+      const recentTransactions = result.items.filter((tx) => tx.timestamp >= sevenDaysAgo);
+      allTransactions.push(...recentTransactions);
+
+      // If oldest transaction in this batch is older than 7 days, we have all we need
+      const oldestInBatch = result.items.at(-1);
+      if (oldestInBatch && oldestInBatch.timestamp < sevenDaysAgo) {
+        hasMore = false;
+      } else if (result.items.length < pageSize) {
+        hasMore = false;
+      } else {
+        currentPage++;
+      }
+    }
+
+    return calculatePositionChanges(allTransactions);
+  };
+
+  const { data, isLoading, error, refetch } = useQuery<SupplierPositionChangesMap>({
+    queryKey,
+    queryFn,
+    enabled: !!marketId && !!loanAssetId && !!network,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    placeholderData: () => new Map(),
+    retry: 1,
+  });
+
+  return {
+    data: data ?? new Map(),
+    isLoading,
+    error,
+    refetch,
+  };
+};
+
+export default useSupplierPositionChanges;


### PR DESCRIPTION
## Summary
Adds position change indicators to the suppliers table on the market detail page, showing whether major suppliers are increasing or decreasing their positions over time.

Closes #351

## Changes
- **New hook:** `useSupplierPositionChanges.ts` - Fetches 7-day transaction data (supply/withdraw events) and calculates net change per user address
- **Updated:** `suppliers-table.tsx` - Added new '7D' column with change indicators

## Features
- Shows arrow icons: ↑ (increase), ↓ (decrease), − (no change)
- Color coding: green for positive, red for negative, muted for neutral
- Percentage change displayed next to arrow
- Tooltip on hover showing:
  - Exact change amount with token symbol
  - Percentage change
  - Number of transactions in the period

## UI Details
- Follows Monarch styling guidelines
- Uses `text-green-500` for positive, `text-red-500` for negative, `text-secondary` for neutral
- Gracefully handles null/insufficient data (shows '−')

## Screenshots
_To be added after testing_

## Testing
- [x] `pnpm check` passes
- [ ] Manual testing on staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a 7-day position change indicator to the suppliers table, displaying directional arrows, color-coded states (green/red/neutral), and percentage changes with detailed tooltips.

* **Refactor**
  * Simplified rendering of daily APY displays in the market table for cleaner code formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->