### PR TITLE
fix: normalize market detail route key

### DIFF
--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -74,6 +74,7 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 - Market-table data enrichments that affect visible columns or sorting must report degraded readiness to the shared market-data notice surface instead of silently replacing values with empty placeholders.
 - Portfolio and position analysis must preserve transaction-discovered market IDs even when current on-chain balances are zero; list-level hide settings must not remove those markets from summary or history inputs.
 - Supplied-position surfaces must distinguish active supply (`supplyShares`/`supplyAssets`) and historical supply (`MarketSupply`/`MarketWithdraw`) from borrow shares and collateral.
+- Shared components/modals launched from multiple pages may receive prefetched data, but every launcher must be verified to provide the same canonical data source and field completeness; do not let one route skip fields required by shared limits, previews, or transaction availability.
 
 
 ## Transactions And Wallet Flows

--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -67,7 +67,7 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 - Data fetching should use existing React Query hooks and established cache keys where possible.
 - Please respect the setting in "useCustomRPC" whenever a request is RPC-related.
 - Grouped fetching via RPC must be bundled with `multicall` to increase efficiency if they're on the same chain or block.
-- Domain matching, token resolution, unit conversion, address normalization, and formatting should live in shared chokepoints.
+- Domain matching, token resolution, unit conversion, entity ID normalization, address normalization, and formatting should live in shared chokepoints.
 - Multi-chain logic must respect chain ID and address together; do not match by address alone across chains.
 - Fallback data should be marked or shaped consistently with primary data so downstream components can reason about it safely.
 - Metadata-backed display guards must expose readiness through the shared dependency-status layer, must not treat missing metadata as a negative match, and must preserve the list or previous data while the guard cannot be evaluated.

--- a/src/data-sources/monarch-api/market-tx-contexts.ts
+++ b/src/data-sources/monarch-api/market-tx-contexts.ts
@@ -1,5 +1,6 @@
 import { isAddress } from 'viem';
 import { envioMarketTxContextsPageQuery, envioMarketTxContextsPageWithinSnapshotQuery } from '@/graphql/envio-queries';
+import { normalizeMarketUniqueKey } from '@/utils/markets';
 import { monarchGraphqlFetcher } from './fetchers';
 
 const MONARCH_MARKET_TX_CONTEXTS_TIMEOUT_MS = 15_000;
