### PR TITLE
Clean up feed detail helper copy

### DIFF
--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -111,21 +111,15 @@ export function FeedHero({
             <StatTile
               label="Markets using"
               value={statValue(marketCount.toLocaleString('en-US'))}
-              detail={
-                isStatsLoading
-                  ? 'Market usage and oracle contracts are loading'
-                  : `${oracleCount.toLocaleString('en-US')} oracle contract${oracleCount === 1 ? '' : 's'}`
-              }
+              detail={isStatsLoading ? undefined : `${oracleCount.toLocaleString('en-US')} oracle contract${oracleCount === 1 ? '' : 's'}`}
             />
             <StatTile
               label="Supply TVL"
               value={statValue(formatUsdCompact(totalSupplyUsd))}
-              detail={isStatsLoading ? 'Supplied value is still calculating' : 'Supplied value in markets using this feed'}
             />
             <StatTile
               label="Borrow TVL"
               value={statValue(formatUsdCompact(totalBorrowUsd))}
-              detail={isStatsLoading ? 'Borrowed value is still calculating' : 'Borrowed value in markets using this feed'}
             />
           </div>
         </div>
@@ -202,10 +196,7 @@ export function FeedMetadataSection({
 
 export function VaultAccountingSection({ leg }: { leg: FeedDependencyLeg | null }) {
   return (
-    <SectionShell
-      title="Vault Accounting"
-      detail="Vault conversions use accounting values, so live price rounds are not shown."
-    >
+    <SectionShell title="Vault Accounting">
       <div>
         <DetailRow
           label="Conversion"
@@ -258,10 +249,7 @@ export function FeedInspectionSection({
   const formattedAnswer = answer != null && decimals != null ? formatOraclePrice(answer, decimals) : 'Unavailable';
 
   return (
-    <SectionShell
-      title="Price, Last 24 Hours"
-      detail="Sampled archive reads from the configured RPC. Current feed context is shown on the right."
-    >
+    <SectionShell title="Price, Last 24 Hours">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)]">
         <PriceHistoryChart
           points={priceHistory}
@@ -362,10 +350,7 @@ export function ContractSection({
   safeThreshold: bigint | null;
 }) {
   return (
-    <SectionShell
-      title="Chainlink Contract Details"
-      detail="Proxy implementation and owner contract, when available from the feed."
-    >
+    <SectionShell title="Chainlink Contract Details">
       <div>
         <DetailRow
           label="Version"
@@ -486,10 +471,7 @@ export function MarketsSection({ dependencies, chainId }: { dependencies: FeedMa
   const paginatedDependencies = dependencies.slice((safePage - 1) * MARKETS_PAGE_SIZE, safePage * MARKETS_PAGE_SIZE);
 
   return (
-    <SectionShell
-      title="Markets Using This Feed"
-      detail="Sorted by supplied plus borrowed USD value."
-    >
+    <SectionShell title="Markets Using This Feed">
       {dependencies.length === 0 ? (
         <p className="text-sm text-secondary">No loaded markets currently use this feed.</p>
       ) : (

--- a/src/features/feed-detail/feed-view.tsx
+++ b/src/features/feed-detail/feed-view.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
-import { toast } from 'react-toastify';
 import { type Address, isAddress } from 'viem';
 import Header from '@/components/layout/header/Header';
 import { Breadcrumbs } from '@/components/shared/breadcrumbs';
-import { StyledToast } from '@/components/ui/styled-toast';
 import { useProcessedMarkets } from '@/hooks/useProcessedMarkets';
 import { useOracleMetadata } from '@/hooks/useOracleMetadata';
 import { useUsdEnrichedMarkets } from '@/hooks/useUsdEnrichedMarkets';
@@ -38,8 +36,6 @@ import {
   VaultAccountingSection,
 } from './components/feed-sections';
 import { getFeedVendorIcon, isChainlinkFeedLeg } from './components/feed-shared';
-
-const FEED_DATA_LOADING_TOAST_ID = 'feed-market-oracle-data-loading';
 
 function routeValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
@@ -144,30 +140,6 @@ export default function FeedContent() {
   const totalBorrowUsd = dependencies.reduce((sum, dependency) => sum + toFiniteNumber(dependency.market.state.borrowAssetsUsd), 0);
   const uniqueOracleCount = getUniqueOracleOccurrences(occurrences).length;
   const isMetadataLoading = isRouteSupported && (oracleMetadataLoading || marketsLoading || isUsdEnrichmentLoading);
-
-  useEffect(() => {
-    if (!isMetadataLoading) {
-      toast.dismiss(FEED_DATA_LOADING_TOAST_ID);
-      return;
-    }
-
-    toast.loading(
-      <StyledToast
-        title="Calculating feed metrics"
-        message="Markets, oracle contracts, Supply TVL, and Borrow TVL are still loading."
-      />,
-      {
-        toastId: FEED_DATA_LOADING_TOAST_ID,
-        closeButton: true,
-        closeOnClick: false,
-        autoClose: false,
-      },
-    );
-
-    return () => {
-      toast.dismiss(FEED_DATA_LOADING_TOAST_ID);
-    };
-  }, [isMetadataLoading]);
 
   if (!isRouteSupported) {
     return (


### PR DESCRIPTION
## Summary
- remove nonessential helper copy from feed detail sections and hero stat tiles
- remove the feed metrics loading toast
- keep useful oracle-contract context visible

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Feed detail loading UI is now cleaner with simplified loading states for market and TVL statistics
  * Persistent "Calculating feed metrics" notification has been removed for a less cluttered interface
  * Section components now display with streamlined layouts focusing on key information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->