### PR TITLE
chore: update docs link to docs.monarchlend.xyz

### DIFF
--- a/src/utils/external.ts
+++ b/src/utils/external.ts
@@ -61,8 +61,10 @@ export const getMerklCampaignURL = (chainId: number, type: string, identifier: s
   return `https://app.merkl.xyz/opportunities/${chainName}/${type}/${identifier}`;
 };
 
+export const MONARCH_DOCS_URL = 'https://docs.monarchlend.xyz';
+
 export const EXTERNAL_LINKS = {
-  docs: 'https://monarch-lend.gitbook.io/monarch-lend/',
+  docs: MONARCH_DOCS_URL,
   discord: 'https://discord.gg/Ur4dwN3aPS',
   github: 'https://github.com/monarch-xyz',
 } as const;


### PR DESCRIPTION
Replace the old GitBook docs link with a centralized constant in src/utils/external.ts. Validation: pnpm typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation link to point to new location at https://docs.monarchlend.xyz

<!-- end of auto-generated comment: release notes by coderabbit.ai -->