### PR TITLE
feat: render custom feed links

### DIFF
--- a/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
@@ -16,9 +16,24 @@ type GeneralFeedTooltipProps = {
   feedFreshness?: FeedFreshnessStatus;
 };
 
+function getSafeCustomLink(link: { label: string; url: string }): { label: string; url: string } | null {
+  const label = link.label.trim();
+  const candidate = link.url.trim();
+  if (!label || !candidate) return null;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return { label, url: url.toString() };
+  } catch {
+    return null;
+  }
+}
+
 export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeedTooltipProps) {
   const baseAsset = feed.pair[0] ?? 'Unknown';
   const quoteAsset = feed.pair[1] ?? 'Unknown';
+  const customLinks = feed.links?.map(getSafeCustomLink).filter((link): link is { label: string; url: string } => link != null) ?? [];
   const isMonarchVerified = isMonarchVerifiedFeed(feed);
 
   const vendor = feed.provider ? mapProviderToVendor(feed.provider) : PriceFeedVendors.Unknown;
@@ -119,6 +134,17 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
             />
             Explorer
           </Link>
+          {customLinks.map((link) => (
+            <Link
+              key={`${link.label}-${link.url}`}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-hovered flex items-center gap-1 rounded-sm px-3 py-2 text-xs font-medium text-primary no-underline transition-all duration-200 hover:bg-opacity-80"
+            >
+              {link.label}
+            </Link>
+          ))}
         </div>
       </div>
     </div>

--- a/src/hooks/useOracleMetadata.ts
+++ b/src/hooks/useOracleMetadata.ts
@@ -40,6 +40,7 @@ export type EnrichedFeed = {
   updateInterval?: number; // Chronicle update cadence in seconds
   updateSpread?: number; // Chronicle deviation threshold percentage
   feedType?: OracleFeedType; // Scanner feed category: "market", "fundamental", "dex", "nav", or future categories
+  links?: Array<{ label: string; url: string }>;
   baseDiscountPerYear?: string; // Pendle base discount per year (raw 18-decimal value)
   innerOracle?: string; // Pendle inner oracle address
   pt?: string; // Pendle PT token address


### PR DESCRIPTION
## Summary
- keep existing production Midas parsing unchanged
- add optional `links: { label, url }[]` feed metadata for scanner-provided contextual links
- render safe custom feed links in the existing feed tooltip next to Explorer

## Validation
- `pnpm typecheck` ✅
- `pnpm exec biome check src/hooks/useOracleMetadata.ts src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx` ✅
- `NEXT_PUBLIC_REOWN_PROJECT_ID=dummy pnpm build` ✅

Notes:
- Custom links are limited to `http:` / `https:` URLs.
- This intentionally does not render generic source URLs like Etherscan or the broad Midas registry unless the scanner emits them as labeled custom links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle tooltips now support displaying custom external links from market feeds, with automatic validation to ensure proper formatting and display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antoncoding/monarch/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->