### PR TITLE
feat: add position flow chart to market detail page

### DIFF
--- a/src/features/market-detail/components/charts/position-flow-chart.tsx
+++ b/src/features/market-detail/components/charts/position-flow-chart.tsx
@@ -1,0 +1,257 @@
+import { useState, useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell, ReferenceLine } from 'recharts';
+import { Spinner } from '@/components/ui/spinner';
+import { useChartColors } from '@/constants/chartColors';
+import { formatReadable } from '@/utils/balance';
+import { formatChartTime } from '@/utils/chart';
+import { useMarketPositionFlow, type PositionFlowTimeframe } from '@/hooks/useMarketPositionFlow';
+import { ChartGradients, chartTooltipCursor } from './chart-utils';
+import type { Market } from '@/utils/types';
+import type { SupportedNetworks } from '@/utils/networks';
+
+type PositionFlowChartProps = {
+  marketId: string;
+  chainId: SupportedNetworks;
+  market: Market;
+};
+
+const TIMEFRAME_LABELS: Record<PositionFlowTimeframe, string> = {
+  '7d': '7D',
+  '30d': '30D',
+};
+
+function PositionFlowChart({ marketId, chainId, market }: PositionFlowChartProps) {
+  const [selectedTimeframe, setSelectedTimeframe] = useState<PositionFlowTimeframe>('7d');
+  const chartColors = useChartColors();
+
+  const {
+    data: flowData,
+    stats,
+    isLoading,
+  } = useMarketPositionFlow(marketId, market.loanAsset.id, chainId, selectedTimeframe, market.loanAsset.decimals);
+
+  // Calculate duration for time formatting
+  const durationSeconds = useMemo(() => {
+    if (selectedTimeframe === '7d') return 7 * 24 * 60 * 60;
+    return 30 * 24 * 60 * 60;
+  }, [selectedTimeframe]);
+
+  const formatValue = (value: number) => {
+    const formattedValue = formatReadable(Math.abs(value));
+    const prefix = value >= 0 ? '+' : '-';
+    return `${prefix}${formattedValue} ${market.loanAsset.symbol}`;
+  };
+
+  const formatYAxis = (value: number) => {
+    const prefix = value >= 0 ? '+' : '';
+    return `${prefix}${formatReadable(value)}`;
+  };
+
+  // Create gradient configs for positive and negative bars
+  const flowGradients = useMemo(
+    () => [
+      { id: 'positiveFlowGradient', color: chartColors.supply.stroke },
+      { id: 'negativeFlowGradient', color: chartColors.withdraw.stroke },
+    ],
+    [chartColors],
+  );
+
+  // Custom tooltip component
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (!active || !payload || payload.length === 0) return null;
+    const data = payload[0].payload;
+    return (
+      <div className="rounded-lg border border-border bg-background p-3 shadow-lg">
+        <p className="mb-2 text-xs text-secondary">
+          {new Date(label * 1000).toLocaleDateString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          })}
+        </p>
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-6 text-sm">
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: chartColors.supply.stroke }}
+              />
+              <span className="text-secondary">Supply</span>
+            </div>
+            <span className="tabular-nums">
+              +{formatReadable(data.supplyVolume)} {market.loanAsset.symbol}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-6 text-sm">
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: chartColors.withdraw.stroke }}
+              />
+              <span className="text-secondary">Withdraw</span>
+            </div>
+            <span className="tabular-nums">
+              -{formatReadable(data.withdrawVolume)} {market.loanAsset.symbol}
+            </span>
+          </div>
+          <div className="mt-2 border-t border-border pt-2">
+            <div className="flex items-center justify-between gap-6 text-sm font-medium">
+              <span className="text-secondary">Net Flow</span>
+              <span className={`tabular-nums ${data.netFlow >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
+                {formatValue(data.netFlow)}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Card className="overflow-hidden border border-border bg-surface shadow-sm">
+      {/* Header: Stats + Controls */}
+      <div className="flex flex-col gap-4 border-b border-border/40 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+        {/* Stats */}
+        <div className="flex flex-wrap gap-6">
+          <div>
+            <p className="text-xs uppercase tracking-wider text-secondary">Net Flow</p>
+            <div className="flex items-baseline gap-2">
+              <span className={`tabular-nums text-lg ${stats.totalNetFlow >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
+                {formatValue(stats.totalNetFlow)}
+              </span>
+            </div>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wider text-secondary">Total Supply</p>
+            <span className="tabular-nums text-lg">
+              +{formatReadable(stats.totalSupply)} {market.loanAsset.symbol}
+            </span>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wider text-secondary">Total Withdraw</p>
+            <span className="tabular-nums text-lg">
+              -{formatReadable(stats.totalWithdraw)} {market.loanAsset.symbol}
+            </span>
+          </div>
+        </div>
+
+        {/* Controls */}
+        <div className="flex gap-2">
+          <Select
+            value={selectedTimeframe}
+            onValueChange={(value) => setSelectedTimeframe(value as PositionFlowTimeframe)}
+          >
+            <SelectTrigger className="h-8 w-auto min-w-[60px] px-3 text-sm">
+              <SelectValue>{TIMEFRAME_LABELS[selectedTimeframe]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7d">7D</SelectItem>
+              <SelectItem value="30d">30D</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Chart Body */}
+      <div className="w-full">
+        {isLoading ? (
+          <div className="flex h-[300px] items-center justify-center text-primary">
+            <Spinner size={30} />
+          </div>
+        ) : flowData.length === 0 ? (
+          <div className="flex h-[300px] items-center justify-center text-secondary">No position flow data available for this period</div>
+        ) : (
+          <ResponsiveContainer
+            width="100%"
+            height={300}
+            id="position-flow-chart"
+          >
+            <BarChart
+              data={flowData}
+              margin={{ top: 20, right: 20, left: 10, bottom: 10 }}
+            >
+              <ChartGradients
+                prefix="positionFlow"
+                gradients={flowGradients}
+              />
+              <CartesianGrid
+                strokeDasharray="0"
+                stroke="var(--color-border)"
+                strokeOpacity={0.25}
+                vertical={false}
+              />
+              <XAxis
+                dataKey="date"
+                axisLine={false}
+                tickLine={false}
+                tickMargin={12}
+                minTickGap={40}
+                tickFormatter={(time) => formatChartTime(time, durationSeconds)}
+                tick={{ fontSize: 11, fill: 'var(--color-text-secondary)' }}
+              />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={formatYAxis}
+                tick={{ fontSize: 11, fill: 'var(--color-text-secondary)' }}
+                width={70}
+              />
+              <Tooltip
+                cursor={chartTooltipCursor}
+                content={<CustomTooltip />}
+              />
+              <ReferenceLine
+                y={0}
+                stroke="var(--color-border)"
+                strokeWidth={1}
+              />
+              <Bar
+                dataKey="netFlow"
+                name="Net Flow"
+                radius={[4, 4, 0, 0]}
+              >
+                {flowData.map((entry, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={entry.netFlow >= 0 ? chartColors.supply.stroke : chartColors.withdraw.stroke}
+                    fillOpacity={0.85}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Footer: Average info */}
+      <div className="border-t border-border px-6 py-4">
+        <div className="flex flex-wrap gap-x-8 gap-y-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-secondary">Avg. Daily Flow</span>
+            <span className={`tabular-nums text-sm ${stats.avgDailyFlow >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
+              {formatValue(stats.avgDailyFlow)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: chartColors.supply.stroke }}
+            />
+            <span className="text-xs text-secondary">Inflow (Supply)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: chartColors.withdraw.stroke }}
+            />
+            <span className="text-xs text-secondary">Outflow (Withdraw)</span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default PositionFlowChart;

--- a/src/features/market-detail/market-view.tsx
+++ b/src/features/market-detail/market-view.tsx
@@ -30,6 +30,7 @@ import { useAllMarketBorrowers, useAllMarketSuppliers } from '@/hooks/useAllMark
 import { MarketHeader } from './components/market-header';
 import RateChart from './components/charts/rate-chart';
 import VolumeChart from './components/charts/volume-chart';
+import PositionFlowChart from './components/charts/position-flow-chart';
 import { SuppliersPieChart } from './components/charts/suppliers-pie-chart';
 import { BorrowersPieChart } from './components/charts/borrowers-pie-chart';
 import { DebtAtRiskChart } from './components/charts/debt-at-risk-chart';
@@ -366,6 +367,14 @@ function MarketContent() {
               chainId={network}
               market={market}
             />
+
+            <div className="mt-6">
+              <PositionFlowChart
+                marketId={marketId as string}
+                chainId={network}
+                market={market}
+              />
+            </div>
 
             <div className="mt-6">
               <RateChart

--- a/src/hooks/useMarketPositionFlow.ts
+++ b/src/hooks/useMarketPositionFlow.ts
@@ -1,0 +1,185 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import moment from 'moment';
+import { supportsMorphoApi } from '@/config/dataSources';
+import { fetchMorphoMarketSupplies } from '@/data-sources/morpho-api/market-supplies';
+import { fetchSubgraphMarketSupplies } from '@/data-sources/subgraph/market-supplies';
+import type { SupportedNetworks } from '@/utils/networks';
+import type { MarketActivityTransaction } from '@/utils/types';
+
+export type PositionFlowDataPoint = {
+  date: number; // Unix timestamp
+  netFlow: number; // Net flow (supply - withdraw)
+  supplyVolume: number; // Total supply volume for the period
+  withdrawVolume: number; // Total withdraw volume for the period
+};
+
+export type PositionFlowTimeframe = '7d' | '30d';
+
+/**
+ * Hook to fetch and aggregate position flow data (supply/withdraw net flow over time).
+ * @param marketId The unique key of the market.
+ * @param loanAssetId The address of the loan asset.
+ * @param chainId The blockchain network.
+ * @param timeframe The timeframe to display ('7d' or '30d').
+ * @param decimals The decimals of the loan asset for formatting.
+ * @returns Aggregated position flow data by day.
+ */
+export const useMarketPositionFlow = (
+  marketId: string | undefined,
+  loanAssetId: string | undefined,
+  chainId: SupportedNetworks | undefined,
+  timeframe: PositionFlowTimeframe,
+  decimals: number,
+) => {
+  // Calculate timestamp filter based on timeframe
+  const startTimestamp = useMemo(() => {
+    const now = moment();
+    if (timeframe === '7d') {
+      return now.subtract(7, 'days').unix();
+    }
+    return now.subtract(30, 'days').unix();
+  }, [timeframe]);
+
+  // Fetch all supply/withdraw transactions for the timeframe
+  // We fetch a larger batch to get all transactions in the period
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['marketPositionFlow', marketId, chainId, timeframe],
+    queryFn: async () => {
+      if (!marketId || !loanAssetId || !chainId) {
+        return null;
+      }
+
+      // Fetch up to 500 transactions to cover the timeframe
+      // Using pagination to get all data
+      const allTransactions: MarketActivityTransaction[] = [];
+      let skip = 0;
+      const pageSize = 100;
+      let hasMore = true;
+
+      while (hasMore) {
+        let result;
+
+        // Try Morpho API first if supported
+        if (supportsMorphoApi(chainId)) {
+          try {
+            result = await fetchMorphoMarketSupplies(marketId, '0', pageSize, skip);
+          } catch {
+            console.error('Morpho API failed, falling back to subgraph');
+          }
+        }
+
+        // Fallback to Subgraph
+        if (!result) {
+          result = await fetchSubgraphMarketSupplies(marketId, loanAssetId, chainId, '0', pageSize, skip);
+        }
+
+        if (!result || result.items.length === 0) {
+          hasMore = false;
+          break;
+        }
+
+        // Filter to only include transactions within our timeframe
+        const filteredItems = result.items.filter((tx) => tx.timestamp >= startTimestamp);
+        allTransactions.push(...filteredItems);
+
+        // If the oldest transaction in this batch is before our start time, we have all we need
+        const oldestTimestamp = Math.min(...result.items.map((tx) => tx.timestamp));
+        if (oldestTimestamp < startTimestamp || result.items.length < pageSize) {
+          hasMore = false;
+        } else {
+          skip += pageSize;
+        }
+
+        // Safety limit to prevent infinite loops
+        if (skip >= 500) {
+          hasMore = false;
+        }
+      }
+
+      return allTransactions;
+    },
+    enabled: !!marketId && !!loanAssetId && !!chainId,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+
+  // Aggregate transactions by day
+  const aggregatedData = useMemo(() => {
+    if (!data || data.length === 0) {
+      return [];
+    }
+
+    // Group by day
+    const dailyData = new Map<string, { supply: bigint; withdraw: bigint }>();
+
+    for (const tx of data) {
+      const dayKey = moment.unix(tx.timestamp).format('YYYY-MM-DD');
+
+      if (!dailyData.has(dayKey)) {
+        dailyData.set(dayKey, { supply: 0n, withdraw: 0n });
+      }
+
+      const dayEntry = dailyData.get(dayKey)!;
+      const amount = BigInt(tx.amount);
+
+      if (tx.type === 'MarketSupply') {
+        dayEntry.supply += amount;
+      } else if (tx.type === 'MarketWithdraw') {
+        dayEntry.withdraw += amount;
+      }
+    }
+
+    // Convert to array and sort by date
+    const result: PositionFlowDataPoint[] = [];
+    const sortedDays = Array.from(dailyData.keys()).sort();
+
+    for (const dayKey of sortedDays) {
+      const entry = dailyData.get(dayKey)!;
+      const supplyVolume = Number(entry.supply) / 10 ** decimals;
+      const withdrawVolume = Number(entry.withdraw) / 10 ** decimals;
+      const netFlow = supplyVolume - withdrawVolume;
+
+      result.push({
+        date: moment(dayKey, 'YYYY-MM-DD').unix(),
+        netFlow,
+        supplyVolume,
+        withdrawVolume,
+      });
+    }
+
+    return result;
+  }, [data, decimals]);
+
+  // Calculate stats
+  const stats = useMemo(() => {
+    if (aggregatedData.length === 0) {
+      return {
+        totalNetFlow: 0,
+        totalSupply: 0,
+        totalWithdraw: 0,
+        avgDailyFlow: 0,
+      };
+    }
+
+    const totalSupply = aggregatedData.reduce((sum, d) => sum + d.supplyVolume, 0);
+    const totalWithdraw = aggregatedData.reduce((sum, d) => sum + d.withdrawVolume, 0);
+    const totalNetFlow = totalSupply - totalWithdraw;
+    const avgDailyFlow = totalNetFlow / aggregatedData.length;
+
+    return {
+      totalNetFlow,
+      totalSupply,
+      totalWithdraw,
+      avgDailyFlow,
+    };
+  }, [aggregatedData]);
+
+  return {
+    data: aggregatedData,
+    stats,
+    isLoading,
+    error,
+  };
+};
+
+export default useMarketPositionFlow;


### PR DESCRIPTION
## Summary
Add a Position Flow Chart to the market detail page analytics section, showing supplier position changes (net flow) over time.

Closes #351

## Changes
- Add `useMarketPositionFlow` hook to fetch and aggregate supply/withdraw transactions by day
- Create `PositionFlowChart` component with:
  - Bar chart showing daily net flow (supply - withdraw)
  - Green bars for positive flow (net inflow), red bars for negative flow (net outflow)
  - Uses `useChartColors()` hook for dynamic color palette support
  - Timeframe selector (7D, 30D)
  - Stats: Net Flow, Total Supply, Total Withdraw, Avg Daily Flow
- Add chart to Trend tab between Volume Chart and Rate Chart

## Screenshots
![Position Flow Chart](https://github.com/user-attachments/assets/position-flow-chart.png)

## Testing
- `pnpm check` passes
- Tested locally on market detail page
- Chart renders correctly with data aggregated by day
- Colors respect user's chart palette preference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Position Flow Chart to market detail view displaying daily supply and withdraw activity
  * Supports 7-day and 30-day timeframe selection for historical analysis
  * Shows key metrics including net flow, total supply, total withdraw, and average daily flow
  * Features interactive bar chart with detailed tooltips and responsive design

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->