### PR TITLE
chore: remove unsupported rapid pay agent

### DIFF
--- a/src/utils/monarch-agent.ts
+++ b/src/utils/monarch-agent.ts
@@ -5,11 +5,7 @@ const agentApyImage: string = require('@/imgs/agent/agent-apy.png') as string;
 
 export enum KnownAgents {
   MAX_APY = '0x038cC0fFf3aBc20dcd644B1136F42A33df135c52',
-  MAX_APY_HOURLY = '0xC953bc5F74a6b3F3c7e3539390116A233CE92108',
 }
-
-// Performance fee constants (WAD format: 1e18 = 100%)
-const PERFORMANCE_FEE_10_PERCENT = 100000000000000000n; // 0.1e18 = 10%
 
 // v2 rebalancer EOA // identical now
 export const v2AgentsBase: AgentMetadata[] = [
@@ -20,14 +16,6 @@ export const v2AgentsBase: AgentMetadata[] = [
     image: agentApyImage,
     performanceFee: 0n,
     performanceFeeRecipient: zeroAddress,
-  },
-  {
-    name: 'Rapid Max APY',
-    address: KnownAgents.MAX_APY_HOURLY,
-    strategyDescription: 'Rebalances every 5 minutes if necessary, optimizing for highest APY considering all managed auto vaults.',
-    image: agentApyImage,
-    performanceFee: PERFORMANCE_FEE_10_PERCENT,
-    performanceFeeRecipient: KnownAgents.MAX_APY_HOURLY,
   },
 ];
 


### PR DESCRIPTION
## Summary
- remove unsupported Rapid Max APY agent from agent registry
- remove rapid-pay specific 10% performance fee constant/address enum
- ensure the agent is no longer selectable in flows derived from v2AgentsBase

## Validation
- pnpm typecheck (pass)
- pnpm check (fails due pre-existing unrelated repo-wide Biome issues)
- touched file compiles and branch is based on latest origin/master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused agent configuration from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->