### PR TITLE
fix: duplicate color on graph from palette

### DIFF
--- a/src/features/position-detail/components/yield-analysis-distribution.tsx
+++ b/src/features/position-detail/components/yield-analysis-distribution.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip as RechartsTooltip } from 'recharts';
 import { Card } from '@/components/ui/card';
 import { useChartColors } from '@/constants/chartColors';
-import { getCollateralColorFromPalette, OTHER_COLOR } from '@/features/positions/utils/colors';
+import { getColorByIndex, OTHER_COLOR } from '@/features/positions/utils/colors';
 import { formatBalance, formatReadable } from '@/utils/balance';
 import type { MarketPositionWithEarnings } from '@/utils/types';
 
@@ -67,7 +67,7 @@ export function YieldAnalysisDistribution({ markets, periodLabel }: YieldAnalysi
 
     const toPercent = (value: bigint) => Number((value * 10_000n) / totalWeighted) / 100;
 
-    const entries: PieEntry[] = weighted.map(({ position, avgCapital, weightedCapital }) => {
+    const entries: PieEntry[] = weighted.map(({ position, avgCapital, weightedCapital }, i) => {
       const decimals = position.market.loanAsset.decimals;
       const avgBalance = formatReadable(Number(formatBalance(avgCapital, decimals)));
       return {
@@ -75,7 +75,7 @@ export function YieldAnalysisDistribution({ markets, periodLabel }: YieldAnalysi
         label: marketDisplayNames[position.market.uniqueKey] ?? position.market.collateralAsset?.symbol ?? 'Unknown',
         value: toPercent(weightedCapital),
         percentage: toPercent(weightedCapital),
-        color: getCollateralColorFromPalette(position.market.uniqueKey.toLowerCase(), chartColors.pie),
+        color: getColorByIndex(i, chartColors.pie),
         avgBalance: `${avgBalance} ${position.market.loanAsset.symbol ?? ''}`.trim(),
       };
     });

--- a/src/features/position-detail/components/yield-analysis-yield-breakdown.tsx
+++ b/src/features/position-detail/components/yield-analysis-yield-breakdown.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip as RechartsTooltip } from 'recharts';
 import { Card } from '@/components/ui/card';
 import { useChartColors } from '@/constants/chartColors';
-import { getCollateralColorFromPalette, OTHER_COLOR } from '@/features/positions/utils/colors';
+import { getColorByIndex, OTHER_COLOR } from '@/features/positions/utils/colors';
 import { formatBalance, formatReadable } from '@/utils/balance';
 import type { MarketPositionWithEarnings } from '@/utils/types';
 
@@ -67,11 +67,11 @@ export function YieldAnalysisYieldBreakdown({ markets, periodLabel }: YieldAnaly
           key: position.market.uniqueKey,
           label: marketDisplayNames[position.market.uniqueKey] ?? position.market.collateralAsset?.symbol ?? 'Unknown',
           percentage: toPercent(earned),
-          color: getCollateralColorFromPalette(position.market.uniqueKey.toLowerCase(), chartColors.pie),
           earnedAmount: `${earnedAmount} ${position.market.loanAsset.symbol ?? ''}`.trim(),
         };
       })
-      .sort((a, b) => b.percentage - a.percentage);
+      .sort((a, b) => b.percentage - a.percentage)
+      .map((entry, i) => ({ ...entry, color: getColorByIndex(i, chartColors.pie) }));
 
     if (formattedEntries.length <= MAX_PIE_ITEMS) return formattedEntries;
 

--- a/src/features/positions/utils/colors.ts
+++ b/src/features/positions/utils/colors.ts
@@ -1,16 +1,10 @@
 // Consistent color for "Other" category across pie charts
 export const OTHER_COLOR = '#64748B';
 
-function hashStringToNumber(label: string): number {
-  let hash = 0;
-  for (let i = 0; i < label.length; i++) {
-    const char = label.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash &= hash;
-  }
-  return Math.abs(hash);
-}
-
-export function getCollateralColorFromPalette(label: string, pieColors: readonly string[]): string {
-  return pieColors[hashStringToNumber(label) % pieColors.length];
+/**
+ * Assign a color from the palette by index order.
+ * Guarantees distinct colors within a single chart as long as item count < palette length.
+ */
+export function getColorByIndex(index: number, pieColors: readonly string[]): string {
+  return pieColors[index % pieColors.length];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated pie chart color assignment across yield analysis and position charts to use index-based selection instead of market key-based selection, ensuring consistent color allocation based on item order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->