### PR TITLE
fix: add sentry.client.config.ts for production builds

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,72 @@
+// biome-ignore lint/performance/noNamespaceImport: Sentry SDK requires namespace import
+import * as Sentry from '@sentry/nextjs';
+
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const sentryEnabled = Boolean(dsn) && process.env.NEXT_PUBLIC_SENTRY_ENABLED !== 'false';
+const sentryDebug = process.env.NEXT_PUBLIC_SENTRY_DEBUG === 'true';
+
+Sentry.init({
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
+  dsn,
+
+  // Enable whenever DSN exists unless explicitly disabled
+  enabled: sentryEnabled,
+
+  // Opt-in verbose SDK logs when troubleshooting
+  debug: sentryDebug,
+
+  // Sample rate for error events (1.0 = 100%)
+  sampleRate: 1.0,
+
+  // Disable performance monitoring (not needed, saves quota)
+  tracesSampleRate: 0,
+
+  // Disable session replay (privacy)
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 0,
+
+  // Capture console.error as breadcrumbs
+  integrations: [
+    Sentry.breadcrumbsIntegration({
+      console: true,
+      dom: true,
+      fetch: true,
+      history: true,
+    }),
+  ],
+
+  // Scrub sensitive data before sending
+  beforeSend(event) {
+    // Remove any potential sensitive data
+    if (event.request?.data) {
+      event.request.data = '[Filtered]';
+    }
+    // Scrub sensitive headers (same as server config)
+    if (event.request?.headers) {
+      const filtered = { ...event.request.headers };
+      for (const key of ['authorization', 'cookie', 'set-cookie']) {
+        if (key in filtered) filtered[key] = '[Filtered]';
+      }
+      event.request.headers = filtered;
+    }
+    return event;
+  },
+
+  // Ignore errors from browser extensions (by source URL)
+  denyUrls: [/extensions\//i, /^chrome-extension:\/\//, /^moz-extension:\/\//],
+
+  // Ignore common non-actionable errors
+  ignoreErrors: [
+    // Network errors (user's connection)
+    'Network request failed',
+    'Failed to fetch',
+    'Load failed',
+    // User rejected wallet actions (not bugs)
+    'User rejected',
+    'User denied',
+    'user rejected transaction',
+    // WalletConnect noise
+    'Missing or invalid topic',
+    'Pairing already exists',
+  ],
+});


### PR DESCRIPTION
## Problem
Sentry wasn't being included in production builds because the `sentry.client.config.ts` file was missing.

The `withSentryConfig` wrapper in `next.config.js` expects this file to exist for client-side Sentry initialization. While `instrumentation-client.ts` works for Turbopack (dev mode), the production build using webpack needs the traditional config file.

## Solution
Added `sentry.client.config.ts` with the same configuration as `instrumentation-client.ts`.

## Testing
- Local build with `NEXT_PUBLIC_SENTRY_DSN` set now includes Sentry in the bundle
- Verified by grepping for 'sentry' in `.next/static/chunks/*.js`

## Note
After merging, Vercel needs to redeploy. The `NEXT_PUBLIC_SENTRY_DSN` env var must be set at **build time** for Sentry to be bundled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established client-side error tracking and monitoring system to improve application reliability and debugging
  * Implemented automatic data sanitization to securely redact sensitive information (authentication, cookies) from error reports
  * Configured intelligent filters to exclude non-actionable errors and browser extension URLs from tracking
  * Disabled performance monitoring and session recording features to optimize data collection and privacy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->