### PR TITLE
feat: allow sub-bps swap slippage

### DIFF
--- a/src/features/swap/constants.ts
+++ b/src/features/swap/constants.ts
@@ -20,8 +20,11 @@ export const DEFAULT_SLIPPAGE_PERCENT = 0.5;
 
 /**
  * Slippage tolerance input bounds as percentages.
+ *
+ * ParaSwap accepts fractional BPS values for RFQ routes, so the UI allows
+ * sub-0.01% tolerances for stable pairs while keeping a positive floor.
  */
-export const MIN_SLIPPAGE_PERCENT = 0.01;
+export const MIN_SLIPPAGE_PERCENT = 0.001;
 export const MAX_SLIPPAGE_PERCENT = 5;
 
 export const clampSlippagePercent = (value: number): number => {
@@ -29,5 +32,5 @@ export const clampSlippagePercent = (value: number): number => {
 };
 
 export const slippagePercentToBps = (value: number): number => {
-  return Math.round(clampSlippagePercent(value) * 100);
+  return Number((clampSlippagePercent(value) * 100).toFixed(6));
 };

--- a/src/features/swap/utils/quote-preview.ts
+++ b/src/features/swap/utils/quote-preview.ts
@@ -3,7 +3,8 @@ import { formatTokenAmountPreview } from '@/hooks/leverage/math';
 const RATE_PREVIEW_DECIMALS = 8;
 
 export const formatSlippagePercent = (value: number): string => {
-  return value.toFixed(2).replace(/\.?0+$/, '');
+  const decimals = value < 0.01 ? 3 : 2;
+  return value.toFixed(decimals).replace(/\.?0+$/, '');
 };
 
 export const computeUnitRatePreviewAmount = (

--- a/src/hooks/leverage/math.ts
+++ b/src/hooks/leverage/math.ts
@@ -8,6 +8,8 @@ const ASSET_INPUT_SHARE_SLIPPAGE_BUFFER_BPS = 50n; // 0.50%
 const MORPHO_VIRTUAL_SHARES = 1_000_000n;
 const MORPHO_VIRTUAL_ASSETS = 1n;
 const DEFAULT_SLIPPAGE_TOLERANCE_BPS = BPS_SCALE - LEVERAGE_SLIPPAGE_BUFFER_BPS;
+const FRACTIONAL_BPS_SCALE = 1_000_000n;
+const FRACTIONAL_BPS_DENOMINATOR = BPS_SCALE * FRACTIONAL_BPS_SCALE;
 const MAX_TARGET_LTV_BPS = BPS_SCALE - 1n;
 const COMPACT_AMOUNT_LOCALE = 'en-US';
 const COMPACT_AMOUNT_MIN_THRESHOLD = 0.000001;
@@ -17,16 +19,18 @@ const UNSIGNED_INTEGER_REGEX = /^\d+$/;
 const minBigInt = (a: bigint, b: bigint): bigint => (a < b ? a : b);
 const floorSub = (value: bigint, subtract: bigint): bigint => (value > subtract ? value - subtract : 0n);
 const getSlippageToleranceBps = (slippageBps?: number): bigint => {
-  if (slippageBps == null || !Number.isFinite(slippageBps)) return DEFAULT_SLIPPAGE_TOLERANCE_BPS;
-  const rounded = BigInt(Math.round(slippageBps));
-  if (rounded <= 0n) return 0n;
-  if (rounded >= BPS_SCALE) return BPS_SCALE - 1n;
-  return rounded;
+  // Return values are scaled by FRACTIONAL_BPS_SCALE so sub-1-bps slippage
+  // survives BigInt floor/ceil math.
+  if (slippageBps == null || !Number.isFinite(slippageBps)) return DEFAULT_SLIPPAGE_TOLERANCE_BPS * FRACTIONAL_BPS_SCALE;
+  const scaled = BigInt(Math.round(slippageBps * Number(FRACTIONAL_BPS_SCALE)));
+  if (scaled <= 0n) return 0n;
+  if (scaled >= FRACTIONAL_BPS_DENOMINATOR) return FRACTIONAL_BPS_DENOMINATOR - 1n;
+  return scaled;
 };
 
 const getSlippageFloorBps = (slippageBps?: number): bigint => {
   const toleranceBps = getSlippageToleranceBps(slippageBps);
-  const floorBps = BPS_SCALE - toleranceBps;
+  const floorBps = FRACTIONAL_BPS_DENOMINATOR - toleranceBps;
   return floorBps > 0n ? floorBps : 1n;
 };
 
@@ -336,14 +340,14 @@ export const formatTokenAmountPreview = (value: bigint, decimals: number): { com
 export const withSlippageFloor = (value: bigint, slippageBps?: number): bigint => {
   if (value <= 0n) return 0n;
   const floorBps = getSlippageFloorBps(slippageBps);
-  const floored = (value * floorBps) / LEVERAGE_MULTIPLIER_SCALE_BPS;
+  const floored = (value * floorBps) / FRACTIONAL_BPS_DENOMINATOR;
   return floored > 0n ? floored : 1n;
 };
 
 export const withSlippageCeil = (value: bigint, slippageBps?: number): bigint => {
   if (value <= 0n) return 0n;
-  const ceilBps = LEVERAGE_MULTIPLIER_SCALE_BPS + getSlippageToleranceBps(slippageBps);
-  return (value * ceilBps + LEVERAGE_MULTIPLIER_SCALE_BPS - 1n) / LEVERAGE_MULTIPLIER_SCALE_BPS;
+  const ceilBps = FRACTIONAL_BPS_DENOMINATOR + getSlippageToleranceBps(slippageBps);
+  return (value * ceilBps + FRACTIONAL_BPS_DENOMINATOR - 1n) / FRACTIONAL_BPS_DENOMINATOR;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Lower custom swap slippage floor from 0.01% to 0.001% for stable/RFQ pairs
- Preserve fractional BPS when converting UI percent into Velora slippage
- Keep leverage/deleverage local slippage floor/ceil math precise for fractional BPS

## Validation
- Live ParaSwap /transactions/8453?ignoreChecks=true accepted fractional slippage values: 0.5, 0.1, 0.01 BPS
- pnpm lint:check
- pnpm typecheck
- pnpm build
- pnpm exec tsx smoke: 0.001% -> 0.1 BPS; 0.1 BPS floor/ceil on 1,000,000 -> 999,990 / 1,000,010
- Independent code review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Reduced minimum slippage tolerance from 0.01% to 0.001%, enabling more precise control over swap parameters.
  * Improved precision in slippage calculations and display formatting for better handling of fractional values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->