@@ -208,7 +209,8 @@ export type PaginatedMarketProActivities = {
 
 const toTimestamp = (value: string | number): number => (typeof value === 'number' ? value : Number.parseInt(value, 10));
 
-const sameMarket = (left: string | undefined, right: string): boolean => left?.toLowerCase() === right.toLowerCase();
+const getMarketKey = (marketId: string | undefined | null): string | undefined => normalizeMarketUniqueKey(marketId);
+const sameMarket = (left: string | undefined, right: string): boolean => getMarketKey(left) === getMarketKey(right);
 
 const isMorphoMarketLegKind = (kind: MarketProActivityLegKind): kind is MorphoMarketLegKind => {
   return (
@@ -258,8 +260,12 @@ const isTrueVaultRebalanceContext = (context: MonarchTxContextRow): boolean => {
     return false;
   }
 
-  const supplyMarketIds = new Set(context.morphoSupplies.map((leg) => leg.market_id.toLowerCase()));
-  const withdrawMarketIds = new Set(context.morphoWithdraws.map((leg) => leg.market_id.toLowerCase()));
+  const supplyMarketIds = new Set(
+    context.morphoSupplies.map((leg) => getMarketKey(leg.market_id)).filter((id): id is string => Boolean(id)),
+  );
+  const withdrawMarketIds = new Set(
+    context.morphoWithdraws.map((leg) => getMarketKey(leg.market_id)).filter((id): id is string => Boolean(id)),
+  );
 
   return supplyMarketIds.size > 0 && withdrawMarketIds.size > 0 && hasDistinctMarketPair(withdrawMarketIds, supplyMarketIds);
 };
@@ -273,13 +279,16 @@ const uniqueMarketIds = (legs: MarketProActivityLeg[]): string[] => {
       continue;
     }
 
-    const normalizedMarketId = leg.marketId.toLowerCase();
+    const normalizedMarketId = getMarketKey(leg.marketId);
+    if (!normalizedMarketId) {
+      continue;
+    }
     if (seen.has(normalizedMarketId)) {
       continue;
     }
 
     seen.add(normalizedMarketId);
-    marketIds.push(leg.marketId);
+    marketIds.push(normalizedMarketId);
   }
 
   return marketIds;
@@ -318,19 +327,23 @@ const mapMorphoLegs = (
   assetType: 'loan' | 'collateral',
   currentMarketId: string,
 ): MarketProActivityLeg[] => {
-  return (rows ?? []).map((row, index) => ({
-    id: `${kind}-${row.market_id}-${row.assets}-${row.caller}-${index}`,
-    kind,
-    source: 'morpho',
-    marketId: row.market_id,
-    amount: row.assets,
-    assetType,
-    isMonarch: row.isMonarch,
-    positionAddress: toOptionalAddress(row.onBehalf),
-    actorAddress: toOptionalAddress(row.caller) ?? toOptionalAddress(row.onBehalf),
-    receiverAddress: toOptionalAddress(row.receiver),
-    isCurrentMarket: sameMarket(row.market_id, currentMarketId),
-  }));
+  return (rows ?? []).map((row, index) => {
+    const marketId = getMarketKey(row.market_id);
+
+    return {
+      id: `${kind}-${marketId ?? row.market_id}-${row.assets}-${row.caller}-${index}`,
+      kind,
+      source: 'morpho',
+      marketId,
+      amount: row.assets,
+      assetType,
+      isMonarch: row.isMonarch,
+      positionAddress: toOptionalAddress(row.onBehalf),
+      actorAddress: toOptionalAddress(row.caller) ?? toOptionalAddress(row.onBehalf),
+      receiverAddress: toOptionalAddress(row.receiver),
+      isCurrentMarket: sameMarket(row.market_id, currentMarketId),
+    };
+  });
 };
 
 const mapVaultDepositLegs = (rows: MonarchVaultDepositRow[] | undefined, source: 'vault-v2' | 'legacy-vault'): MarketProActivityLeg[] => {
@@ -435,7 +448,7 @@ const mapLegacyVaultReallocateSupplyLegs = (
     id: row.id,
     kind: 'legacyVaultReallocateSupply',
     source: 'legacy-vault',
-    marketId: row.market_id,
+    marketId: getMarketKey(row.market_id),
     amount: row.suppliedAssets,
     assetType: 'loan',
     isMonarch: row.isMonarch,
@@ -453,7 +466,7 @@ const mapLegacyVaultReallocateWithdrawLegs = (
     id: row.id,
     kind: 'legacyVaultReallocateWithdraw',
     source: 'legacy-vault',
-    marketId: row.market_id,
+    marketId: getMarketKey(row.market_id),
     amount: row.withdrawnAssets,
     assetType: 'loan',
     isMonarch: row.isMonarch,

--- a/src/data-sources/monarch-api/markets.ts
+++ b/src/data-sources/monarch-api/markets.ts
@@ -2,7 +2,7 @@ import { Market as BlueMarket, MarketParams as BlueMarketParams } from '@morpho-
 import { formatUnits, type Address, zeroAddress } from 'viem';
 import { buildEnvioMarketsPageQuery, envioMarketByIdQuery } from '@/graphql/envio-queries';
 import type { CustomRpcUrls } from '@/stores/useCustomRpc';
-import { isMarketRegistryEntryAllowed } from '@/utils/markets';
+import { isMarketRegistryEntryAllowed, normalizeMarketUniqueKey } from '@/utils/markets';
 import { getMorphoAddress } from '@/utils/morpho';
 import { isSupportedChain, type SupportedNetworks } from '@/utils/networks';
 import { infoToKey } from '@/utils/tokens';
@@ -170,9 +170,14 @@ const mapMonarchMarketToMarket = (
     return null;
   }
 
+  const marketId = normalizeMarketUniqueKey(market.marketId);
+  if (!marketId) {
+    return null;
+  }
+
   return {
-    id: normalizeAddress(market.marketId),
-    uniqueKey: normalizeAddress(market.marketId),
+    id: marketId,
+    uniqueKey: marketId,
     lltv: market.lltv,
     irmAddress: normalizeAddress(market.irm),
     oracleAddress: normalizeAddress(market.oracle) as Address,

--- a/src/features/market-detail/market-view.tsx
+++ b/src/features/market-detail/market-view.tsx
@@ -12,7 +12,6 @@ import Header from '@/components/layout/header/Header';
 import { Breadcrumbs } from '@/components/shared/breadcrumbs';
 import { useModal } from '@/hooks/useModal';
 import { useMarketData } from '@/hooks/useMarketData';
-import { normalizeMarketUniqueKey } from '@/utils/markets';
 import { useOraclePrice } from '@/hooks/useOraclePrice';
 import { useTransactionFilters } from '@/stores/useTransactionFilters';
 import { useMarketDetailPreferences, type MarketDetailActivitiesView, type MarketDetailTab } from '@/stores/useMarketDetailPreferences';
@@ -30,6 +29,7 @@ import TransactionFiltersModal from '@/features/market-detail/components/filters
 import { useMarketWarnings } from '@/hooks/useMarketWarnings';
 import { useMarketLiquiditySourcing } from '@/hooks/useMarketLiquiditySourcing';
 import { useAllMarketBorrowers, useAllMarketSuppliers } from '@/hooks/useAllMarketPositions';
+import { normalizeMarketUniqueKey } from '@/utils/markets';
 import { ProActivitiesTable } from './components/pro-activities-table';
 import { MarketHeader } from './components/market-header';
 import { TokenIcon } from '@/components/shared/token-icon';

--- a/src/features/market-detail/market-view.tsx
+++ b/src/features/market-detail/market-view.tsx
@@ -12,6 +12,7 @@ import Header from '@/components/layout/header/Header';
 import { Breadcrumbs } from '@/components/shared/breadcrumbs';
 import { useModal } from '@/hooks/useModal';
 import { useMarketData } from '@/hooks/useMarketData';
+import { normalizeMarketUniqueKey } from '@/utils/markets';
 import { useOraclePrice } from '@/hooks/useOraclePrice';
 import { useTransactionFilters } from '@/stores/useTransactionFilters';
 import { useMarketDetailPreferences, type MarketDetailActivitiesView, type MarketDetailTab } from '@/stores/useMarketDetailPreferences';
@@ -61,6 +62,7 @@ const ACTIVITIES_VIEW_OPTIONS: ButtonOption[] = [
 function MarketContent() {
   // 1. Get URL params first
   const { marketid: marketId, chainId } = useParams();
+  const marketKey = normalizeMarketUniqueKey(typeof marketId === 'string' ? marketId : undefined);
 
   // 2. Network setup
   const network = Number(chainId as string) as SupportedNetworks;
@@ -79,12 +81,7 @@ function MarketContent() {
   const [minBorrowerShares, setMinBorrowerShares] = useState('');
 
   // 4. Data fetching hooks - use unified time range
-  const {
-    data: market,
-    isLoading: isMarketLoading,
-    error: marketError,
-    refetch: refetchMarket,
-  } = useMarketData(marketId as string, network);
+  const { data: market, isLoading: isMarketLoading, error: marketError, refetch: refetchMarket } = useMarketData(marketKey, network);
 
   // Transaction filters with localStorage persistence (per symbol)
   const { minSupplyAmount, minBorrowAmount, setMinSupplyAmount, setMinBorrowAmount } = useTransactionFilters(
@@ -99,7 +96,7 @@ function MarketContent() {
 
   const { address } = useConnection();
 
-  const { position: userPosition, refetch: refetchUserPosition } = useUserPosition(address, network, marketId as string);
+  const { position: userPosition, refetch: refetchUserPosition } = useUserPosition(address, network, marketKey);
 
   // Get all warnings for this market (hook handles undefined market)
   const allWarnings = useMarketWarnings(market);
@@ -246,8 +243,7 @@ function MarketContent() {
   }
 
   if (isMarketLoading || !market) {
-    const marketIdLabel =
-      typeof marketId === 'string' && marketId.length > 10 ? `${marketId.slice(0, 6)}...${marketId.slice(-4)}` : 'Market';
+    const marketIdLabel = marketKey && marketKey.length > 10 ? `${marketKey.slice(0, 6)}...${marketKey.slice(-4)}` : 'Market';
 
     return (
       <div className="flex flex-col font-zen">
@@ -271,7 +267,7 @@ function MarketContent() {
           </div>
           <MarketHeader
             market={market}
-            marketId={marketId as string}
+            marketId={marketKey}
             network={network}
             isLoading={true}
           />
@@ -378,7 +374,7 @@ function MarketContent() {
         {/* Unified Market Header */}
         <MarketHeader
           market={market}
-          marketId={marketId as string}
+          marketId={marketKey}
           network={network}
           userPosition={userPosition}
           oraclePrice={formattedOraclePrice}
@@ -437,14 +433,14 @@ function MarketContent() {
 
           <TabsContent value="trend">
             <VolumeChart
-              marketId={marketId as string}
+              marketId={marketKey ?? ''}
               chainId={network}
               market={market}
             />
 
             <div className="mt-6">
               <RateChart
-                marketId={marketId as string}
+                marketId={marketKey ?? ''}
                 chainId={network}
                 market={market}
               />
@@ -453,7 +449,7 @@ function MarketContent() {
             {showSupplierPositionsChart && (
               <div className="mt-6">
                 <SupplierPositionsChart
-                  marketId={marketId as string}
+                  marketId={marketKey ?? ''}
                   chainId={network}
                   market={market}
                 />

--- a/src/utils/markets.ts
+++ b/src/utils/markets.ts
@@ -25,6 +25,12 @@ export const parseNumericThreshold = (rawValue: string | undefined | null): numb
 const normalizeAddress = (value: string | undefined | null): string => value?.toLowerCase() ?? '';
 const isValidRegistryAddress = (value: string): boolean => value.length > 0 && isAddress(value);
 
+export const normalizeMarketUniqueKey = (value: string | undefined | null): string | undefined => {
+  const normalized = value?.toLowerCase();
+  if (!normalized) return undefined;
+  return normalized.startsWith('0x') ? normalized : `0x${normalized}`;
+};
+
 export const isBlockedMarketToken = (address: string | undefined | null): boolean => {
   const normalized = normalizeAddress(address);
   return normalized.length > 0 && blacklistTokens.includes(normalized);

--- a/src/utils/markets.ts
+++ b/src/utils/markets.ts
@@ -26,7 +26,7 @@ const normalizeAddress = (value: string | undefined | null): string => value?.to
 const isValidRegistryAddress = (value: string): boolean => value.length > 0 && isAddress(value);
 
 export const normalizeMarketUniqueKey = (value: string | undefined | null): string | undefined => {
-  const normalized = value?.toLowerCase();
+  const normalized = value?.trim().toLowerCase();
   if (!normalized) return undefined;
   return normalized.startsWith('0x') ? normalized : `0x${normalized}`;
 };


### PR DESCRIPTION
## Summary
- Normalize market detail route params to canonical `0x...` market keys before data hooks run.
- Pass the normalized key to market, position, header, and chart consumers.
- Add a validation rule for shared component launcher data parity.

## Test Plan
- [x] `pnpm lint:check`
- [x] `pnpm typecheck`
- [x] `pnpm build`

## Notes
This keeps the fix at the market-detail route boundary. It does not change modal liquidity logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified validation guidelines for shared components and modals receiving prefetched data to require a common canonical source and all necessary fields.

* **Improvements**
  * Normalized market identifiers for consistent data fetching and display.
  * Centralized market detail link generation across the app to ensure uniform routing and link behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antoncoding/monarch/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->