### PR TITLE
fix: add retry logic for intermittent Morpho API NOT_FOUND errors

### DIFF
--- a/src/data-sources/morpho-api/fetchers.ts
+++ b/src/data-sources/morpho-api/fetchers.ts
@@ -1,44 +1,57 @@
 import { URLS } from '@/utils/urls';
 
-// Generic fetcher for Morpho API
+// Generic fetcher for Morpho API with retry on intermittent NOT_FOUND errors
 export const morphoGraphqlFetcher = async <T extends Record<string, any>>(
   query: string,
   variables: Record<string, unknown>,
+  maxRetries = 3,
 ): Promise<T | null> => {
-  const response = await fetch(URLS.MORPHO_BLUE_API, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, variables }),
-    cache: 'no-store', // Disable browser caching to ensure fresh data
-  });
+  let lastError: Error | null = null;
 
-  if (!response.ok) {
-    throw new Error('Network response was not ok from Morpho API');
-  }
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const response = await fetch(URLS.MORPHO_BLUE_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+      cache: 'no-store',
+    });
 
-  const result = (await response.json()) as T;
-
-  // Check for GraphQL errors
-  if ('errors' in result && Array.isArray((result as any).errors) && (result as any).errors.length > 0) {
-    // If it's known "NOT FOUND" error, handle gracefully
-    const notFoundError = (result as any).errors.find((err: { status?: string }) => err.status?.includes('NOT_FOUND'));
-
-    if (notFoundError) {
-      // Morpho API sometimes returns NOT_FOUND error alongside valid data
-      // Only return null if there's truly no data
-      if ('data' in result && result.data !== null) {
-        console.log('Morpho API returned NOT_FOUND error but has valid data, using data');
-        return result;
-      }
-      console.log('Morpho API return Not Found error:', notFoundError);
-      return null;
+    if (!response.ok) {
+      throw new Error('Network response was not ok from Morpho API');
     }
 
-    // Log the full error for debugging
-    console.error('Morpho API GraphQL Error:', (result as any).errors);
+    const result = (await response.json()) as T;
 
-    throw new Error('Unknown GraphQL error from Morpho API');
+    // Check for GraphQL errors
+    if ('errors' in result && Array.isArray((result as any).errors) && (result as any).errors.length > 0) {
+      const notFoundError = (result as any).errors.find((err: { status?: string }) => err.status?.includes('NOT_FOUND'));
+
+      if (notFoundError) {
+        // Morpho API sometimes returns NOT_FOUND error alongside valid data
+        if ('data' in result && result.data !== null) {
+          console.log('Morpho API returned NOT_FOUND error but has valid data, using data');
+          return result;
+        }
+
+        // NOT_FOUND with null data - this is intermittent, retry
+        if (attempt < maxRetries) {
+          console.log(`Morpho API NOT_FOUND error (attempt ${attempt}/${maxRetries}), retrying...`);
+          await new Promise((resolve) => setTimeout(resolve, 500 * attempt)); // Backoff
+          continue;
+        }
+
+        console.log('Morpho API NOT_FOUND error after retries:', notFoundError);
+        return null;
+      }
+
+      // Non-NOT_FOUND errors - don't retry
+      console.error('Morpho API GraphQL Error:', (result as any).errors);
+      throw new Error('Unknown GraphQL error from Morpho API');
+    }
+
+    // Success
+    return result;
   }
 
-  return result;
+  return null;
 };


### PR DESCRIPTION
## Problem
Morpho API has intermittent NOT_FOUND errors due to corrupted market records. Same query fails sometimes, succeeds on retry.

## Solution
Add simple retry logic in `morphoGraphqlFetcher`:
- Max 3 attempts on NOT_FOUND errors with null data
- Exponential backoff (500ms, 1000ms, 1500ms)
- **No page size changes** - keeps original 500

## Why this works
The error is intermittent - tested 5 consecutive requests:
```
Attempt 1: FAIL (has_errors: true, items: 0)
Attempt 2: OK (has_errors: false, items: 500)
Attempt 3: OK
Attempt 4: OK
Attempt 5: OK
```

A simple retry handles this without changing pagination logic.

## Changes
- `src/data-sources/morpho-api/fetchers.ts`: Add retry loop with backoff

Bug report for Morpho: https://hackmd.io/ryVLMOWO-e