### PR TITLE
feat: Add Days to Liquidation column to borrowers table

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -513,3 +513,15 @@ pre {
   border-radius: 20px;
   border: transparent;
 }
+
+/* Accessibility: Respect user's preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -9,7 +9,8 @@ type AvatarProps = {
 };
 
 export function Avatar({ address, size = 30, rounded = true }: AvatarProps) {
-  const [useEffigy, setUseEffigy] = useState(true);
+  const [effigyErrorAddress, setEffigyErrorAddress] = useState<Address | null>(null);
+  const useEffigy = effigyErrorAddress !== address;
   const effigyUrl = `https://effigy.im/a/${address}.svg`;
   const dicebearUrl = `https://api.dicebear.com/7.x/pixel-art/png?seed=${address}`;
 
@@ -21,7 +22,7 @@ export function Avatar({ address, size = 30, rounded = true }: AvatarProps) {
         width={size}
         height={size}
         style={{ borderRadius: rounded ? '50%' : '5px' }}
-        onError={() => setUseEffigy(false)}
+        onError={() => setEffigyErrorAddress(address)}
       />
     </div>
   );

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import type { Address } from 'viem';
-import { getMorphoAddress } from '@/utils/morpho';
 
 type AvatarProps = {
   address: Address;
@@ -13,20 +12,6 @@ export function Avatar({ address, size = 30, rounded = true }: AvatarProps) {
   const [useEffigy, setUseEffigy] = useState(true);
   const effigyUrl = `https://effigy.im/a/${address}.svg`;
   const dicebearUrl = `https://api.dicebear.com/7.x/pixel-art/png?seed=${address}`;
-
-  useEffect(() => {
-    const checkEffigyAvailability = async () => {
-      const effigyMockurl = `https://effigy.im/a/${getMorphoAddress(1)}.png`;
-      try {
-        const response = await fetch(effigyMockurl, { method: 'HEAD' });
-        setUseEffigy(response.ok);
-      } catch (_error) {
-        setUseEffigy(false);
-      }
-    };
-
-    void checkEffigyAvailability();
-  }, []);
 
   return (
     <div style={{ width: size, height: size }}>

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -10,14 +10,14 @@ type AvatarProps = {
 
 export function Avatar({ address, size = 30, rounded = true }: AvatarProps) {
   const [effigyErrorAddress, setEffigyErrorAddress] = useState<Address | null>(null);
-  const useEffigy = effigyErrorAddress !== address;
+  const effigyActive = effigyErrorAddress !== address;
   const effigyUrl = `https://effigy.im/a/${address}.svg`;
   const dicebearUrl = `https://api.dicebear.com/7.x/pixel-art/png?seed=${address}`;
 
   return (
     <div style={{ width: size, height: size }}>
       <Image
-        src={useEffigy ? effigyUrl : dicebearUrl}
+        src={effigyActive ? effigyUrl : dicebearUrl}
         alt={`Avatar for ${address}`}
         width={size}
         height={size}

--- a/src/features/autovault/components/vault-detail/settings/EditMetadata.tsx
+++ b/src/features/autovault/components/vault-detail/settings/EditMetadata.tsx
@@ -69,13 +69,17 @@ export function EditMetadata({
     }
   }, [computedNameInput, computedSymbolInput, metadataError]);
 
-  // Reset edit state when upstream values change
+  // Reset name edit state when upstream name changes
   useEffect(() => {
     nameEdited.current = false;
-    symbolEdited.current = false;
     setNameInput('');
+  }, [previousName]);
+
+  // Reset symbol edit state when upstream symbol changes
+  useEffect(() => {
+    symbolEdited.current = false;
     setSymbolInput('');
-  }, [previousName, previousSymbol]);
+  }, [previousSymbol]);
 
   const trimmedName = computedNameInput.trim();
   const trimmedSymbol = computedSymbolInput.trim();

--- a/src/features/autovault/components/vault-detail/settings/EditMetadata.tsx
+++ b/src/features/autovault/components/vault-detail/settings/EditMetadata.tsx
@@ -67,7 +67,15 @@ export function EditMetadata({
     if (metadataError) {
       setMetadataError(null);
     }
-  }, [computedNameInput, computedSymbolInput]);
+  }, [computedNameInput, computedSymbolInput, metadataError]);
+
+  // Reset edit state when upstream values change
+  useEffect(() => {
+    nameEdited.current = false;
+    symbolEdited.current = false;
+    setNameInput('');
+    setSymbolInput('');
+  }, [previousName, previousSymbol]);
 
   const trimmedName = computedNameInput.trim();
   const trimmedSymbol = computedSymbolInput.trim();

--- a/src/features/market-detail/components/charts/concentration-chart.tsx
+++ b/src/features/market-detail/components/charts/concentration-chart.tsx
@@ -22,6 +22,36 @@ type ConcentrationChartProps = {
 
 const MIN_PERCENT_THRESHOLD = 0.1;
 
+// Custom tooltip at module scope
+function ConcentrationTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload: ConcentrationDataPoint }[];
+}) {
+  if (!active || !payload?.[0]) return null;
+  const data = payload[0].payload;
+
+  if (data.position === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-3 shadow-lg">
+      <p className="mb-2 text-xs text-secondary">Top {data.position.toLocaleString()}</p>
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-6 text-sm">
+          <span className="text-secondary">Actual</span>
+          <span className="tabular-nums font-medium">{data.cumulativePercent.toFixed(1)}%</span>
+        </div>
+        <div className="flex items-center justify-between gap-6 text-sm">
+          <span className="text-secondary">If equal</span>
+          <span className="tabular-nums text-secondary">{data.idealPercent.toFixed(1)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ConcentrationChart({ positions, totalCount, isLoading, title, color }: ConcentrationChartProps) {
   const { chartData, meaningfulCount, totalPercentShown } = useMemo(() => {
     const emptyResult = { chartData: [], meaningfulCount: 0, totalPercentShown: 0 };
@@ -74,29 +104,6 @@ export function ConcentrationChart({ positions, totalCount, isLoading, title, co
       top100: findPercent(100),
     };
   }, [chartData]);
-
-  function CustomTooltip({ active, payload }: { active?: boolean; payload?: { payload: ConcentrationDataPoint }[] }) {
-    if (!active || !payload?.[0]) return null;
-    const data = payload[0].payload;
-
-    if (data.position === 0) return null;
-
-    return (
-      <div className="rounded-lg border border-border bg-background p-3 shadow-lg">
-        <p className="mb-2 text-xs text-secondary">Top {data.position.toLocaleString()}</p>
-        <div className="space-y-1">
-          <div className="flex items-center justify-between gap-6 text-sm">
-            <span className="text-secondary">Actual</span>
-            <span className="tabular-nums font-medium">{data.cumulativePercent.toFixed(1)}%</span>
-          </div>
-          <div className="flex items-center justify-between gap-6 text-sm">
-            <span className="text-secondary">If equal</span>
-            <span className="tabular-nums text-secondary">{data.idealPercent.toFixed(1)}%</span>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   if (isLoading) {
     return (
@@ -197,7 +204,7 @@ export function ConcentrationChart({ positions, totalCount, isLoading, title, co
             />
             <Tooltip
               cursor={chartTooltipCursor}
-              content={<CustomTooltip />}
+              content={<ConcentrationTooltip />}
             />
             <Line
               type="monotone"

--- a/src/features/market-detail/components/charts/debt-at-risk-chart.tsx
+++ b/src/features/market-detail/components/charts/debt-at-risk-chart.tsx
@@ -24,6 +24,38 @@ type RiskDataPoint = {
   cumulativeDebtPercent: number; // Percentage of total debt
 };
 
+// Custom tooltip at module scope
+function DebtAtRiskTooltip({
+  active,
+  payload,
+  symbol,
+}: {
+  active?: boolean;
+  payload?: { value: number; payload: RiskDataPoint }[];
+  symbol: string;
+}) {
+  if (!active || !payload || !payload[0]) return null;
+  const data = payload[0].payload;
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-3 shadow-lg">
+      <p className="mb-2 text-xs text-secondary">At {data.priceDrop}% price drop</p>
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-6 text-sm">
+          <span className="text-secondary">% of Total Debt</span>
+          <span className="tabular-nums font-medium">{data.cumulativeDebtPercent.toFixed(1)}%</span>
+        </div>
+        <div className="flex items-center justify-between gap-6 text-sm">
+          <span className="text-secondary">Debt at Risk</span>
+          <span className="tabular-nums">
+            {formatReadable(data.cumulativeDebt)} {symbol}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function DebtAtRiskChart({ chainId, market, oraclePrice }: DebtAtRiskChartProps) {
   const { data: borrowers, isLoading } = useAllMarketBorrowers(market.uniqueKey, chainId);
   const chartColors = useChartColors();
@@ -105,29 +137,6 @@ export function DebtAtRiskChart({ chainId, market, oraclePrice }: DebtAtRiskChar
       },
     };
   }, [borrowers, oraclePrice, market.loanAsset.decimals, lltv]);
-
-  const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: { value: number; payload: RiskDataPoint }[] }) => {
-    if (!active || !payload || !payload[0]) return null;
-    const data = payload[0].payload;
-
-    return (
-      <div className="rounded-lg border border-border bg-background p-3 shadow-lg">
-        <p className="mb-2 text-xs text-secondary">At {data.priceDrop}% price drop</p>
-        <div className="space-y-1">
-          <div className="flex items-center justify-between gap-6 text-sm">
-            <span className="text-secondary">% of Total Debt</span>
-            <span className="tabular-nums font-medium">{data.cumulativeDebtPercent.toFixed(1)}%</span>
-          </div>
-          <div className="flex items-center justify-between gap-6 text-sm">
-            <span className="text-secondary">Debt at Risk</span>
-            <span className="tabular-nums">
-              {formatReadable(data.cumulativeDebt)} {market.loanAsset.symbol}
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  };
 
   if (isLoading) {
     return (
@@ -214,7 +223,7 @@ export function DebtAtRiskChart({ chainId, market, oraclePrice }: DebtAtRiskChar
             />
             <Tooltip
               cursor={chartTooltipCursor}
-              content={<CustomTooltip />}
+              content={<DebtAtRiskTooltip symbol={market.loanAsset.symbol} />}
             />
             <Area
               type="stepAfter"

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook to detect if the user prefers reduced motion.
+ * Returns true if the user has enabled reduced motion in their system settings.
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    // Check if the browser supports media queries
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/src/modals/borrow/borrow-modal.tsx
+++ b/src/modals/borrow/borrow-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { LuArrowRightLeft } from 'react-icons/lu';
 import { useConnection, useReadContract, useBalance } from 'wagmi';
 import { erc20Abi } from 'viem';
@@ -32,11 +32,6 @@ export function BorrowModal({
   liquiditySourcing,
 }: BorrowModalProps): JSX.Element {
   const [mode, setMode] = useState<'borrow' | 'repay'>(defaultMode);
-
-  // Reset mode when defaultMode changes (e.g., modal re-opened with different mode)
-  useEffect(() => {
-    setMode(defaultMode);
-  }, [defaultMode]);
   const { address: account } = useConnection();
 
   // Get token balances
@@ -95,6 +90,7 @@ export function BorrowModal({
       isOpen
       onOpenChange={onOpenChange}
       size="lg"
+      key={defaultMode}
     >
       <ModalHeader
         mainIcon={mainIcon}

--- a/src/modals/borrow/borrow-modal.tsx
+++ b/src/modals/borrow/borrow-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { LuArrowRightLeft } from 'react-icons/lu';
 import { useConnection, useReadContract, useBalance } from 'wagmi';
 import { erc20Abi } from 'viem';
@@ -32,6 +32,12 @@ export function BorrowModal({
   liquiditySourcing,
 }: BorrowModalProps): JSX.Element {
   const [mode, setMode] = useState<'borrow' | 'repay'>(defaultMode);
+
+  // Sync mode with defaultMode when it changes
+  useEffect(() => {
+    setMode(defaultMode);
+  }, [defaultMode]);
+
   const { address: account } = useConnection();
 
   // Get token balances
@@ -90,7 +96,6 @@ export function BorrowModal({
       isOpen
       onOpenChange={onOpenChange}
       size="lg"
-      key={defaultMode}
     >
       <ModalHeader
         mainIcon={mainIcon}

--- a/src/modals/settings/monarch-settings/details/BlacklistedMarketsDetail.tsx
+++ b/src/modals/settings/monarch-settings/details/BlacklistedMarketsDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { FiPlus } from 'react-icons/fi';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Button } from '@/components/ui/button';
@@ -20,9 +20,10 @@ export function BlacklistedMarketsDetail() {
     useBlacklistedMarkets();
   const { success: toastSuccess } = useStyledToast();
 
-  useEffect(() => {
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
     setCurrentPage(1);
-  }, [searchQuery]);
+  }, []);
 
   const { blacklistedMarkets, availableMarkets } = useMemo(() => {
     const blacklisted: Market[] = [];
@@ -132,7 +133,7 @@ export function BlacklistedMarketsDetail() {
               type="text"
               placeholder="Search to add markets (min 2 characters)..."
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={handleSearchChange}
               className="bg-hovered h-9 w-full rounded p-2 font-zen text-xs focus:border-primary focus:outline-none"
             />
           </div>

--- a/src/utils/generateMetadata.ts
+++ b/src/utils/generateMetadata.ts
@@ -10,7 +10,7 @@ type MetaTagsProps = {
 };
 
 const deployUrl = process.env.BOAT_DEPLOY_URL ?? process.env.VERCEL_URL;
-const defaultUrl = deployUrl ? `https://${deployUrl}` : `http://localhost:${process.env.PORT ?? 3000}`;
+const defaultUrl = deployUrl ? `https://${deployUrl}` : 'https://monarchlend.xyz';
 
 export const generateMetadata = ({
   title = 'Monarch',


### PR DESCRIPTION
## Summary

Adds a "Days to Liq." column to the borrowers table showing estimated days until liquidation.

## Calculation

Uses continuous compounding formula:
`Days = ln(lltv/ltv) / borrowApy * 365`

Where:
- **LTV**: Current loan-to-value ratio (borrow / collateral value)
- **lltv**: Market's liquidation threshold (e.g., 80%)
- **borrowApy**: Annual borrow APY from market state

## Display

- **Red** (<7 days): Critical
- **Orange** (7-30 days): Warning  
- **Green** (>30 days): Safe
- **—**: No risk (no collateral or no borrow)

## Related

Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Days to Liquidation metric and display for borrowers.
  * Added reduced-motion accessibility support tied to system preference (CSS + detection).

* **Bug Fixes**
  * Improved avatar image fallback for more reliable avatar display.
  * Made market data pagination more tolerant of incomplete responses.

* **Improvements**
  * Smoother metadata editing flow in vault settings.
  * More consistent and refined chart tooltips.
  * More stable settings search input handling.
  * Default metadata URL updated to production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->