### PR TITLE
Guard Morpho token prices by API support

### DIFF
--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -67,6 +67,7 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 
 - Data fetching should use existing React Query hooks and established cache keys where possible.
 - Please respect the setting in "useCustomRPC" whenever a request is RPC-related.
+- Shared Morpho API callers must gate requested chain IDs with the Morpho API support helper before building GraphQL variables; Monarch-supported chains are not always Morpho-API-supported chains.
 - Grouped fetching via RPC must be bundled with `multicall` to increase efficiency if they're on the same chain or block.
 - Domain matching, token resolution, unit conversion, entity ID normalization, address normalization, and formatting should live in shared chokepoints.
 - Multi-chain logic must respect chain ID and address together; do not match by address alone across chains.

--- a/src/config/dataSources.ts
+++ b/src/config/dataSources.ts
@@ -1,4 +1,4 @@
-import { SupportedNetworks } from '@/utils/networks';
+import { isSupportedNetwork, SupportedNetworks } from '@/utils/supported-networks';
 
 /**
  * Check if a network supports Morpho API as a data source
@@ -18,4 +18,8 @@ export const supportsMorphoApi = (network: SupportedNetworks): boolean => {
     default:
       return false;
   }
+};
+
+export const supportsMorphoApiChainId = (chainId: number): chainId is SupportedNetworks => {
+  return isSupportedNetwork(chainId) && supportsMorphoApi(chainId);
 };

--- a/src/data-sources/morpho-api/prices.ts
+++ b/src/data-sources/morpho-api/prices.ts
@@ -1,3 +1,4 @@
+import { supportsMorphoApiChainId } from '@/config/dataSources';
 import { assetPricesQuery } from '@/graphql/morpho-api-queries';
 import { morphoGraphqlFetcher } from './fetchers';
 
@@ -55,7 +56,12 @@ export const fetchTokenPrices = async (tokens: TokenPriceInput[]): Promise<Map<s
 
   // Group tokens by chain for efficient querying
   const tokensByChain = new Map<number, string[]>();
-  tokens.forEach((token) => {
+  for (const token of tokens) {
+    // Morpho Blue rejects unsupported chains at GraphQL validation time.
+    if (!supportsMorphoApiChainId(token.chainId)) {
+      continue;
+    }
+
     const existing = tokensByChain.get(token.chainId) ?? [];
     // Deduplicate and lowercase addresses
     const normalizedAddress = token.address.toLowerCase();
@@ -63,7 +69,11 @@ export const fetchTokenPrices = async (tokens: TokenPriceInput[]): Promise<Map<s
       existing.push(normalizedAddress);
     }
     tokensByChain.set(token.chainId, existing);
-  });
+  }
+
+  if (tokensByChain.size === 0) {
+    return new Map();
+  }
 
   // Fetch prices for all chains in parallel
   const priceMap = new Map<string, number>();


### PR DESCRIPTION
## Summary
- add a shared chain-id guard for Morpho API support
- skip unsupported chains before token price GraphQL variables are built
- add a validation rule to keep Monarch-supported chains distinct from Morpho-API-supported chains

## Root cause
`useTokenPrices()` eventually calls `fetchTokenPrices()` with every token chain it receives. Etherlink is supported by Monarch but not by Morpho Blue API, so the token-price `assets(where: { chainId_in: [42793] })` query triggered Morpho's `BAD_USER_INPUT` unsupported chain error.

## Validation
- `pnpm typecheck`
- focused `tsx` probe: Etherlink-only token price request made 0 fetch calls
- focused `tsx` probe: mixed Mainnet/Etherlink request sent only Mainnet variables
- `git diff --check`

## Notes
- `npx ultracite fix` and `npx ultracite check` are currently blocked by existing `biome.jsonc` rule keys that this installed Biome/Ultracite version does not recognize (`noUselessUndefined`, `useConsistentArrowReturn`, `useMaxParams`, etc.). This PR does not change that unrelated config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of blockchain network IDs for API operations to filter unsupported chains before data fetching.
  * Enhanced chain compatibility checks to prevent errors when handling incompatible networks.

* **Documentation**
  * Added validation rules documentation clarifying that API callers must verify chain support before making requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antoncoding/monarch/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->