### PR TITLE
Migrate rewards to Merkl API

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -79,6 +79,9 @@ MONARCH_API_KEYS_ADMIN_URL=
 DATA_API_INTERNAL_ORIGIN=
 DATA_API_INTERNAL_ADMIN_KEY=
 
+# Server-only Merkl API key used by /api/merkl to attach X-API-Key.
+MERKL_API_KEY=
+
 # ==================== Oracle Metadata ====================
 # Base URL for oracle metadata Gist (without trailing slash)
 # Example: https://gist.githubusercontent.com/username/gist-id/raw

--- a/app/api/merkl/[...path]/route.ts
+++ b/app/api/merkl/[...path]/route.ts
@@ -1,0 +1,53 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+const MERKL_API_BASE_URL = 'https://api.merkl.xyz';
+const MERKL_API_TIMEOUT_MS = 15_000;
+
+type MerklRouteContext = {
+  params: Promise<{
+    path?: string[];
+  }>;
+};
+
+export async function GET(request: NextRequest, context: MerklRouteContext) {
+  const { path = [] } = await context.params;
+  const targetPath = path.join('/');
+
+  if (!targetPath.startsWith('v4/')) {
+    return NextResponse.json({ error: 'Unsupported Merkl API path.' }, { status: 400 });
+  }
+
+  const targetUrl = new URL(`/${targetPath}`, MERKL_API_BASE_URL);
+  for (const [key, value] of request.nextUrl.searchParams.entries()) {
+    targetUrl.searchParams.append(key, value);
+  }
+
+  const headers: Record<string, string> = {};
+  const apiKey = process.env.MERKL_API_KEY?.trim();
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(targetUrl, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(MERKL_API_TIMEOUT_MS),
+      cache: 'no-store',
+    });
+  } catch (caught) {
+    if (caught instanceof DOMException && caught.name === 'TimeoutError') {
+      return NextResponse.json({ error: 'Merkl API timed out.' }, { status: 504 });
+    }
+    return NextResponse.json({ error: 'Failed to connect to Merkl API.' }, { status: 502 });
+  }
+
+  const body = await response.text();
+  return new NextResponse(body, {
+    status: response.status,
+    headers: {
+      'Content-Type': response.headers.get('content-type') ?? 'application/json',
+    },
+  });
+}

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -214,13 +214,14 @@ Market metrics: external data API via `/v1/markets/metrics`
 | Vaults list | Morpho API | 5 min | `useAllMorphoVaultsQuery` |
 | User autovault metadata | Monarch GraphQL + on-chain enrichment | 60s | `useUserVaultsV2Query` |
 | Vault detail/settings metadata | Monarch GraphQL + narrow RPC fallback | 30s | `useVaultV2Data` |
+| Vault V2 rewards | Morpho API rewards fields backed by Merkl | 5 min | `useVaultV2RewardsQuery` |
 | Market detail participants/activity | Monarch GraphQL + Morpho API/Subgraph fallback | 2-5 min stale | `useMarketSuppliers` / `useMarketBorrowers` / `useMarketSupplies` / `useMarketBorrows` |
 | Vault allocations | On-chain multicall | 30s | `useAllocationsQuery` |
 | Token balances | On-chain multicall | 5 min | `useUserBalancesQuery` |
 | Oracle metadata | Scanner Gist | 30 min | `useOracleMetadata` / `useAllOracleMetadata` |
 | Account contract tags | Kleros Scout API | 6h stale | `useKlerosAddressTagsQuery` |
-| User rewards and distributions | Morpho rewards REST + Merkl API | 30s | `useUserRewardsQuery` |
-| Reward campaigns | Merkl API | 5 min stale | `useMerklCampaignsQuery` |
+| User claimable rewards | Merkl API via `/api/merkl` | 5 min stale, forced refresh on manual refetch | `useUserRewardsQuery` |
+| Reward campaigns | Merkl API via `/api/merkl` | 5 min stale | `useMerklCampaignsQuery` |
 | Market liquidations | Monarch GraphQL + Morpho API/Subgraph fallback | 5 min stale | `useMarketLiquidations` |
 | Admin stats transactions | Monarch GraphQL + market registry/token price enrichment | 2 min stale | `useMonarchTransactions` |
 
@@ -262,6 +263,7 @@ Hooks omitted from this matrix are local-state hooks or pure view/composition he
 |---------------|----------------|-------------|----------------------------------|
 | `useUserVaultsV2Query` | User vault list with optional balance, TVL, and yield enrichment | Monarch vault metadata + RPC balances/totalAssets + RPC 4626 yield snapshots | Already off Morpho for yield; no new Envio schema gap identified |
 | `useVaultV2Data` | Vault detail/settings metadata for a single vault | Monarch vault detail first, narrow RPC fallback if metadata unavailable | Already aligned with Monarch-first design |
+| `useVaultV2RewardsQuery` | Vault detail reward APR enrichment | Morpho API `vaultV2ByAddress.rewards` backed by Merkl | Outside Monarch/Envio scope today |
 | `useAllMorphoVaultsQuery` | Global whitelisted vault registry | Morpho API only | Intentionally Morpho-only today |
 | `usePublicAllocatorVaults` | Public allocator config for supplying vaults in a market | Morpho API only | Intentionally Morpho-only today |
 | `useAllocationsQuery` | Live vault `allocation(capId)` values | Pure RPC multicall | No Envio gap |
@@ -277,8 +279,8 @@ Hooks omitted from this matrix are local-state hooks or pure view/composition he
 | `useTokensQuery` | Token metadata lookup for app UI | Local token registry + Pendle assets API | Not part of Monarch migration |
 | `useOracleMetadata` / `useAllOracleMetadata` | Oracle classification and feed metadata | Scanner gist JSON | Not part of Monarch migration |
 | `useMarketMetricsQuery` | Enhanced market metrics, flows, trending, scores | External data API via `/v1/markets/metrics` | Already Monarch-backed |
-| `useUserRewardsQuery` | Claimable rewards and distributions | Morpho rewards REST + Merkl API | Outside Monarch/Envio scope today |
-| `useMerklCampaignsQuery` / `useMerklHoldIncentivesQuery` | Campaign and HOLD incentive enrichment | Merkl API + hardcoded opportunity mapping | Outside Monarch/Envio scope today |
+| `useUserRewardsQuery` | User claimable rewards and Merkl proofs | Merkl API through the server-side `/api/merkl` API-key proxy | Outside Monarch/Envio scope today |
+| `useMerklCampaignsQuery` / `useMerklHoldIncentivesQuery` | Campaign and HOLD incentive enrichment | Merkl API through `/api/merkl` + hardcoded opportunity mapping | Outside Monarch/Envio scope today |
 
 ### Data Flow Patterns
 
@@ -357,6 +359,9 @@ All hooks in `/src/hooks/queries/` follow React Query patterns:
 | `useUserBalancesQuery` | `['user-balances', addr, networks]` | 30s | - | Yes |
 | `useUserVaultsV2Query` | `['user-vaults-v2', addr]` | 60s | - | Yes |
 | `useVaultV2Data` | `['vault-v2-data', addr, chainId]` | 30s | - | No |
+| `useVaultV2RewardsQuery` | `['vault-v2-rewards', addr, chainId]` | 5 min | - | No |
+| `useUserRewardsQuery` | `['user-rewards', addr]` | 5 min | Manual forced reload | No |
+| `useMerklCampaignsQuery` | `['merkl-campaigns']` | 5 min | 5 min | Yes |
 | `useMarketLiquidations` | `['marketLiquidations', id, net]` | 5 min | - | Yes |
 | `useUserTransactionsQuery` | `['user-transactions', ...]` | 60s | - | No |
 | `useAllocationsQuery` | `['vault-allocations', ...]` | 30s | - | No |
