### PR TITLE
Preserve portfolio analytics period

### DIFF
--- a/src/stores/usePositionsFilters.ts
+++ b/src/stores/usePositionsFilters.ts
@@ -4,7 +4,9 @@ import { persist } from 'zustand/middleware';
 /**
  * Earnings calculation periods for the positions summary page.
  */
-export type EarningsPeriod = 'day' | 'week' | 'month' | 'threemonth' | 'sixmonth' | 'all';
+export const EARNINGS_PERIODS = ['day', 'week', 'month', 'threemonth', 'sixmonth', 'all'] as const;
+
+export type EarningsPeriod = (typeof EARNINGS_PERIODS)[number];
 
 type PositionsFiltersState = {
   /** Currently selected earnings period */
@@ -23,6 +25,21 @@ type PositionsFiltersStore = PositionsFiltersState & PositionsFiltersActions;
 
 const DEFAULT_STATE: PositionsFiltersState = {
   period: 'month',
+};
+
+const isEarningsPeriod = (value: unknown): value is EarningsPeriod =>
+  typeof value === 'string' && EARNINGS_PERIODS.includes(value as EarningsPeriod);
+
+const normalizePositionsFilters = (state: unknown): PositionsFiltersState => {
+  if (!state || typeof state !== 'object') {
+    return DEFAULT_STATE;
+  }
+
+  const period = (state as Partial<PositionsFiltersState>).period;
+
+  return {
+    period: isEarningsPeriod(period) ? period : DEFAULT_STATE.period,
+  };
 };
 
 /**
@@ -50,16 +67,9 @@ export const usePositionsFilters = create<PositionsFiltersStore>()(
     }),
     {
       name: 'monarch_store_positionsFilters',
-      version: 2,
-      migrate: (state, version) => {
-        if (!state || typeof state !== 'object') {
-          return DEFAULT_STATE;
-        }
-        if (version < 2) {
-          return { ...state, period: 'month' } as PositionsFiltersState;
-        }
-        return state as PositionsFiltersState;
-      },
+      version: 3,
+      partialize: (state) => ({ period: state.period }),
+      migrate: normalizePositionsFilters,
     },
   ),
 );

--- a/src/stores/usePositionsFilters.ts
+++ b/src/stores/usePositionsFilters.ts
@@ -28,7 +28,7 @@ const DEFAULT_STATE: PositionsFiltersState = {
 };
 
 const isEarningsPeriod = (value: unknown): value is EarningsPeriod =>
-  typeof value === 'string' && EARNINGS_PERIODS.includes(value as EarningsPeriod);
+  (EARNINGS_PERIODS as readonly unknown[]).includes(value);
 
 const normalizePositionsFilters = (state: unknown): PositionsFiltersState => {
   if (!state || typeof state !== 'object') {


### PR DESCRIPTION
## Summary
- preserve the selected portfolio analytics period through positions filter store migrations
- persist only the period field for the positions filters store
- validate stored period values before restoring them

## Validation
- pnpm typecheck
- git diff --check
- npx ultracite fix (blocked by existing biome.jsonc unsupported keys)
- npx ultracite check (blocked by existing biome.jsonc unsupported keys)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced positions filter state persistence logic with improved validation and recovery mechanisms for corrupted or unknown filter states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antoncoding/monarch/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->