### PR TITLE
fix: remove dead HyperEVM goldsky subgraph

### DIFF
--- a/src/utils/subgraph-urls.ts
+++ b/src/utils/subgraph-urls.ts
@@ -27,16 +27,14 @@ const arbitrumSubgraph = apiKey
   ? `https://gateway.thegraph.com/api/${apiKey}/subgraphs/id/XsJn88DNCHJ1kgTqYeTgHMQSK4LuG1LR75339QVeQ26`
   : undefined;
 
-const hyperevmSubgraph = 'https://api.goldsky.com/api/public/project_cmg4ky61ivud801r23qsug3es/subgraphs/morpho-blue-hyperevm/1.0.3/gn';
-
 // Map network IDs (from SupportedNetworks) to Subgraph URLs
+// Note: HyperEVM goldsky subgraph was removed (endpoint deleted)
 export const SUBGRAPH_URLS: Partial<Record<SupportedNetworks, string>> = {
   [SupportedNetworks.Base]: baseSubgraphUrl,
   [SupportedNetworks.Mainnet]: mainnetSubgraphUrl,
   [SupportedNetworks.Polygon]: polygonSubgraphUrl,
   [SupportedNetworks.Unichain]: unichainSubgraphUrl,
   [SupportedNetworks.Arbitrum]: arbitrumSubgraph,
-  [SupportedNetworks.HyperEVM]: hyperevmSubgraph,
 };
 
 export const getSubgraphUrl = (network: SupportedNetworks): string | undefined => {


### PR DESCRIPTION
## Summary
The Goldsky subgraph for HyperEVM at `api.goldsky.com/.../morpho-blue-hyperevm/1.0.3/gn` has been deleted and returns 404:

```json
{"statusCode":404,"message":"Subgraph not found. Have you deleted this subgraph recently?"}
```

This was causing data fetching issues when the app tried to use the subgraph data source for HyperEVM.

## Changes
- Removed the dead HyperEVM Goldsky subgraph URL from `subgraph-urls.ts`

## Impact
- HyperEVM data is still fully available via Morpho Blue API (chainId: 999) ✅
- The subgraph was only used as a secondary data source for specific queries
- All data-source code already handles missing subgraph URLs gracefully (returns null)

## Testing
Verified:
- ✅ Morpho Blue API works for HyperEVM: `markets(where: { chainId_in: [999] })` returns data
- ✅ TheGraph subgraphs for other networks are working
- ✅ Code handles undefined subgraph URLs gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed HyperEVM network from supported networks list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->