@@ -446,11 +451,11 @@ Fallback Strategy:
 ### APIs
 | Service | Endpoint | Purpose |
 |---------|----------|---------|
-| Morpho API | `https://blue-api.morpho.org/graphql` | Markets, vaults, positions |
+| Morpho API | `https://blue-api.morpho.org/graphql` | Markets, vaults, positions, Vault V2 reward APRs |
 | Monarch GraphQL | `https://api.monarchlend.xyz/graphql` | Autovault metadata, market live state, historical charts, market detail/activity, admin transactions |
 | Monarch Metrics | External data API `/v1/markets/metrics` | Market metrics and admin stats |
 | The Graph | Per-chain subgraph URLs | Fallback data, suppliers, borrowers |
-| Merkl API | `https://api.merkl.xyz` | Reward campaigns |
+| Merkl API | `https://api.merkl.xyz` via `/api/merkl` | Reward campaigns, opportunities, and user claimable rewards with server-side API-key auth |
 | Velora API | `https://api.paraswap.io` | Swap quotes and executable tx payloads |
 | Alchemy | Per-chain RPC | Default RPC provider |
 

--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -32,6 +32,7 @@ const ACTIONABLE_QUERY_ROOT_KEYS = new Set<string>([
   'user-rewards',
   'user-transactions',
   'vault-historical-apy',
+  'vault-v2-rewards',
   'vault-v2-data',
   'vault-allocations',
 ]);

--- a/src/data-sources/morpho-api/vaults.ts
+++ b/src/data-sources/morpho-api/vaults.ts
@@ -1,4 +1,4 @@
-import { allVaultsQuery, vaultApysQuery, vaultV2MetadataQuery } from '@/graphql/vault-queries';
+import { allVaultsQuery, vaultApysQuery, vaultV2MetadataQuery, vaultV2RewardsQuery } from '@/graphql/vault-queries';
 import { morphoGraphqlFetcher } from './fetchers';
 
 export type VaultAddressByNetwork = {
@@ -35,6 +35,24 @@ export type MorphoVaultV2Metadata = {
   metadataImage?: string;
   name: string;
   symbol: string;
+};
+
+export type MorphoVaultV2Reward = {
+  supplyApr: number;
+  asset: {
+    address: string;
+    symbol: string;
+    price?: {
+      usd?: number | null;
+    } | null;
+  };
+};
+
+export type MorphoVaultV2Rewards = {
+  address: string;
+  apy: number | null;
+  netApy: number | null;
+  rewards: MorphoVaultV2Reward[];
 };
 
 // API response types
@@ -100,6 +118,13 @@ type VaultV2MetadataApiResponse = {
     vaultV2s?: {
       items?: ApiVaultV2[];
     };
+  };
+  errors?: { message: string }[];
+};
+
+type VaultV2RewardsApiResponse = {
+  data?: {
+    vaultV2ByAddress?: MorphoVaultV2Rewards | null;
   };
   errors?: { message: string }[];
 };
@@ -257,6 +282,28 @@ export const fetchListedMorphoVaultV2Metadata = async (): Promise<MorphoVaultV2M
   } catch (error) {
     console.warn('Error fetching listed Morpho V2 vault metadata:', error);
     return [];
+  }
+};
+
+export const fetchMorphoVaultV2Rewards = async (vaultAddress: string, chainId: number): Promise<MorphoVaultV2Rewards | null> => {
+  try {
+    const response = await morphoGraphqlFetcher<VaultV2RewardsApiResponse>(vaultV2RewardsQuery, {
+      address: vaultAddress.toLowerCase(),
+      chainId,
+    });
+
+    const vault = response?.data?.vaultV2ByAddress;
+    if (!vault) {
+      return null;
+    }
+
+    return {
+      ...vault,
+      rewards: Array.isArray(vault.rewards) ? vault.rewards : [],
+    };
+  } catch (error) {
+    console.warn('Error fetching Morpho V2 vault rewards:', error);
+    return null;
   }
 };
 

