### PR TITLE
feat: notifications for new features

### DIFF
--- a/src/components/layout/notification-banner.tsx
+++ b/src/components/layout/notification-banner.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { useActiveNotifications } from '@/hooks/useActiveNotifications';
 import { useNotificationStore } from '@/stores/useNotificationStore';
+import { GridAccent } from '@/components/landing';
 
 export function NotificationBanner() {
   const { currentNotification, totalCount, isLoading } = useActiveNotifications();
@@ -21,11 +22,12 @@ export function NotificationBanner() {
   const action = currentNotification.action;
 
   return (
-    <div className="relative w-full bg-primary">
+    <div className="relative w-full bg-primary overflow-hidden">
       {/* Grid background overlay */}
-      <div
-        className="pointer-events-none absolute inset-0 bg-dot-grid opacity-30"
-        aria-hidden="true"
+      <GridAccent
+        position="top-strip"
+        variant="dots"
+        className="opacity-40"
       />
 
       {/* Content container - same height as header */}

--- a/src/config/notifications.ts
+++ b/src/config/notifications.ts
@@ -36,17 +36,17 @@ export type NotificationConfig = {
  */
 export const NOTIFICATIONS: NotificationConfig[] = [
   {
-    id: 'position-history-chart-2026-02',
+    id: 'position-history-chart-2026-02-01',
     message: '💎 New feature: Position History Graph — analyze any account\'s allocation changes over time!',
     type: 'info',
     category: 'global',
-    expiresAt: new Date('2026-02-16'),
+    expiresAt: new Date('2026-02-10'),
   },
   {
     id: 'custom-tags-2026-02',
     message: '💎 New feature: Custom Tags — create your own tags on market flow metrics! Try it in Settings → Experimental',
     type: 'info',
     category: 'global',
-    expiresAt: new Date('2026-02-16'),
+    expiresAt: new Date('2026-02-10'),
   },
 ];

--- a/src/features/home/home-view.tsx
+++ b/src/features/home/home-view.tsx
@@ -64,7 +64,7 @@ function HomePage() {
           />
 
           {/* Main hero content */}
-          <div className="flex-1 flex items-center">
+          <div className="flex-1 flex items-center relative z-10">
             <div className="container mx-auto px-6 sm:px-8 md:px-12 lg:px-16">
               {/* Two-column grid */}
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">

--- a/src/hooks/useActiveNotifications.ts
+++ b/src/hooks/useActiveNotifications.ts
@@ -35,7 +35,7 @@ export type ActiveNotificationsResult = {
  * ```
  */
 export const useActiveNotifications = (): ActiveNotificationsResult => {
-  const isDismissed = useNotificationStore((s) => s.isDismissed);
+  const dismissedIds = useNotificationStore((s) => s.dismissedIds);
   const conditions = useNotificationConditions();
 
   const { activeNotifications, isLoading } = useMemo(() => {
@@ -49,7 +49,7 @@ export const useActiveNotifications = (): ActiveNotificationsResult => {
       }
 
       // Check if dismissed
-      if (isDismissed(notification.id)) {
+      if (dismissedIds.includes(notification.id)) {
         return false;
       }
 
@@ -81,7 +81,7 @@ export const useActiveNotifications = (): ActiveNotificationsResult => {
       activeNotifications: active,
       isLoading: hasLoadingCondition,
     };
-  }, [isDismissed, conditions]);
+  }, [dismissedIds, conditions]);
 
   const currentNotification = activeNotifications[0] ?? null;
   const totalCount = activeNotifications.length;


### PR DESCRIPTION
Adds 2 notification banners for newly shipped features:

1. **Position History Chart** — guides users to /positions
2. **Custom Tags** — mentions Settings → Experimental, links to /markets

Both expire in 2 weeks (Feb 16).

Dismissing one smoothly reveals the next (existing behavior via `1/2` badge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two active global notifications that appear across the app (message, type, category and expiration). No changes to public APIs or exported signatures.
* **Bug Fixes / UI**
  * Improved banner visuals and layering so background accents and the close button display correctly.
  * Fixed hero content layering to ensure correct stacking with the banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->