### PR TITLE
Lower Smart Rebalance max fee cap to $5

### DIFF
--- a/src/config/fees.ts
+++ b/src/config/fees.ts
@@ -3,7 +3,7 @@ import { parseUnits } from 'viem';
 const FEE_DENOMINATOR_PPM = 1_000_000n;
 const REBALANCE_FEE_RATE_PPM = 30n; // 0.3 bps = 0.003%
 const LEVERAGE_FEE_RATE_PPM = 75n; // 0.75 bps = 0.0075%
-export const REBALANCE_FEE_CEILING_USD = 10;
+export const REBALANCE_FEE_CEILING_USD = 5;
 export const LEVERAGE_FEE_CEILING_USD = 5;
 
 type FeeParams = {

--- a/src/features/market-detail/components/charts/volume-chart.tsx
+++ b/src/features/market-detail/components/charts/volume-chart.tsx
@@ -30,6 +30,18 @@ type VolumeChartProps = {
   market: Market;
 };
 
+const MAX_NET_GROWTH_PERCENT = 20_000;
+
+function formatNetChangePercentage(value: number): string {
+  if (!Number.isFinite(value)) return '0.00%';
+
+  if (value > MAX_NET_GROWTH_PERCENT) {
+    return '>' + MAX_NET_GROWTH_PERCENT.toLocaleString() + '%';
+  }
+
+  return (value >= 0 ? '+' : '') + value.toFixed(2) + '%';
+}
+
 function VolumeChart({ marketId, chainId, market }: VolumeChartProps) {
   const selectedTimeframe = useMarketDetailChartState((s) => s.selectedTimeframe);
   const selectedTimeRange = useMarketDetailChartState((s) => s.selectedTimeRange);
@@ -191,8 +203,7 @@ function VolumeChart({ marketId, chainId, market }: VolumeChartProps) {
             <div className="flex items-baseline gap-2">
               <span className="tabular-nums text-lg">{formatValue(supplyStats.current)}</span>
               <span className={`text-xs tabular-nums ${supplyStats.netChangePercentage >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
-                {supplyStats.netChangePercentage >= 0 ? '+' : ''}
-                {supplyStats.netChangePercentage.toFixed(2)}%
+                {formatNetChangePercentage(supplyStats.netChangePercentage)}
               </span>
             </div>
           </div>
@@ -201,8 +212,7 @@ function VolumeChart({ marketId, chainId, market }: VolumeChartProps) {
             <div className="flex items-baseline gap-2">
               <span className="tabular-nums text-lg">{formatValue(borrowStats.current)}</span>
               <span className={`text-xs tabular-nums ${borrowStats.netChangePercentage >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
-                {borrowStats.netChangePercentage >= 0 ? '+' : ''}
-                {borrowStats.netChangePercentage.toFixed(2)}%
+                {formatNetChangePercentage(borrowStats.netChangePercentage)}
               </span>
             </div>
           </div>
@@ -211,8 +221,7 @@ function VolumeChart({ marketId, chainId, market }: VolumeChartProps) {
             <div className="flex items-baseline gap-2">
               <span className="tabular-nums text-lg">{formatValue(liquidityStats.current)}</span>
               <span className={`text-xs tabular-nums ${liquidityStats.netChangePercentage >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
-                {liquidityStats.netChangePercentage >= 0 ? '+' : ''}
-                {liquidityStats.netChangePercentage.toFixed(2)}%
+                {formatNetChangePercentage(liquidityStats.netChangePercentage)}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- lower Smart Rebalance max fee cap from $10 to $5
- keep fee cap sourced from shared REBALANCE_FEE_CEILING_USD constant in src/config/fees.ts

## Validation
- npx ultracite fix (fails: pre-existing biome.jsonc unknown-rule configuration errors)
- npx ultracite check (fails: same pre-existing biome.jsonc unknown-rule configuration errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved net change percentage formatting with enhanced handling of edge cases, large values, and non-finite inputs.

* **Chores**
  * Reduced rebalance fee ceiling from $10 to $5, lowering the maximum USD-based ceiling applied to rebalance fees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->