### PR TITLE
fix: data source

### DIFF
--- a/src/data-sources/morpho-api/prices.ts
+++ b/src/data-sources/morpho-api/prices.ts
@@ -72,7 +72,7 @@ export const fetchTokenPrices = async (tokens: TokenPriceInput[]): Promise<Map<s
     Array.from(tokensByChain.entries()).map(async ([chainId, addresses]) => {
       try {
         const addressChunks = chunkAddresses(addresses);
-        const responses = await Promise.all(
+        const responses = await Promise.allSettled(
           addressChunks.map((addressChunk) =>
             morphoGraphqlFetcher<AssetPricesResponse>(assetPricesQuery, {
               where: {
@@ -83,7 +83,14 @@ export const fetchTokenPrices = async (tokens: TokenPriceInput[]): Promise<Map<s
           ),
         );
 
-        for (const response of responses) {
+        for (const responseResult of responses) {
+          if (responseResult.status === 'rejected') {
+            console.error(`Failed to fetch prices for chain ${chainId}:`, responseResult.reason);
+            continue;
+          }
+
+          const response = responseResult.value;
+
           // Handle NOT_FOUND - skip this batch
           if (!response) {
             continue;


### PR DESCRIPTION
Morpho API cannot specify asset_in > 100 entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and responsiveness of price lookups by using batched, parallel queries.
  * Lookup process now tolerates and skips failed or empty batches so overall retrieval continues.
  * Skips missing entries while aggregating valid results, preserving previous not-found behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->