### PR TITLE
Attach API keys only for Vercel previews

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -58,10 +58,16 @@ ALCHEMY_API_KEY=
 # used for getting block
 ETHERSCAN_API_KEY=
 
-# ==================== External Data API ====================
-# Required in production now that Vercel data-route fallbacks are removed.
-# Single required base URL for both metrics and token metadata.
-NEXT_PUBLIC_DATA_API_BASE_URL=
+# ==================== Monarch APIs ====================
+# Public data API used by markets, risk data, and token metadata.
+NEXT_PUBLIC_DATA_API_BASE_URL=https://api.monarchlend.xyz
+
+# Public GraphQL indexer endpoint used by Monarch data-source fetchers.
+NEXT_PUBLIC_MONARCH_API_NEW=https://indexer.monarchlend.xyz/graphql
+
+# Set in Vercel Preview only. The app sends it only on *.vercel.app hosts.
+# Do not use the old NEXT_PUBLIC_MONARCH_API_KEY variable.
+NEXT_PUBLIC_MONARCH_PREVIEW_API_KEY=
 
 # ==================== Oracle Metadata ====================
 # Base URL for oracle metadata Gist (without trailing slash)

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -385,7 +385,7 @@ Fallback Strategy:
 
 **Monarch GraphQL** (`/src/data-sources/monarch-api/fetchers.ts`):
 - Endpoint: `NEXT_PUBLIC_MONARCH_API_NEW`
-- Browser fetch against a public endpoint; `NEXT_PUBLIC_MONARCH_API_KEY` is optional and only sent when configured
+- Browser fetch against a public endpoint. Production Monarch origins do not send an API key; Vercel preview builds can set `NEXT_PUBLIC_MONARCH_PREVIEW_API_KEY`, which is only sent when the app runs on a `*.vercel.app` host.
 - Used as the primary read path for autovault V2 metadata, market-detail live state/history/activity, and admin transaction reads
 
 **Subgraph** (`/src/data-sources/subgraph/fetchers.ts`):

