### PR TITLE
fix: markets loading state uses full width to align with filters

### DIFF
--- a/src/features/markets/components/table/markets-table.tsx
+++ b/src/features/markets/components/table/markets-table.tsx
@@ -85,7 +85,11 @@ function MarketsTable({ currentPage, setCurrentPage, className, tableClassName, 
 
   const totalPages = Math.ceil(markets.length / entriesPerPage);
 
-  const containerClassName = ['flex flex-col gap-2 pb-4', loading || isEmpty || markets.length === 0 ? 'container items-center' : className]
+  const containerClassName = [
+    'flex flex-col gap-2 pb-4',
+    className ?? 'w-full',
+    loading || isEmpty || markets.length === 0 ? 'items-center' : '',
+  ]
     .filter((value): value is string => Boolean(value))
     .join(' ');
   const tableClassNames = ['responsive', tableClassName].filter((value): value is string => Boolean(value)).join(' ');


### PR DESCRIPTION
## Problem
When the markets view is loading, the loading card had adaptive width, causing misalignment with the filter bar.

## Solution
Changed the `containerClassName` logic to always use the passed `className` prop (defaults to `w-full`) instead of replacing it with `container items-center` during loading states.

Before: Loading state replaces `className` → width inconsistency
After: Loading state keeps `className` + adds `items-center` → consistent full width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced markets table container styling by refactoring how conditional CSS classes are composed and applied across different component states (loading, empty, or displaying data). The updated approach improves code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->