### PR TITLE
fix: show withdraw liquidity cap in modal

### DIFF
--- a/src/modals/supply/withdraw-modal-content.tsx
+++ b/src/modals/supply/withdraw-modal-content.tsx
@@ -341,8 +341,7 @@ export function WithdrawModalContent({
             }
           />
           <p className="mt-1 text-right text-xs text-secondary">
-            Available: {formatReadable(formatBalance(position?.state.supplyAssets ?? 0n, activeMarket.loanAsset.decimals))}{' '}
-            {activeMarket.loanAsset.symbol}
+            Available: {formatReadable(formatBalance(effectiveMax, activeMarket.loanAsset.decimals))} {activeMarket.loanAsset.symbol}
           </p>
 
           {needsSourcing && reallocationPlan && (


### PR DESCRIPTION
## Summary
- Show the effective withdraw cap in the withdraw modal `Available:` label
- Keeps the label aligned with the existing input max: user supply capped by market liquidity plus sourced PA liquidity

## Test Plan
- [x] `pnpm typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined withdrawal amount calculations to more accurately reflect total available liquidity across all sources
  * Improved visibility of liquidity reallocation plan when required during withdrawal operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->