### PR TITLE
Audit Morpho API changelog fields

### DIFF
--- a/src/data-sources/morpho-api/market-borrows.ts
+++ b/src/data-sources/morpho-api/market-borrows.ts
@@ -8,7 +8,7 @@ type MorphoAPIBorrowsResponse = {
   data?: {
     transactions?: {
       items?: {
-        type: 'MarketBorrow' | 'MarketRepay'; // Specific types for this query
+        type: 'Borrow' | 'Repay';
         hash: string;
         timestamp: number;
         data: {
@@ -64,7 +64,7 @@ export const fetchMorphoMarketBorrows = async (
 
     // Map to unified type (reusing MarketActivityTransaction)
     const mappedItems = items.map((item) => ({
-      type: item.type, // Directly use 'MarketBorrow' or 'MarketRepay'
+      type: item.type === 'Borrow' ? ('MarketBorrow' as const) : ('MarketRepay' as const),
       hash: item.hash,
       timestamp: item.timestamp,
       amount: item.data.assets, // Map 'assets' to 'amount'

--- a/src/data-sources/morpho-api/market-supplies.ts
+++ b/src/data-sources/morpho-api/market-supplies.ts
@@ -8,7 +8,7 @@ type MorphoAPISuppliesResponse = {
     // Mark data as optional to align with fetcher's generic handling
     transactions?: {
       items?: {
-        type: 'MarketSupply' | 'MarketWithdraw';
+        type: 'Supply' | 'Withdraw';
         hash: string;
         timestamp: number;
         data: {
@@ -67,7 +67,7 @@ export const fetchMorphoMarketSupplies = async (
 
     // Map to unified type
     const mappedItems = items.map((item) => ({
-      type: item.type,
+      type: item.type === 'Supply' ? ('MarketSupply' as const) : ('MarketWithdraw' as const),
       hash: item.hash,
       timestamp: item.timestamp,
       amount: item.data.assets,

--- a/src/data-sources/morpho-api/prices.ts
+++ b/src/data-sources/morpho-api/prices.ts
@@ -18,7 +18,9 @@ type AssetPriceItem = {
   chain: {
     id: number;
   };
-  priceUsd: number | null;
+  price: {
+    usd: number;
+  } | null;
 };
 
 type AssetPricesResponse = {
@@ -113,9 +115,9 @@ export const fetchTokenPrices = async (tokens: TokenPriceInput[]): Promise<Map<s
 
           // Process each asset and add to price map
           for (const asset of response.data.assets.items) {
-            if (asset.priceUsd !== null) {
+            if (asset.price !== null) {
               const key = getTokenPriceKey(asset.address, asset.chain.id);
-              priceMap.set(key, asset.priceUsd);
+              priceMap.set(key, asset.price.usd);
             }
           }
         }

--- a/src/data-sources/morpho-api/prices.ts
+++ b/src/data-sources/morpho-api/prices.ts
@@ -18,8 +18,8 @@ type AssetPriceItem = {
   chain: {
     id: number;
   };
-  price: {
-    usd: number;
+  price?: {
+    usd?: number | null;
   } | null;
 };
 
@@ -115,7 +115,7 @@ export const fetchTokenPrices = async (tokens: TokenPriceInput[]): Promise<Map<s
 
           // Process each asset and add to price map
           for (const asset of response.data.assets.items) {
-            if (asset.price !== null) {
+            if (asset.price?.usd != null) {
               const key = getTokenPriceKey(asset.address, asset.chain.id);
               priceMap.set(key, asset.price.usd);
             }

--- a/src/data-sources/morpho-api/transactions.ts
+++ b/src/data-sources/morpho-api/transactions.ts
@@ -1,13 +1,60 @@
 import { userTransactionsQuery } from '@/graphql/morpho-api-queries';
+import { UserTxTypes, type UserTransaction } from '@/utils/types';
 import type { TransactionFilters, TransactionResponse } from '@/utils/user-transactions';
 import { morphoGraphqlFetcher } from './fetchers';
+
+type MorphoMarketTransactionType = 'Supply' | 'Withdraw' | 'Borrow' | 'Repay' | 'SupplyCollateral' | 'WithdrawCollateral' | 'Liquidation';
+
+type MorphoMarketTransaction = {
+  data: {
+    __typename: string;
+    assets?: string;
+    shares?: string;
+  };
+  hash: string;
+  logIndex: number;
+  market: {
+    uniqueKey: string;
+  };
+  timestamp: number | string;
+  type: MorphoMarketTransactionType;
+};
 
 // Define the expected shape of the GraphQL response for transactions
 type MorphoTransactionsApiResponse = {
   data?: {
-    transactions?: TransactionResponse;
+    transactions?: Omit<TransactionResponse, 'items'> & {
+      items: MorphoMarketTransaction[];
+    };
   };
   // errors are handled by the fetcher
+};
+
+const MORPHO_MARKET_TRANSACTION_TYPE_MAP: Record<MorphoMarketTransactionType, UserTxTypes> = {
+  Borrow: UserTxTypes.MarketBorrow,
+  Liquidation: UserTxTypes.MarketLiquidation,
+  Repay: UserTxTypes.MarketRepay,
+  Supply: UserTxTypes.MarketSupply,
+  SupplyCollateral: UserTxTypes.MarketSupplyCollateral,
+  Withdraw: UserTxTypes.MarketWithdraw,
+  WithdrawCollateral: UserTxTypes.MarketWithdrawCollateral,
+};
+
+const toUserTransaction = (transaction: MorphoMarketTransaction): UserTransaction => {
+  const type = MORPHO_MARKET_TRANSACTION_TYPE_MAP[transaction.type];
+
+  return {
+    hash: transaction.hash,
+    id: `${transaction.hash.toLowerCase()}-${transaction.logIndex}`,
+    timestamp: Number(transaction.timestamp),
+    type,
+    data: {
+      assets: transaction.data.assets ?? '0',
+      market: transaction.market,
+      shares: transaction.data.shares ?? '0',
+      __typename: type,
+    },
+  };
 };
 
 export const fetchMorphoTransactions = async (filters: TransactionFilters): Promise<TransactionResponse> => {
@@ -58,7 +105,10 @@ export const fetchMorphoTransactions = async (filters: TransactionFilters): Prom
       };
     }
 
-    return transactions;
+    return {
+      ...transactions,
+      items: transactions.items.map(toUserTransaction),
+    };
   } catch (err) {
     console.error('Error fetching Morpho API transactions:', err);
     return {

--- a/src/data-sources/morpho-api/transactions.ts
+++ b/src/data-sources/morpho-api/transactions.ts
@@ -23,7 +23,7 @@ type MorphoMarketTransaction = {
 // Define the expected shape of the GraphQL response for transactions
 type MorphoTransactionsApiResponse = {
   data?: {
-    transactions?: Omit<TransactionResponse, 'items'> & {
+    transactions?: Pick<TransactionResponse, 'pageInfo'> & {
       items: MorphoMarketTransaction[];
     };
   };
@@ -74,6 +74,7 @@ export const fetchMorphoTransactions = async (filters: TransactionFilters): Prom
     whereClause.timestamp_lte = filters.timestampLte;
   }
   if (filters.hash) {
+    // Morpho exposes transaction hashes as txHash, but MarketTransactionFilters still uses hash.
     whereClause.hash = filters.hash;
   }
   if (filters.assetIds && filters.assetIds.length > 0) {
@@ -108,6 +109,7 @@ export const fetchMorphoTransactions = async (filters: TransactionFilters): Prom
     return {
       ...transactions,
       items: transactions.items.map(toUserTransaction),
+      error: null,
     };
   } catch (err) {
     console.error('Error fetching Morpho API transactions:', err);

--- a/src/graphql/morpho-api-queries.ts
+++ b/src/graphql/morpho-api-queries.ts
@@ -339,22 +339,25 @@ export const marketHistoricalDataQuery = `
 `;
 
 export const userTransactionsQuery = `
-  query getUserTransactions($where: TransactionFilters, $first: Int, $skip: Int) {
-    transactions(where: $where, first: $first, skip: $skip) {
+  query getUserTransactions($where: MarketTransactionFilters, $first: Int, $skip: Int) {
+    transactions: marketTransactions(where: $where, first: $first, skip: $skip) {
       items {
-        id
-        hash
+        hash: txHash
+        logIndex
         timestamp
         type
         data {
           __typename
-          ... on MarketTransferTransactionData {
+          ... on MarketTransactionTransferData {
             shares
             assets
-            market {
-              uniqueKey: marketId
-            }
           }
+          ... on MarketTransactionCollateralTransferData {
+            assets
+          }
+        }
+        market {
+          uniqueKey: marketId
         }
       }
       pageInfo {
@@ -367,19 +370,19 @@ export const userTransactionsQuery = `
 
 export const marketLiquidationsQuery = `
   query getMarketLiquidations($uniqueKey: String!, $first: Int, $skip: Int) {
-  transactions (where: {
+  transactions: marketTransactions (where: {
     marketUniqueKey_in: [$uniqueKey],
-    type_in: [MarketLiquidation]
+    type_in: [Liquidation]
   },
   first: $first,
   skip: $skip
   ) {
       items {
-        hash
+        hash: txHash
         timestamp
         type
         data {
-          ... on MarketLiquidationTransactionData {
+          ... on MarketTransactionLiquidationData {
             repaidAssets
             seizedAssets
             liquidator
@@ -399,20 +402,20 @@ export const marketLiquidationsQuery = `
 
 export const marketSuppliesQuery = `
   query getMarketSupplyActivities($uniqueKey: String!, $minAssets: BigInt!,  $first: Int, $skip: Int) {
-    transactions (where: {
+    transactions: marketTransactions (where: {
       marketUniqueKey_in: [$uniqueKey],
       assets_gte: $minAssets,
-      type_in: [MarketSupply, MarketWithdraw]
+      type_in: [Supply, Withdraw]
     },
     first: $first,
     skip: $skip
     ) {
       items {
         type
-        hash
+        hash: txHash
         timestamp
         data {
-          ... on MarketTransferTransactionData {
+          ... on MarketTransactionTransferData {
             assets
             shares
           }
@@ -433,20 +436,20 @@ export const marketSuppliesQuery = `
 
 export const marketBorrowsQuery = `
   query getMarketBorrowActivities($uniqueKey: String!, $minAssets: BigInt, $first: Int, $skip: Int) {
-    transactions (where: {
+    transactions: marketTransactions (where: {
       marketUniqueKey_in: [$uniqueKey],
       assets_gte: $minAssets,
-      type_in: [MarketBorrow, MarketRepay]
+      type_in: [Borrow, Repay]
     },
     first: $first,
     skip: $skip
     ) {
       items {
         type
-        hash
+        hash: txHash
         timestamp
         data {
-          ... on MarketTransferTransactionData {
+          ... on MarketTransactionTransferData {
             assets
             shares
           }
@@ -536,7 +539,9 @@ export const assetPricesQuery = `
         chain {
           id
         }
-        priceUsd
+        price {
+          usd
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace scheduled-removal `Asset.priceUsd` usage with `asset.price.usd`.
- Move Morpho market activity/user transaction fallback reads from deprecated root `transactions` to `marketTransactions`.
- Preserve Monarch's existing transaction/activity shapes by aliasing `txHash` and mapping Morpho's scoped market transaction enum values back to existing `Market*` values.

## Changelog audit
Checked the full official Morpho API changelog and live schema against Monarch's Morpho API GraphQL modules. Besides the already-merged `Market.uniqueKey`/`marketByUniqueKey` fix, the remaining relevant dependencies were:
- `Asset.priceUsd` -> `price.usd` (scheduled removal October 21, 2026)
- `Query.transactions` -> `marketTransactions` for market transaction reads (scheduled removal July 29, 2026)

No other Morpho API query-module dependencies on listed deprecated fields were found. The only exact term scan hits left are nested `MarketState.borrowAssetsUsd` / `supplyAssetsUsd`, which the live schema reports as non-deprecated and which are not the deprecated `MarketPosition.*` fields from the changelog.

## Validation
- Synced `master` from `origin/master` before branching.
- Live Morpho API validation passed for all Morpho API query modules: markets, whitelist metadata, rate fields, detail, historical data, user transactions, market activities, suppliers/borrowers, liquidations, prices, public allocator, and vault queries.
- Runtime smoke fetch passed for token price and market supply/borrow activity fetchers.
- `pnpm typecheck` passed.
- `npx ultracite fix` and `npx ultracite check` are blocked by existing unknown Biome rule keys in `biome.jsonc` before file analysis.