--- a/src/data-sources/morpho-api/vaults.ts
+++ b/src/data-sources/morpho-api/vaults.ts
@@ -51,7 +51,6 @@ export type MorphoVaultV2Reward = {
 export type MorphoVaultV2Rewards = {
   address: string;
   apy: number | null;
-  netApy: number | null;
   rewards: MorphoVaultV2Reward[];
 };
 

--- a/src/features/autovault/components/vault-detail/vault-header.tsx
+++ b/src/features/autovault/components/vault-detail/vault-header.tsx
@@ -181,12 +181,6 @@ export function VaultHeader({
                     <span>Asset: {assetSymbol}</span>
                   </>
                 )}
-                {curator && (
-                  <>
-                    <span className="text-border">·</span>
-                    <span>Curator: {getSlicedAddress(curator as Address)}</span>
-                  </>
-                )}
                 {showCapsAdapter && (
                   <>
                     <span className="text-border">·</span>

--- a/src/features/autovault/components/vault-detail/vault-header.tsx
+++ b/src/features/autovault/components/vault-detail/vault-header.tsx
@@ -11,6 +11,8 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { TokenIcon } from '@/components/shared/token-icon';
 import { AddressIdentity } from '@/components/shared/address-identity';
+import { Tooltip } from '@/components/ui/tooltip';
+import { TooltipContent } from '@/components/shared/tooltip-content';
 import { useStyledToast } from '@/hooks/useStyledToast';
 import { getNetworkImg, getNetworkName, type SupportedNetworks } from '@/utils/networks';
 import { getExplorerURL } from '@/utils/external';
@@ -28,6 +30,12 @@ type VaultHeaderAdapterRow = {
   adapterType?: string;
 };
 
+type VaultHeaderRewardRow = {
+  assetAddress: string;
+  assetSymbol: string;
+  apr: number;
+};
+
 type VaultHeaderProps = {
   vaultAddress: Address;
   chainId: SupportedNetworks;
@@ -37,6 +45,9 @@ type VaultHeaderProps = {
   assetSymbol?: string;
   totalAssetsLabel: string;
   apyLabel: string;
+  baseApyLabel?: string;
+  rewardAprLabel?: string;
+  rewards?: VaultHeaderRewardRow[];
   userShareBalance?: string;
   allocators?: string[];
   sentinels?: string[];
@@ -65,6 +76,9 @@ export function VaultHeader({
   assetSymbol,
   totalAssetsLabel,
   apyLabel,
+  baseApyLabel,
+  rewardAprLabel,
+  rewards = [],
   userShareBalance,
   allocators = [],
   sentinels = [],
@@ -106,6 +120,13 @@ export function VaultHeader({
     capsAdapterRows.length === 1
       ? `${formatVaultAdapterType(capsAdapterRows[0].adapterType)} ${getSlicedAddress(capsAdapterRows[0].adapter)}`
       : `${capsAdapterRows.length} configured adapters`;
+  const hasRewards = rewards.length > 0 && rewardAprLabel !== undefined;
+  const rewardsDetail = [
+    baseApyLabel ? `Base APY ${baseApyLabel}` : null,
+    ...rewards.map((reward) => `${reward.assetSymbol} reward +${(reward.apr * 100).toFixed(2)}%`),
+  ]
+    .filter((row): row is string => Boolean(row))
+    .join('\n');
 
   return (
     <div className="mt-6 mb-6 space-y-4">
@@ -223,6 +244,32 @@ export function VaultHeader({
                     <p className="tabular-nums text-lg font-medium text-primary">{apyLabel}</p>
                   )}
                 </div>
+                {!isLoading && hasRewards && (
+                  <Tooltip
+                    content={
+                      <TooltipContent
+                        title="Vault Rewards"
+                        detail={rewardsDetail}
+                      />
+                    }
+                  >
+                    <span className="mt-0.5 inline-flex cursor-help items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                      {rewardAprLabel}
+                      <span className="inline-flex -space-x-1">
+                        {rewards.slice(0, 3).map((reward) => (
+                          <TokenIcon
+                            key={`${reward.assetAddress}-${reward.assetSymbol}`}
+                            address={reward.assetAddress}
+                            chainId={chainId}
+                            symbol={reward.assetSymbol}
+                            width={14}
+                            height={14}
+                          />
+                        ))}
+                      </span>
+                    </span>
+                  </Tooltip>
+                )}
               </div>
               <div>
                 <p className="text-xs uppercase tracking-wider text-secondary">Total Assets</p>

--- a/src/features/autovault/components/vault-detail/vault-header.tsx
+++ b/src/features/autovault/components/vault-detail/vault-header.tsx
@@ -7,6 +7,7 @@ import { ChevronDownIcon, GearIcon } from '@radix-ui/react-icons';
 import { IoEllipsisVertical } from 'react-icons/io5';
 import { FiExternalLink } from 'react-icons/fi';
 import { LuCopy } from 'react-icons/lu';
+import { RiSparklingFill } from 'react-icons/ri';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { TokenIcon } from '@/components/shared/token-icon';
@@ -14,6 +15,7 @@ import { AddressIdentity } from '@/components/shared/address-identity';
 import { Tooltip } from '@/components/ui/tooltip';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { useStyledToast } from '@/hooks/useStyledToast';
+import { MONARCH_PRIMARY } from '@/constants/chartColors';
 import { getNetworkImg, getNetworkName, type SupportedNetworks } from '@/utils/networks';
 import { getExplorerURL } from '@/utils/external';
 import { RefetchIcon } from '@/components/ui/refetch-icon';
@@ -33,7 +35,7 @@ type VaultHeaderAdapterRow = {
 type VaultHeaderRewardRow = {
   assetAddress: string;
   assetSymbol: string;
-  apr: number;
+  rate: number;
 };
 
 type VaultHeaderProps = {
@@ -45,9 +47,10 @@ type VaultHeaderProps = {
   assetSymbol?: string;
   totalAssetsLabel: string;
   apyLabel: string;
-  baseApyLabel?: string;
-  rewardAprLabel?: string;
+  baseRateLabel?: string;
+  rateLabel?: string;
   rewards?: VaultHeaderRewardRow[];
+  showRewardSparkle?: boolean;
   userShareBalance?: string;
   allocators?: string[];
   sentinels?: string[];
@@ -76,9 +79,10 @@ export function VaultHeader({
   assetSymbol,
   totalAssetsLabel,
   apyLabel,
-  baseApyLabel,
-  rewardAprLabel,
+  baseRateLabel,
+  rateLabel = 'APY',
   rewards = [],
+  showRewardSparkle = false,
   userShareBalance,
   allocators = [],
   sentinels = [],
@@ -120,10 +124,11 @@ export function VaultHeader({
     capsAdapterRows.length === 1
       ? `${formatVaultAdapterType(capsAdapterRows[0].adapterType)} ${getSlicedAddress(capsAdapterRows[0].adapter)}`
       : `${capsAdapterRows.length} configured adapters`;
-  const hasRewards = rewards.length > 0 && rewardAprLabel !== undefined;
+  const hasRewards = rewards.length > 0;
   const rewardsDetail = [
-    baseApyLabel ? `Base APY ${baseApyLabel}` : null,
-    ...rewards.map((reward) => `${reward.assetSymbol} reward +${(reward.apr * 100).toFixed(2)}%`),
+    baseRateLabel ? `Base ${rateLabel} ${baseRateLabel}` : null,
+    ...rewards.map((reward) => `${reward.assetSymbol} reward +${(reward.rate * 100).toFixed(2)}%`),
+    `Net ${rateLabel} ${apyLabel}`,
   ]
     .filter((row): row is string => Boolean(row))
     .join('\n');
@@ -236,40 +241,37 @@ export function VaultHeader({
             {/* Key Stats */}
             <div className="flex items-center gap-6 border-r border-border pr-6">
               <div>
-                <p className="text-xs uppercase tracking-wider text-secondary">APY</p>
+                <p className="text-xs uppercase tracking-wider text-secondary">{rateLabel}</p>
                 <div className="flex items-center gap-2">
                   {isLoading ? (
                     <div className="h-6 w-16 animate-pulse rounded bg-hovered" />
+                  ) : hasRewards ? (
+                    <Tooltip
+                      content={
+                        <TooltipContent
+                          title={`Vault ${rateLabel} Breakdown`}
+                          detail={rewardsDetail}
+                        />
+                      }
+                    >
+                      <button
+                        type="button"
+                        className="inline-flex cursor-help items-center gap-1 rounded-sm tabular-nums text-lg font-medium text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                        aria-label={`Show vault ${rateLabel.toLowerCase()} breakdown`}
+                      >
+                        <span>{apyLabel}</span>
+                        {showRewardSparkle && (
+                          <RiSparklingFill
+                            className="h-3 w-3"
+                            color={MONARCH_PRIMARY}
+                          />
+                        )}
+                      </button>
+                    </Tooltip>
                   ) : (
                     <p className="tabular-nums text-lg font-medium text-primary">{apyLabel}</p>
                   )}
                 </div>
-                {!isLoading && hasRewards && (
-                  <Tooltip
-                    content={
-                      <TooltipContent
-                        title="Vault Rewards"
-                        detail={rewardsDetail}
-                      />
-                    }
-                  >
-                    <span className="mt-0.5 inline-flex cursor-help items-center gap-1 text-xs text-green-600 dark:text-green-400">
-                      {rewardAprLabel}
-                      <span className="inline-flex -space-x-1">
-                        {rewards.slice(0, 3).map((reward) => (
-                          <TokenIcon
-                            key={`${reward.assetAddress}-${reward.assetSymbol}`}
-                            address={reward.assetAddress}
-                            chainId={chainId}
-                            symbol={reward.assetSymbol}
-                            width={14}
-                            height={14}
-                          />
-                        ))}
-                      </span>
-                    </span>
-                  </Tooltip>
-                )}
               </div>
               <div>
                 <p className="text-xs uppercase tracking-wider text-secondary">Total Assets</p>

--- a/src/features/rewards/components/reward-table.tsx
+++ b/src/features/rewards/components/reward-table.tsx
@@ -5,17 +5,14 @@ import { RefetchIcon } from '@/components/ui/refetch-icon';
 import LoadingScreen from '@/components/status/loading-screen';
 import { Table, TableHeader, TableBody, TableRow, TableCell, TableHead } from '@/components/ui/table';
 import Image from 'next/image';
-import type { Address } from 'viem';
-import { useConnection, useChainId, useSwitchChain } from 'wagmi';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { TableContainerWithHeader } from '@/components/common/table-container-with-header';
 import { TokenIcon } from '@/components/shared/token-icon';
-import type { DistributionResponseType, MerklRewardWithProofs } from '@/hooks/queries/useUserRewardsQuery';
+import type { MerklRewardWithProofs } from '@/hooks/queries/useUserRewardsQuery';
 import { useClaimMerklRewards } from '@/hooks/useClaimMerklRewards';
 import { useStyledToast } from '@/hooks/useStyledToast';
-import { useTransactionWithToast } from '@/hooks/useTransactionWithToast';
 import { formatBalance, formatSimple } from '@/utils/balance';
 import { getNetworkImg, getNetworkName } from '@/utils/networks';
 import { findToken } from '@/utils/tokens';
@@ -24,7 +21,6 @@ import type { AggregatedRewardType } from '@/utils/types';
 type RewardTableProps = {
   account: string;
   rewards: AggregatedRewardType[];
-  distributions: DistributionResponseType[];
   merklRewardsWithProofs: MerklRewardWithProofs[];
   onRefresh: () => void;
   isRefetching: boolean;
@@ -40,31 +36,9 @@ function getMerklClaimButtonText(isClaiming: boolean, status: ClaimStatus): stri
   return 'Claim';
 }
 
-export default function RewardTable({
-  rewards,
-  distributions,
-  merklRewardsWithProofs,
-  account,
-  onRefresh,
-  isRefetching,
-  isLoading,
-}: RewardTableProps) {
-  const { chainId } = useConnection();
-  const currentChainId = useChainId();
+export default function RewardTable({ rewards, merklRewardsWithProofs, account, onRefresh, isRefetching, isLoading }: RewardTableProps) {
   const toast = useStyledToast();
   const [claimingRewardKey, setClaimingRewardKey] = useState<string | null>(null);
-  const { mutateAsync: switchChainAsync } = useSwitchChain();
-
-  const { sendTransaction } = useTransactionWithToast({
-    toastId: 'claim',
-    pendingText: 'Claiming Reward...',
-    successText: 'Reward Claimed!',
-    errorText: 'Failed to claim rewards',
-    chainId,
-    pendingDescription: 'Claiming rewards',
-    successDescription: 'Successfully claimed rewards',
-    onSuccess: onRefresh,
-  });
 
   // Initialize Merkl claiming hook
   const { claimSingleReward, claimStatus } = useClaimMerklRewards();
@@ -76,40 +50,6 @@ export default function RewardTable({
         return tokenReward.total.claimable > 0n;
       }),
     [rewards],
-  );
-
-  const handleClaim = useCallback(
-    async (distribution: DistributionResponseType | undefined) => {
-      if (!account) {
-        toast.error('No account connected', 'Please connect your wallet to continue.');
-        return;
-      }
-      if (!distribution) {
-        toast.error('No claim data', 'No claim data found for this reward please try again later.');
-        return;
-      }
-
-      try {
-        // Check if we need to switch chains
-        if (currentChainId !== distribution.distributor.chain_id) {
-          await switchChainAsync({ chainId: distribution.distributor.chain_id });
-        }
-
-        // Send the transaction
-        sendTransaction({
-          account: account as Address,
-          to: distribution.distributor.address as Address,
-          data: distribution.tx_data as `0x${string}`,
-          chainId: distribution.distributor.chain_id,
-        });
-      } catch (error) {
-        // User rejected chain switch or other error
-        if (error instanceof Error && !error.message.includes('User rejected')) {
-          toast.error('Claim Failed', error.message);
-        }
-      }
-    },
-    [account, currentChainId, switchChainAsync, toast, sendTransaction],
   );
 
   const handleMerklClaim = useCallback(
@@ -197,7 +137,6 @@ export default function RewardTable({
               <TableRow>
                 <TableHead className="text-left">Asset</TableHead>
                 <TableHead className="text-center">Chain</TableHead>
-                <TableHead className="text-center">Source</TableHead>
                 <TableHead className="text-right">Claimable</TableHead>
                 <TableHead className="text-right">Actions</TableHead>
               </TableRow>
@@ -210,14 +149,6 @@ export default function RewardTable({
                   img: undefined,
                   decimals: 18,
                 };
-
-                const distribution = distributions.find(
-                  (d) =>
-                    d.asset.address.toLowerCase() === tokenReward.asset.address.toLowerCase() &&
-                    d.asset.chain_id === tokenReward.asset.chain_id,
-                );
-
-                const isMerklReward = tokenReward.source === 'merkl';
 
                 // Create unique key for tracking claim status
                 const rewardKey = `${tokenReward.asset.address.toLowerCase()}-${tokenReward.asset.chain_id}`;
@@ -255,19 +186,6 @@ export default function RewardTable({
                         </div>
                       </div>
                     </TableCell>
-                    <TableCell>
-                      <div className="flex items-center justify-center">
-                        <span
-                          className={`rounded px-2 py-0.5 text-xs ${
-                            isMerklReward
-                              ? 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300'
-                              : 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
-                          }`}
-                        >
-                          {isMerklReward ? 'Merkl' : 'Morpho'}
-                        </span>
-                      </div>
-                    </TableCell>
                     <TableCell className="text-sm">
                       <div className="flex items-center justify-end gap-1">
                         <TokenIcon
@@ -281,26 +199,15 @@ export default function RewardTable({
                     </TableCell>
                     <TableCell>
                       <div className="flex items-center justify-end">
-                        {isMerklReward ? (
-                          <Button
-                            onClick={() => handleMerklClaim(tokenReward.asset.address, tokenReward.asset.chain_id)}
-                            variant="surface"
-                            size="sm"
-                            disabled={tokenReward.total.claimable === BigInt(0) || isThisRewardClaiming}
-                            isLoading={isThisRewardClaiming}
-                          >
-                            {getMerklClaimButtonText(isThisRewardClaiming, claimStatus)}
-                          </Button>
-                        ) : (
-                          <Button
-                            onClick={() => handleClaim(distribution)}
-                            variant="surface"
-                            size="sm"
-                            disabled={tokenReward.total.claimable === BigInt(0) || distribution === undefined}
-                          >
-                            Claim
-                          </Button>
-                        )}
+                        <Button
+                          onClick={() => handleMerklClaim(tokenReward.asset.address, tokenReward.asset.chain_id)}
+                          variant="surface"
+                          size="sm"
+                          disabled={tokenReward.total.claimable === BigInt(0) || isThisRewardClaiming}
+                          isLoading={isThisRewardClaiming}
+                        >
+                          {getMerklClaimButtonText(isThisRewardClaiming, claimStatus)}
+                        </Button>
                       </div>
                     </TableCell>
                   </TableRow>

--- a/src/features/rewards/rewards-view.tsx
+++ b/src/features/rewards/rewards-view.tsx
@@ -19,14 +19,14 @@ import { usePortfolioBookmarks } from '@/stores/usePortfolioBookmarks';
 import { formatBalance, formatSimple } from '@/utils/balance';
 import { SupportedNetworks } from '@/utils/networks';
 import { MORPHO_LEGACY, MORPHO_TOKEN_BASE, MORPHO_TOKEN_MAINNET } from '@/utils/tokens';
-import type { MarketRewardType, RewardAmount, AggregatedRewardType } from '@/utils/types';
+import type { AggregatedRewardType } from '@/utils/types';
 import RewardTable from './components/reward-table';
 import { PositionBreadcrumbs } from '@/features/position-detail/components/position-breadcrumbs';
 import { ReferralRewardsBlock } from './referral-rewards-block';
 
 export default function Rewards() {
   const { account } = useParams<{ account: string }>();
-  const { rewards, distributions, merklRewardsWithProofs, isLoading, isRefetching, refetch } = useUserRewardsQuery(account);
+  const { rewards, merklRewardsWithProofs, isLoading, isRefetching, refetch } = useUserRewardsQuery(account);
   const { addVisitedAddress, toggleAddressBookmark, isAddressBookmarked } = usePortfolioBookmarks();
 
   const { data: morphoBalanceMainnet, refetch: refetchMainnet } = useReadContract({
@@ -67,68 +67,23 @@ export default function Rewards() {
 
   const allRewards = useMemo(() => {
     const result: AggregatedRewardType[] = [];
-    // For Morpho distributor rewards, aggregate by token+chain (they share one tx_data)
-    const morphoRewards: Record<string, AggregatedRewardType> = {};
 
     for (const reward of rewards) {
-      // Check if this is a Merkl reward
-      const isMerklReward = reward.type === 'uniform-reward' && reward.program_id === 'merkl';
-
-      if (isMerklReward) {
-        // Merkl rewards: add each as separate entry (already non-aggregated from useRewards)
-        const claimable = BigInt(reward.amount.claimable_now);
-        if (claimable > 0n) {
-          result.push({
-            asset: reward.asset,
-            total: {
-              claimable,
-              pendingAmount: BigInt(reward.amount.claimable_next),
-              claimed: BigInt(reward.amount.claimed),
-            },
-            source: 'merkl',
-          });
-        }
-      } else {
-        // Morpho distributor rewards: aggregate by token+chain
-        const key = `${reward.asset.address.toLowerCase()}-${reward.asset.chain_id}`;
-        if (!morphoRewards[key]) {
-          morphoRewards[key] = {
-            asset: reward.asset,
-            total: { claimable: 0n, pendingAmount: 0n, claimed: 0n },
-            source: 'morpho-distributor',
-          };
-        }
-
-        if (reward.type === 'uniform-reward') {
-          morphoRewards[key].total.claimable += BigInt(reward.amount.claimable_now);
-          morphoRewards[key].total.pendingAmount += BigInt(reward.amount.claimable_next);
-          morphoRewards[key].total.claimed += BigInt(reward.amount.claimed);
-        } else if (reward.type === 'market-reward' || reward.type === 'vault-reward') {
-          if (reward.for_supply) {
-            morphoRewards[key].total.claimable += BigInt(reward.for_supply.claimable_now);
-            morphoRewards[key].total.pendingAmount += BigInt(reward.for_supply.claimable_next);
-            morphoRewards[key].total.claimed += BigInt(reward.for_supply.claimed);
-          }
-          if ((reward as MarketRewardType).for_borrow) {
-            const borrow = (reward as MarketRewardType).for_borrow as RewardAmount;
-            morphoRewards[key].total.claimable += BigInt(borrow.claimable_now);
-            morphoRewards[key].total.pendingAmount += BigInt(borrow.claimable_next);
-            morphoRewards[key].total.claimed += BigInt(borrow.claimed);
-          }
-          if ((reward as MarketRewardType).for_collateral) {
-            const collateral = (reward as MarketRewardType).for_collateral as RewardAmount;
-            morphoRewards[key].total.claimable += BigInt(collateral.claimable_now);
-            morphoRewards[key].total.pendingAmount += BigInt(collateral.claimable_next);
-            morphoRewards[key].total.claimed += BigInt(collateral.claimed);
-          }
-        }
+      if (reward.program_id !== 'merkl') {
+        continue;
       }
-    }
 
-    // Add Morpho rewards with claimable > 0
-    for (const reward of Object.values(morphoRewards)) {
-      if (reward.total.claimable > 0n) {
-        result.push(reward);
+      const claimable = BigInt(reward.amount.claimable_now);
+      if (claimable > 0n) {
+        result.push({
+          asset: reward.asset,
+          total: {
+            claimable,
+            pendingAmount: BigInt(reward.amount.claimable_next),
+            claimed: BigInt(reward.amount.claimed),
+          },
+          source: 'merkl',
+        });
       }
     }
 
@@ -147,8 +102,6 @@ export default function Rewards() {
       return acc;
     }, 0n);
   }, [allRewards]);
-
-  const _canClaim = totalClaimable > 0n;
 
   const showLegacy = morphoBalanceLegacy !== undefined && morphoBalanceLegacy !== 0n;
   const isBookmarked = isAddressBookmarked(account as Address);
@@ -288,7 +241,6 @@ export default function Rewards() {
           <RewardTable
             account={account}
             rewards={allRewards}
-            distributions={distributions}
             merklRewardsWithProofs={merklRewardsWithProofs}
             onRefresh={handleRefresh}
             isRefetching={isRefetching}

--- a/src/features/vault/vault-view.tsx
+++ b/src/features/vault/vault-view.tsx
@@ -21,6 +21,7 @@ import { VaultSharePriceChart } from '@/features/vault/components/vault-share-pr
 import { useModal } from '@/hooks/useModal';
 import { type VaultMarketAdapter, useMorphoMarketAdapters } from '@/hooks/useMorphoMarketAdapters';
 import { useTokensQuery } from '@/hooks/queries/useTokensQuery';
+import { useVaultV2RewardsQuery } from '@/hooks/queries/useVaultV2RewardsQuery';
 import useUserPositionsSummaryData from '@/hooks/useUserPositionsSummaryData';
 import { useVaultAllocations } from '@/hooks/useVaultAllocations';
 import { useVaultPage } from '@/hooks/useVaultPage';
@@ -258,6 +259,11 @@ export default function VaultContent() {
   }, [chainId]);
 
   const vaultDataQuery = useVaultV2Data({ vaultAddress: vaultAddressValue, chainId });
+  const {
+    data: vaultRewardsData,
+    refetch: refetchVaultRewards,
+    isRefetching: isRefetchingVaultRewards,
+  } = useVaultV2RewardsQuery({ vaultAddress: vaultAddressValue, chainId });
   const vaultContract = useVaultV2({
     vaultAddress: vaultAddressValue,
     chainId,
@@ -277,8 +283,9 @@ export default function VaultContent() {
 
   const handleRefreshVault = useCallback(() => {
     void vaultContract.refetch();
+    void refetchVaultRewards();
     void refetchVaultQueries({ includeRetries: true });
-  }, [refetchVaultQueries, vaultContract]);
+  }, [refetchVaultQueries, refetchVaultRewards, vaultContract]);
 
   const vaultData = vaultDataQuery.data;
   const hasError = vaultDataQuery.isError;
@@ -301,12 +308,54 @@ export default function VaultContent() {
   const hasNoAllocators = Boolean(vaultData?.capsData) && (vaultData?.allocators ?? []).length === 0;
   const capsUninitialized = vaultData?.capsData?.needSetupCaps === true;
 
-  const isRefetching = vaultDataQuery.isRefetching || vaultContract.isRefetching || adapterQuery.isRefetching || isRefetchingVaultQueries;
+  const isRefetching =
+    vaultDataQuery.isRefetching ||
+    vaultContract.isRefetching ||
+    adapterQuery.isRefetching ||
+    isRefetchingVaultQueries ||
+    isRefetchingVaultRewards;
+
+  const vaultRewardRows = useMemo(
+    () =>
+      (vaultRewardsData?.rewards ?? [])
+        .filter((reward) => Number.isFinite(reward.supplyApr) && reward.supplyApr > 0)
+        .map((reward) => ({
+          assetAddress: reward.asset.address,
+          assetSymbol: reward.asset.symbol,
+          apr: reward.supplyApr,
+        })),
+    [vaultRewardsData?.rewards],
+  );
+
+  const vaultRewardApr = useMemo(() => vaultRewardRows.reduce((sum, reward) => sum + reward.apr, 0), [vaultRewardRows]);
+  const displayedVaultApy = useMemo(() => {
+    if (vaultRewardsData?.netApy !== null && vaultRewardsData?.netApy !== undefined) {
+      return vaultRewardsData.netApy;
+    }
+
+    if (vaultAPY === null || vaultAPY === undefined) {
+      return null;
+    }
+
+    return vaultAPY + vaultRewardApr;
+  }, [vaultAPY, vaultRewardApr, vaultRewardsData?.netApy]);
+
+  const baseVaultApy = vaultRewardsData?.apy ?? vaultAPY;
 
   const apyLabel = useMemo(() => {
-    if (vaultAPY === null || vaultAPY === undefined) return '0%';
-    return `${(vaultAPY * 100).toFixed(2)}%`;
-  }, [vaultAPY]);
+    if (displayedVaultApy === null || displayedVaultApy === undefined) return '0%';
+    return `${(displayedVaultApy * 100).toFixed(2)}%`;
+  }, [displayedVaultApy]);
+
+  const baseApyLabel = useMemo(() => {
+    if (baseVaultApy === null || baseVaultApy === undefined) return undefined;
+    return `${(baseVaultApy * 100).toFixed(2)}%`;
+  }, [baseVaultApy]);
+
+  const rewardAprLabel = useMemo(() => {
+    if (vaultRewardApr <= 0) return undefined;
+    return `+${(vaultRewardApr * 100).toFixed(2)}% rewards`;
+  }, [vaultRewardApr]);
 
   const totalAssetsLabel = useMemo(() => {
     if (vaultContract.totalAssets === undefined || tokenDecimals === undefined) return '--';
@@ -417,6 +466,9 @@ export default function VaultContent() {
             assetSymbol={tokenSymbol}
             totalAssetsLabel={totalAssetsLabel}
             apyLabel={apyLabel}
+            baseApyLabel={baseApyLabel}
+            rewardAprLabel={rewardAprLabel}
+            rewards={vaultRewardRows}
             userShareBalance={userShareBalanceLabel}
             allocators={vaultData?.allocators}
             sentinels={vaultData?.sentinels}

--- a/src/features/vault/vault-view.tsx
+++ b/src/features/vault/vault-view.tsx
@@ -23,11 +23,13 @@ import { type VaultMarketAdapter, useMorphoMarketAdapters } from '@/hooks/useMor
 import { useTokensQuery } from '@/hooks/queries/useTokensQuery';
 import { useVaultV2RewardsQuery } from '@/hooks/queries/useVaultV2RewardsQuery';
 import useUserPositionsSummaryData from '@/hooks/useUserPositionsSummaryData';
+import { useRateLabel } from '@/hooks/useRateLabel';
 import { useVaultAllocations } from '@/hooks/useVaultAllocations';
 import { useVaultPage } from '@/hooks/useVaultPage';
 import { useVaultQueryRefresh } from '@/hooks/useVaultQueryRefresh';
 import { useVaultV2 } from '@/hooks/useVaultV2';
 import { useVaultV2Data } from '@/hooks/useVaultV2Data';
+import { useAppSettings } from '@/stores/useAppSettings';
 import { useVaultInitializationModalStore } from '@/stores/vault-initialization-modal-store';
 import { useMarketDetailChartState } from '@/stores/useMarketDetailChartState';
 import type { EarningsPeriod } from '@/stores/usePositionsFilters';
@@ -37,6 +39,7 @@ import { getSlicedAddress } from '@/utils/address';
 import { getVaultURL, supportsMorphoAppLinks } from '@/utils/external';
 import { parseCapIdParams } from '@/utils/morpho';
 import { groupPositionsByLoanAsset, processCollaterals } from '@/utils/positions';
+import { convertAprToApy, convertApyToApr } from '@/utils/rateMath';
 import { ALL_SUPPORTED_NETWORKS, getNetworkConfig, SupportedNetworks } from '@/utils/networks';
 import { formatVaultAdapterType } from '@/utils/vaults';
 
@@ -225,6 +228,8 @@ export default function VaultContent() {
   const [hasMounted, setHasMounted] = useState(false);
   const { open: openModal } = useModal();
   const { findToken } = useTokensQuery();
+  const { showFullRewardAPY, isAprDisplay } = useAppSettings();
+  const { short: rateLabel } = useRateLabel();
   const selectedAnalyticsTimeframe = useMarketDetailChartState((state) => state.selectedTimeframe);
   const setAnalyticsTimeframe = useMarketDetailChartState((state) => state.setTimeframe);
   const analyticsPeriod = vaultAnalyticsTimeframeToEarningsPeriod[selectedAnalyticsTimeframe];
@@ -322,40 +327,35 @@ export default function VaultContent() {
         .map((reward) => ({
           assetAddress: reward.asset.address,
           assetSymbol: reward.asset.symbol,
-          apr: reward.supplyApr,
+          rate: isAprDisplay ? reward.supplyApr : convertAprToApy(reward.supplyApr),
         })),
-    [vaultRewardsData?.rewards],
+    [isAprDisplay, vaultRewardsData?.rewards],
   );
 
-  const vaultRewardApr = useMemo(() => vaultRewardRows.reduce((sum, reward) => sum + reward.apr, 0), [vaultRewardRows]);
-  const displayedVaultApy = useMemo(() => {
-    if (vaultRewardsData?.netApy !== null && vaultRewardsData?.netApy !== undefined) {
-      return vaultRewardsData.netApy;
-    }
+  const vaultRewardRate = useMemo(() => vaultRewardRows.reduce((sum, reward) => sum + reward.rate, 0), [vaultRewardRows]);
+  const baseVaultApy = vaultRewardsData?.apy ?? vaultAPY;
+  const baseVaultRate = useMemo(() => {
+    if (baseVaultApy === null || baseVaultApy === undefined) return null;
+    return isAprDisplay ? convertApyToApr(baseVaultApy) : baseVaultApy;
+  }, [baseVaultApy, isAprDisplay]);
 
-    if (vaultAPY === null || vaultAPY === undefined) {
+  const displayedVaultRate = useMemo(() => {
+    if (baseVaultRate === null || baseVaultRate === undefined) {
       return null;
     }
 
-    return vaultAPY + vaultRewardApr;
-  }, [vaultAPY, vaultRewardApr, vaultRewardsData?.netApy]);
-
-  const baseVaultApy = vaultRewardsData?.apy ?? vaultAPY;
+    return showFullRewardAPY && vaultRewardRows.length > 0 ? baseVaultRate + vaultRewardRate : baseVaultRate;
+  }, [baseVaultRate, showFullRewardAPY, vaultRewardRate, vaultRewardRows.length]);
 
   const apyLabel = useMemo(() => {
-    if (displayedVaultApy === null || displayedVaultApy === undefined) return '0%';
-    return `${(displayedVaultApy * 100).toFixed(2)}%`;
-  }, [displayedVaultApy]);
+    if (displayedVaultRate === null || displayedVaultRate === undefined) return '0%';
+    return `${(displayedVaultRate * 100).toFixed(2)}%`;
+  }, [displayedVaultRate]);
 
-  const baseApyLabel = useMemo(() => {
-    if (baseVaultApy === null || baseVaultApy === undefined) return undefined;
-    return `${(baseVaultApy * 100).toFixed(2)}%`;
-  }, [baseVaultApy]);
-
-  const rewardAprLabel = useMemo(() => {
-    if (vaultRewardApr <= 0) return undefined;
-    return `+${(vaultRewardApr * 100).toFixed(2)}% rewards`;
-  }, [vaultRewardApr]);
+  const baseRateLabel = useMemo(() => {
+    if (baseVaultRate === null || baseVaultRate === undefined) return undefined;
+    return `${(baseVaultRate * 100).toFixed(2)}%`;
+  }, [baseVaultRate]);
 
   const totalAssetsLabel = useMemo(() => {
     if (vaultContract.totalAssets === undefined || tokenDecimals === undefined) return '--';
@@ -466,9 +466,10 @@ export default function VaultContent() {
             assetSymbol={tokenSymbol}
             totalAssetsLabel={totalAssetsLabel}
             apyLabel={apyLabel}
-            baseApyLabel={baseApyLabel}
-            rewardAprLabel={rewardAprLabel}
+            baseRateLabel={baseRateLabel}
+            rateLabel={rateLabel}
             rewards={vaultRewardRows}
+            showRewardSparkle={showFullRewardAPY && vaultRewardRows.length > 0}
             userShareBalance={userShareBalanceLabel}
             allocators={vaultData?.allocators}
             sentinels={vaultData?.sentinels}

--- a/src/graphql/vault-queries.ts
+++ b/src/graphql/vault-queries.ts
@@ -80,3 +80,23 @@ export const vaultV2MetadataQuery = `
     }
   }
 `;
+
+export const vaultV2RewardsQuery = `
+  query VaultV2Rewards($address: String!, $chainId: Int!) {
+    vaultV2ByAddress(address: $address, chainId: $chainId) {
+      address
+      apy
+      netApy
+      rewards {
+        supplyApr
+        asset {
+          address
+          symbol
+          price {
+            usd
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/graphql/vault-queries.ts
+++ b/src/graphql/vault-queries.ts
@@ -86,7 +86,6 @@ export const vaultV2RewardsQuery = `
     vaultV2ByAddress(address: $address, chainId: $chainId) {
       address
       apy
-      netApy
       rewards {
         supplyApr
         asset {

--- a/src/hooks/queries/useUserRewardsQuery.ts
+++ b/src/hooks/queries/useUserRewardsQuery.ts
@@ -1,28 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import { fetchMerklApi } from '@/utils/merklApi';
 import { reportHandledError } from '@/utils/sentry';
 import type { RewardResponseType } from '@/utils/types';
-import { URLS } from '@/utils/urls';
 import { ALL_SUPPORTED_NETWORKS } from '@/utils/networks';
-
-export type DistributionResponseType = {
-  user: Address;
-  asset: {
-    id: string;
-    address: string;
-    chain_id: number;
-  };
-  distributor: {
-    id: string;
-    address: string;
-    chain_id: number;
-  };
-  claimable: string;
-  proof: string[];
-  tx_data: string;
-};
 
 export type MerklRewardWithProofs = {
   tokenAddress: Address;
@@ -37,7 +19,6 @@ export type MerklRewardWithProofs = {
 
 type UserRewardsData = {
   rewards: RewardResponseType[];
-  distributions: DistributionResponseType[];
   merklRewardsWithProofs: MerklRewardWithProofs[];
 };
 
@@ -48,6 +29,7 @@ type MerklRewardsResponse = Array<{
   rewards?: Array<{
     amount?: string;
     claimed?: string;
+    pending?: string;
     proofs?: string[];
     token: {
       address: string;
@@ -65,141 +47,103 @@ export const userRewardsKeys = {
 
 async function fetchMerklRewards(
   userAddress: string,
+  options: { forceReload?: boolean } = {},
 ): Promise<{ rewards: RewardResponseType[]; rewardsWithProofs: MerklRewardWithProofs[] }> {
   const rewardsList: RewardResponseType[] = [];
   const rewardsWithProofsList: MerklRewardWithProofs[] = [];
 
-  // Scan all supported networks for Merkl rewards
-  for (const chainId of ALL_SUPPORTED_NETWORKS) {
-    const { data, error, status } = await fetchMerklApi<MerklRewardsResponse>(`/v4/users/${userAddress}/rewards`, {
-      chainId: [chainId],
-      reloadChainId: chainId,
-      test: false,
-      claimableOnly: true,
-      breakdownPage: 0,
-      type: 'TOKEN',
-    });
+  const { data, error, status } = await fetchMerklApi<MerklRewardsResponse>(`/v4/users/${userAddress}/rewards`, {
+    chainId: ALL_SUPPORTED_NETWORKS,
+    reloadChainId: options.forceReload ? ALL_SUPPORTED_NETWORKS : undefined,
+    test: false,
+    claimableOnly: true,
+    breakdownPage: 0,
+    type: 'TOKEN',
+  });
 
-    if (error ?? status !== 200) {
+  if (error || status !== 200) {
+    throw new Error(`Merkl rewards fetch failed: ${status} ${error ?? ''}`.trim());
+  }
+
+  if (!Array.isArray(data) || data.length === 0) {
+    return { rewards: rewardsList, rewardsWithProofs: rewardsWithProofsList };
+  }
+
+  for (const chainData of data) {
+    if (!chainData.rewards || chainData.rewards.length === 0) {
       continue;
     }
 
-    if (!Array.isArray(data) || data.length === 0) {
-      continue;
-    }
-
-    for (const chainData of data) {
-      if (!chainData.rewards || chainData.rewards.length === 0) {
+    for (const reward of chainData.rewards) {
+      const amount = BigInt(reward.amount ?? '0');
+      const claimed = BigInt(reward.claimed ?? '0');
+      const pending = BigInt(reward.pending ?? '0');
+      const claimable = amount > claimed ? amount - claimed : 0n;
+      if (claimable <= 0n) {
         continue;
       }
 
-      for (const reward of chainData.rewards) {
-        const amount = BigInt(reward.amount ?? '0');
-        const claimed = BigInt(reward.claimed ?? '0');
-        const claimable = amount > claimed ? amount - claimed : 0n;
+      const tokenAddress = reward.token.address;
 
-        const tokenAddress = reward.token.address;
-
-        rewardsList.push({
-          type: 'uniform-reward',
-          asset: {
-            id: `${tokenAddress}-${chainData.chain.id}`,
-            address: tokenAddress,
-            chain_id: chainData.chain.id,
-          },
-          user: userAddress,
-          amount: {
-            total: amount.toString(),
-            claimable_now: claimable.toString(),
-            claimable_next: '0',
-            claimed: claimed.toString(),
-          },
-          program_id: 'merkl',
-        });
-
-        rewardsWithProofsList.push({
-          tokenAddress: tokenAddress as Address,
-          chainId: chainData.chain.id,
-          amount: amount.toString(),
+      rewardsList.push({
+        type: 'uniform-reward',
+        asset: {
+          id: `${tokenAddress}-${chainData.chain.id}`,
+          address: tokenAddress,
+          chain_id: chainData.chain.id,
+        },
+        user: userAddress,
+        amount: {
+          total: amount.toString(),
+          claimable_now: claimable.toString(),
+          claimable_next: pending.toString(),
           claimed: claimed.toString(),
-          pending: claimable.toString(),
-          proofs: reward.proofs ?? [],
-          symbol: reward.token.symbol,
-          decimals: reward.token.decimals,
-        });
-      }
+        },
+        program_id: 'merkl',
+      });
+
+      rewardsWithProofsList.push({
+        tokenAddress: tokenAddress as Address,
+        chainId: chainData.chain.id,
+        amount: amount.toString(),
+        claimed: claimed.toString(),
+        pending: pending.toString(),
+        proofs: reward.proofs ?? [],
+        symbol: reward.token.symbol,
+        decimals: reward.token.decimals,
+      });
     }
   }
 
   return { rewards: rewardsList, rewardsWithProofs: rewardsWithProofsList };
 }
 
-async function fetchMorphoRewards(
-  userAddress: string,
-): Promise<{ rewards: RewardResponseType[]; distributions: DistributionResponseType[] }> {
-  // IMPORTANT: exclude_merkl_programs=true prevents duplicates with Merkl API data
-  const [totalRewardsRes, distributionRes] = await Promise.all([
-    fetch(`${URLS.MORPHO_REWARDS_API}/users/${userAddress}/rewards?exclude_merkl_programs=true`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }),
-    fetch(`${URLS.MORPHO_REWARDS_API}/users/${userAddress}/distributions`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }),
-  ]);
-
-  const morphoRewards = (await totalRewardsRes.json()).data as RewardResponseType[];
-  const distributions = (await distributionRes.json()).data as DistributionResponseType[];
+async function fetchAllRewards(userAddress: string, options: { forceReload?: boolean } = {}): Promise<UserRewardsData> {
+  const merklData = await fetchMerklRewards(userAddress, options).catch((err) => {
+    console.error('Merkl rewards fetch failed:', err);
+    reportHandledError(err, {
+      scope: 'user_rewards',
+      operation: 'fetch:merkl',
+      level: 'warning',
+    });
+    return { rewards: [] as RewardResponseType[], rewardsWithProofs: [] as MerklRewardWithProofs[] };
+  });
 
   return {
-    rewards: Array.isArray(morphoRewards) ? morphoRewards : [],
-    distributions: Array.isArray(distributions) ? distributions : [],
-  };
-}
-
-// Combined fetch function - each API wrapped so one failure doesn't affect the other
-async function fetchAllRewards(userAddress: string): Promise<UserRewardsData> {
-  const [morphoData, merklData] = await Promise.all([
-    fetchMorphoRewards(userAddress).catch((err) => {
-      console.error('Morpho rewards fetch failed:', err);
-      reportHandledError(err, {
-        scope: 'user_rewards',
-        operation: 'fetch:morpho',
-        level: 'warning',
-      });
-      return { rewards: [] as RewardResponseType[], distributions: [] as DistributionResponseType[] };
-    }),
-    fetchMerklRewards(userAddress).catch((err) => {
-      console.error('Merkl rewards fetch failed:', err);
-      reportHandledError(err, {
-        scope: 'user_rewards',
-        operation: 'fetch:merkl',
-        level: 'warning',
-      });
-      return { rewards: [] as RewardResponseType[], rewardsWithProofs: [] as MerklRewardWithProofs[] };
-    }),
-  ]);
-
-  return {
-    rewards: [...morphoData.rewards, ...merklData.rewards],
-    distributions: morphoData.distributions,
+    rewards: merklData.rewards,
     merklRewardsWithProofs: merklData.rewardsWithProofs,
   };
 }
 
 export const useUserRewardsQuery = (user: string | undefined) => {
   const queryClient = useQueryClient();
+  const forceReloadRef = useRef(false);
 
   const query = useQuery({
     queryKey: userRewardsKeys.user(user ?? ''),
-    queryFn: () => fetchAllRewards(user!),
+    queryFn: () => fetchAllRewards(user!, { forceReload: forceReloadRef.current }),
     enabled: !!user,
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: 5 * 60 * 1000,
   });
 
   const invalidate = useCallback(() => {
@@ -208,14 +152,22 @@ export const useUserRewardsQuery = (user: string | undefined) => {
     });
   }, [queryClient, user]);
 
+  const refetch = useCallback(async () => {
+    forceReloadRef.current = true;
+    try {
+      return await query.refetch();
+    } finally {
+      forceReloadRef.current = false;
+    }
+  }, [query.refetch]);
+
   return {
     rewards: query.data?.rewards ?? [],
-    distributions: query.data?.distributions ?? [],
     merklRewardsWithProofs: query.data?.merklRewardsWithProofs ?? [],
     isLoading: query.isLoading,
     isRefetching: query.isRefetching,
     error: query.error,
-    refetch: query.refetch,
+    refetch,
     invalidate,
   };
 };

--- a/src/hooks/queries/useVaultV2RewardsQuery.ts
+++ b/src/hooks/queries/useVaultV2RewardsQuery.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Address } from 'viem';
+import { fetchMorphoVaultV2Rewards, type MorphoVaultV2Rewards } from '@/data-sources/morpho-api/vaults';
+import type { SupportedNetworks } from '@/utils/networks';
+
+type UseVaultV2RewardsQueryArgs = {
+  vaultAddress?: Address;
+  chainId: SupportedNetworks;
+};
+
+export function useVaultV2RewardsQuery({ vaultAddress, chainId }: UseVaultV2RewardsQueryArgs) {
+  const normalizedVaultAddress = vaultAddress?.toLowerCase() as Address | undefined;
+
+  return useQuery<MorphoVaultV2Rewards | null>({
+    queryKey: ['vault-v2-rewards', normalizedVaultAddress, chainId],
+    queryFn: () => fetchMorphoVaultV2Rewards(normalizedVaultAddress!, chainId),
+    enabled: Boolean(normalizedVaultAddress),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/utils/merklApi.ts
+++ b/src/utils/merklApi.ts
@@ -1,6 +1,6 @@
 import type { MerklCampaign, SimplifiedCampaign, MerklApiParams, MerklOpportunityLookupParams, MerklOpportunity } from './merklTypes';
 
-const MERKL_API_BASE_URL = 'https://api.merkl.xyz';
+const MERKL_API_PROXY_BASE_PATH = '/api/merkl';
 
 const MERKL_LIVE_STATUS = 'LIVE';
 const MERKL_HOLD_ACTION = 'HOLD';
@@ -14,22 +14,24 @@ type MerklApiResult<T> = {
 };
 
 const buildMerklUrl = (path: string, query: Record<string, MerklQueryValue | null | undefined> = {}): string => {
-  const url = new URL(path, MERKL_API_BASE_URL);
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const searchParams = new URLSearchParams();
 
   for (const [key, value] of Object.entries(query)) {
     if (value == null) continue;
 
     if (Array.isArray(value)) {
       for (const item of value) {
-        url.searchParams.append(key, String(item));
+        searchParams.append(key, String(item));
       }
       continue;
     }
 
-    url.searchParams.set(key, String(value));
+    searchParams.set(key, String(value));
   }
 
-  return url.toString();
+  const queryString = searchParams.toString();
+  return `${MERKL_API_PROXY_BASE_PATH}${normalizedPath}${queryString ? `?${queryString}` : ''}`;
 };
 
 export async function fetchMerklApi<T>(

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -112,26 +112,6 @@ export type RewardAmount = {
   claimed: string;
 };
 
-export type MarketRewardType = {
-  // shared
-  type: 'market-reward';
-  asset: AssetType;
-  user: string;
-  // specific
-  for_borrow: RewardAmount | null;
-  for_collateral: RewardAmount | null;
-  for_supply: RewardAmount | null;
-  program: {
-    creator: string;
-    start: string;
-    end: string;
-    created_at: string;
-    blacklist: string[];
-    market_id: string;
-    asset: AssetType;
-  };
-};
-
 export type UniformRewardType = {
   // shared
   type: 'uniform-reward';
@@ -142,34 +122,9 @@ export type UniformRewardType = {
   program_id: string;
 };
 
-export type VaultRewardType = {
-  // shared
-  type: 'vault-reward';
-  asset: AssetType;
-  user: string;
-  // specific
-  program: VaultProgramType;
-  for_supply: RewardAmount | null;
-};
+export type RewardResponseType = UniformRewardType;
 
-export type VaultProgramType = {
-  type: 'vault-reward';
-  asset: AssetType;
-  vault: string;
-  chain_id: number;
-  rate_per_year: string;
-  distributor: AssetType;
-  creator: string;
-  blacklist: string[];
-  start: string;
-  end: string;
-  created_at: string;
-  id: string;
-};
-
-export type RewardResponseType = MarketRewardType | UniformRewardType | VaultRewardType;
-
-export type RewardSource = 'merkl' | 'morpho-distributor';
+export type RewardSource = 'merkl';
 
 export type AggregatedRewardType = {
   asset: AssetType;

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -2,9 +2,6 @@ import { SupportedNetworks } from './networks';
 
 export const URLS = {
   MORPHO_BLUE_API: 'https://blue-api.morpho.org/graphql',
-
-  // only returns morpho reward, won't include merkl rewards
-  MORPHO_REWARDS_API: 'https://rewards.morpho.org/v1',
 } as const;
 
 export const DATA_API_BASE_URL = process.env.NEXT_PUBLIC_DATA_API_BASE_URL?.replace(/\/+$/, '') ?? '';


### PR DESCRIPTION
## Summary
- add a server-side Merkl proxy that attaches `MERKL_API_KEY` as `X-API-Key`
- migrate user claimable rewards to a single multi-chain Merkl rewards request and remove deprecated Morpho rewards REST/URD claim handling
- add Vault V2 reward APR enrichment on the vault page using Morpho `vaultV2ByAddress.rewards`
- make the vault rate header follow existing APR/APY and full reward APY settings, with reward detail only in hover and the same sparkle affordance used by market APY cells
- update technical overview and env example for the Merkl API-key flow

## Validation
- `npx ultracite fix`
- `npx ultracite check`
- `pnpm typecheck`
- `git diff --check`
- browser check on `/vault/1/0xb576765fB15505433aF24FEe2c0325895C559FB2`: rendered compact rate with sparkle, no rewards line, no console errors
- local `/api/merkl/.../rewards` returned 200
