### PR TITLE
Fix Morpho marketId GraphQL fields

### DIFF
--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -67,6 +67,7 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 
 - Data fetching should use existing React Query hooks and established cache keys where possible.
 - Please respect the setting in "useCustomRPC" whenever a request is RPC-related.
+- External GraphQL API field removals should be checked against the live schema or official changelog, then handled at the shared query/module boundary with aliases or shared mappers when preserving Monarch's internal domain contract.
 - Shared Morpho API callers must gate requested chain IDs with the Morpho API support helper before building GraphQL variables; Monarch-supported chains are not always Morpho-API-supported chains.
 - Grouped fetching via RPC must be bundled with `multicall` to increase efficiency if they're on the same chain or block.
 - Domain matching, token resolution, unit conversion, entity ID normalization, address normalization, and formatting should live in shared chokepoints.

--- a/src/graphql/morpho-api-queries.ts
+++ b/src/graphql/morpho-api-queries.ts
@@ -1,6 +1,6 @@
 const commonMarketFields = `
 lltv
-uniqueKey
+uniqueKey: marketId
 irmAddress
 oracle {
   address
@@ -97,7 +97,7 @@ export const marketsQuery = `
     
   fragment MarketFields on Market {
     lltv
-    uniqueKey
+    uniqueKey: marketId
     irmAddress
     oracle {
       address
@@ -163,7 +163,7 @@ export const marketsWhitelistStatusQuery = `
   query getMarketsWhitelistStatus($first: Int, $skip: Int, $where: MarketFilters) {
     markets(first: $first, skip: $skip, where: $where) {
       items {
-        uniqueKey
+        uniqueKey: marketId
         listed
         supplyingVaults {
           address
@@ -185,7 +185,7 @@ export const marketsRateFieldsQuery = `
   query getMarketsRateFields($first: Int, $skip: Int, $where: MarketFilters) {
     markets(first: $first, skip: $skip, where: $where) {
       items {
-        uniqueKey
+        uniqueKey: marketId
         state {
           apyAtTarget
           rateAtTarget
@@ -243,7 +243,7 @@ export const userPositionMarketsQuery = `
           collateral
         }
         market {
-          uniqueKey
+          uniqueKey: marketId
           morphoBlue {
             chain {
               id
@@ -281,8 +281,8 @@ export const userPositionForMarketQuery = `
 `;
 
 export const marketDetailQuery = `
-  query getMarketDetail($uniqueKey: String!, $chainId: Int) {
-    marketByUniqueKey(uniqueKey: $uniqueKey, chainId: $chainId) {
+  query getMarketDetail($uniqueKey: String!, $chainId: Int!) {
+    marketByUniqueKey: marketById(marketId: $uniqueKey, chainId: $chainId) {
       ...MarketFields
     }
   }
@@ -290,8 +290,8 @@ export const marketDetailQuery = `
 `;
 
 export const marketHistoricalDataQuery = `
-  query getMarketHistoricalData($uniqueKey: String!, $options: TimeseriesOptions!, $chainId: Int) {
-    marketByUniqueKey(uniqueKey: $uniqueKey, chainId: $chainId) {
+  query getMarketHistoricalData($uniqueKey: String!, $options: TimeseriesOptions!, $chainId: Int!) {
+    marketByUniqueKey: marketById(marketId: $uniqueKey, chainId: $chainId) {
       historicalState {
         supplyApy(options: $options) {
           x
@@ -352,7 +352,7 @@ export const userTransactionsQuery = `
             shares
             assets
             market {
-              uniqueKey
+              uniqueKey: marketId
             }
           }
         }

--- a/src/graphql/public-allocator-query.ts
+++ b/src/graphql/public-allocator-query.ts
@@ -22,7 +22,7 @@ export const publicAllocatorVaultsQuery = `
             maxIn
             maxOut
             market {
-              uniqueKey
+              uniqueKey: marketId
             }
           }
         }
@@ -33,7 +33,7 @@ export const publicAllocatorVaultsQuery = `
           totalAssets
           allocation {
             market {
-              uniqueKey
+              uniqueKey: marketId
               loanAsset {
                 address
                 symbol


### PR DESCRIPTION
## Summary
- Alias Morpho API `marketId` back to Monarch's internal `uniqueKey` shape in shared GraphQL queries.
- Replace deprecated `marketByUniqueKey` usage with `marketById` while preserving existing response shape for callers.
- Add a validation rule for external GraphQL field removals.

## Validation
- Checked Morpho's official API changelog and live schema.
- Ran live Morpho GraphQL validation for markets, whitelist metadata, rate fields, market detail, historical data, user transactions, position markets, market activities, suppliers/borrowers, liquidations, and public allocator queries.
- `pnpm typecheck` passed.
- `npx ultracite fix` and `npx ultracite check` are currently blocked by existing unknown Biome rule keys in `biome.jsonc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added validation guidelines for handling external GraphQL API field compatibility through proper field mapping strategies.

* **Bug Fixes**
  * Fixed GraphQL queries to properly align with external API schema changes, ensuring continued data compatibility across market and allocator queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antoncoding/monarch/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->