### PR TITLE
Fix performance fee application on vault init

### DIFF
--- a/src/hooks/useVaultV2.ts
+++ b/src/hooks/useVaultV2.ts
@@ -8,6 +8,7 @@ import type { SupportedNetworks } from '@/utils/networks';
 import { useTransactionWithToast } from './useTransactionWithToast';
 import type { Market } from '@/utils/types';
 import { encodeMarketParams } from '@/utils/morpho';
+import { findAgent } from '@/utils/monarch-agent';
 import { useVaultKeysCache } from '@/stores/useVaultKeysCache';
 
 export type PerformanceFeeConfig = {
@@ -339,6 +340,14 @@ export function useVaultV2({
         });
 
         txs.push(submitSetAllocatorTx, setAllocatorTx);
+
+        // Step 6.4 (Optional). Apply performance fee if allocator is a known agent with a fee.
+        const agent = findAgent(allocator);
+        if (agent?.performanceFee !== undefined && agent.performanceFeeRecipient) {
+          txs.push(
+            ...buildPerformanceFeeCalls({ fee: agent.performanceFee, recipient: agent.performanceFeeRecipient }),
+          );
+        }
       }
 
       // Step 7. Execute multicall with all steps.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance fee support for Vault v2. When an allocator is configured with a performance fee and recipient, these fees are now automatically configured during vault initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->