--- a/src/data-sources/monarch-api/fetchers.ts
+++ b/src/data-sources/monarch-api/fetchers.ts
@@ -1,3 +1,5 @@
+import { getMonarchApiAuthHeaders } from '@/utils/monarchApiAuth';
+
 type GraphQLVariables = Record<string, unknown>;
 
 type GraphQLError = {
@@ -9,7 +11,6 @@ type MonarchGraphqlFetcherOptions = {
 };
 
 const MONARCH_GRAPHQL_API_ENDPOINT = process.env.NEXT_PUBLIC_MONARCH_API_NEW;
-const MONARCH_GRAPHQL_API_KEY = process.env.NEXT_PUBLIC_MONARCH_API_KEY;
 
 export const monarchGraphqlFetcher = async <T extends Record<string, unknown>>(
   query: string,
@@ -22,11 +23,8 @@ export const monarchGraphqlFetcher = async <T extends Record<string, unknown>>(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    ...getMonarchApiAuthHeaders(),
   };
-
-  if (MONARCH_GRAPHQL_API_KEY) {
-    headers.Authorization = `Bearer ${MONARCH_GRAPHQL_API_KEY}`;
-  }
 
   const response = await fetch(MONARCH_GRAPHQL_API_ENDPOINT, {
     method: 'POST',

--- a/src/hooks/queries/useAssetRiskQuery.ts
+++ b/src/hooks/queries/useAssetRiskQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useDeferredQueryEnable } from '@/hooks/useDeferredQueryEnable';
+import { getMonarchApiAuthHeaders } from '@/utils/monarchApiAuth';
 import { DATA_API_BASE_URL } from '@/utils/urls';
 
 export type AssetRiskEntry = {
@@ -31,7 +32,9 @@ const ASSET_RISK_REFRESH_MS = 15 * 60 * 1000;
 const getAssetRiskResponseKey = (address: string, chainId: number): string => `${chainId}:${address.toLowerCase()}`;
 
 const fetchAssetRisk = async (chainId: number): Promise<AssetRiskResponse> => {
-  const response = await fetch(`${DATA_API_BASE_URL}/v1/risk/assets?chain_id=${chainId}`);
+  const response = await fetch(`${DATA_API_BASE_URL}/v1/risk/assets?chain_id=${chainId}`, {
+    headers: getMonarchApiAuthHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch asset risk data');

--- a/src/hooks/queries/useMarketMetricsQuery.ts
+++ b/src/hooks/queries/useMarketMetricsQuery.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useDeferredQueryEnable } from '@/hooks/useDeferredQueryEnable';
 import { useMarketPreferences, type CustomTagConfig, type FlowTimeWindow } from '@/stores/useMarketPreferences';
+import { getMonarchApiAuthHeaders } from '@/utils/monarchApiAuth';
 import { DATA_API_BASE_URL } from '@/utils/urls';
 
 // Re-export types for convenience
@@ -101,7 +102,9 @@ const fetchMarketMetricsPage = async (params: MarketMetricsParams, limit: number
   searchParams.set('limit', String(limit));
   searchParams.set('offset', String(offset));
 
-  const response = await fetch(getMarketMetricsClientUrl(searchParams));
+  const response = await fetch(getMarketMetricsClientUrl(searchParams), {
+    headers: getMonarchApiAuthHeaders(),
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch market metrics');

--- a/src/utils/monarchApiAuth.ts
+++ b/src/utils/monarchApiAuth.ts
@@ -1,0 +1,20 @@
+const VERCEL_PREVIEW_HOST_SUFFIX = '.vercel.app';
+const MONARCH_PREVIEW_API_KEY = process.env.NEXT_PUBLIC_MONARCH_PREVIEW_API_KEY?.trim();
+
+const isVercelPreviewHostname = (hostname: string): boolean => hostname.endsWith(VERCEL_PREVIEW_HOST_SUFFIX);
+
+const isVercelPreviewRuntime = (): boolean => {
+  if (typeof window !== 'undefined') {
+    return isVercelPreviewHostname(window.location.hostname);
+  }
+
+  return process.env.VERCEL_ENV === 'preview';
+};
+
+export const getMonarchApiAuthHeaders = (): Record<string, string> => {
+  if (!MONARCH_PREVIEW_API_KEY || !isVercelPreviewRuntime()) {
+    return {};
+  }
+
+  return { 'X-API-Key': MONARCH_PREVIEW_API_KEY };
+};

--- a/src/utils/tokenMetadata.ts
+++ b/src/utils/tokenMetadata.ts
@@ -4,6 +4,7 @@ import type { SupportedNetworks } from './networks';
 import { getClient } from './rpc';
 import { findToken, infoToKey, type ERC20Token } from './tokens';
 import type { TokenInfo } from './types';
+import { getMonarchApiAuthHeaders } from './monarchApiAuth';
 import { DATA_API_BASE_URL } from './urls';
 
 export type TokenAddressInput = {
@@ -303,6 +304,7 @@ const fetchResolvedUnknownTokenInfosFromServer = async (tokens: TokenAddressInpu
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...getMonarchApiAuthHeaders(),
         },
         body: JSON.stringify({ tokens: tokenBatch }),
       });


### PR DESCRIPTION
## Summary

send the shared preview API key only on *.vercel.app hosts\n- stop using the old global NEXT_PUBLIC_MONARCH_API_KEY for indexer calls\n- document preview key behavior for Monarch API reads\n\n## Validation\n- pnpm typecheck passed\n- npx ultracite fix/check blocked by existing biome.jsonc unknown-rule config errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication behavior for Monarch API: production origins do not send an API key, while Vercel preview builds send authentication only when running on `*.vercel.app` hosts.

* **Refactor**
  * Consolidated Monarch API authentication logic into a shared helper function used across multiple API requests for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antoncoding/monarch/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->