### PR TITLE
Fix market flow chart event fetching

### DIFF
--- a/src/data-sources/monarch-api/index.ts
+++ b/src/data-sources/monarch-api/index.ts
@@ -14,7 +14,6 @@ export {
   fetchMonarchMarketSupplies,
 } from './market-detail';
 export {
-  fetchMonarchMarketTxContextsInWindow,
   fetchMonarchMarketTxContexts,
   type MarketProActivity,
   type MarketProActivityKind,
@@ -22,6 +21,11 @@ export {
   type MarketTxContextCursor,
   type PaginatedMarketProActivities,
 } from './market-tx-contexts';
+export {
+  fetchMonarchMarketFlowEventsInWindow,
+  type MarketFlowEvent,
+  type MarketFlowKind,
+} from './market-flow-events';
 export {
   fetchMonarchTransactions,
   type MonarchSupplyTransaction,

--- a/src/data-sources/monarch-api/market-flow-events.ts
+++ b/src/data-sources/monarch-api/market-flow-events.ts
@@ -1,0 +1,145 @@
+import { envioMarketBorrowFlowEventsWindowQuery, envioMarketSupplyFlowEventsWindowQuery } from '@/graphql/envio-queries';
+import { monarchGraphqlFetcher } from './fetchers';
+
+export type MarketFlowKind = 'supply' | 'borrow';
+export type MarketFlowDirection = 'positive' | 'negative';
+type MarketFlowEventType = 'supply' | 'withdraw' | 'borrow' | 'repay';
+
+export type MarketFlowEvent = {
+  id: string;
+  hash: string;
+  timestamp: number;
+  direction: MarketFlowDirection;
+  amount: string;
+  address: string;
+};
+
+export type PaginatedMarketFlowEvents = {
+  items: MarketFlowEvent[];
+  totalCount: number;
+  hasNextPage: boolean;
+};
+
+type MonarchGraphqlResponse<T> = {
+  data?: T;
+};
+
+type MonarchFlowEventRow = {
+  id: string;
+  txHash: string;
+  timestamp: string | number;
+  assets: string;
+  onBehalf: string;
+};
+
+type MonarchSupplyFlowEventsResponse = MonarchGraphqlResponse<{
+  supplies: MonarchFlowEventRow[];
+  withdraws: MonarchFlowEventRow[];
+}>;
+
+type MonarchBorrowFlowEventsResponse = MonarchGraphqlResponse<{
+  borrows: MonarchFlowEventRow[];
+  repays: MonarchFlowEventRow[];
+}>;
+
+const toTimestamp = (value: string | number): number => (typeof value === 'number' ? value : Number.parseInt(value, 10));
+
+const mapFlowRows = (rows: MonarchFlowEventRow[], eventType: MarketFlowEventType, direction: MarketFlowDirection): MarketFlowEvent[] =>
+  rows.map((row) => ({
+    id: `${eventType}:${row.id}`,
+    hash: row.txHash,
+    timestamp: toTimestamp(row.timestamp),
+    direction,
+    amount: row.assets,
+    address: row.onBehalf,
+  }));
+
+const sortFlowEvents = (left: MarketFlowEvent, right: MarketFlowEvent): number => {
+  if (left.timestamp !== right.timestamp) {
+    return right.timestamp - left.timestamp;
+  }
+
+  const hashOrder = right.hash.localeCompare(left.hash);
+  if (hashOrder !== 0) {
+    return hashOrder;
+  }
+
+  return right.id.localeCompare(left.id);
+};
+
+const fetchSupplyFlowEvents = async (
+  marketId: string,
+  chainId: number,
+  startTimestamp: number,
+  endTimestamp: number,
+  limit: number,
+  offset: number,
+) => {
+  const response = await monarchGraphqlFetcher<MonarchSupplyFlowEventsResponse>(envioMarketSupplyFlowEventsWindowQuery, {
+    chainId,
+    marketId,
+    startTimestamp: startTimestamp.toString(),
+    endTimestamp: endTimestamp.toString(),
+    limit,
+    offset,
+  });
+
+  return {
+    positiveRows: response.data?.supplies ?? [],
+    negativeRows: response.data?.withdraws ?? [],
+  };
+};
+
+const fetchBorrowFlowEvents = async (
+  marketId: string,
+  chainId: number,
+  startTimestamp: number,
+  endTimestamp: number,
+  limit: number,
+  offset: number,
+) => {
+  const response = await monarchGraphqlFetcher<MonarchBorrowFlowEventsResponse>(envioMarketBorrowFlowEventsWindowQuery, {
+    chainId,
+    marketId,
+    startTimestamp: startTimestamp.toString(),
+    endTimestamp: endTimestamp.toString(),
+    limit,
+    offset,
+  });
+
+  return {
+    positiveRows: response.data?.borrows ?? [],
+    negativeRows: response.data?.repays ?? [],
+  };
+};
+
+export const fetchMonarchMarketFlowEventsInWindow = async (
+  marketId: string,
+  chainId: number,
+  flowKind: MarketFlowKind,
+  startTimestamp: number,
+  endTimestamp: number,
+  first = 500,
+  skip = 0,
+): Promise<PaginatedMarketFlowEvents> => {
+  const rows =
+    flowKind === 'supply'
+      ? await fetchSupplyFlowEvents(marketId, chainId, startTimestamp, endTimestamp, first + 1, skip)
+      : await fetchBorrowFlowEvents(marketId, chainId, startTimestamp, endTimestamp, first + 1, skip);
+  const positiveRows = rows.positiveRows.slice(0, first);
+  const negativeRows = rows.negativeRows.slice(0, first);
+  const positiveEventType = flowKind === 'supply' ? 'supply' : 'borrow';
+  const negativeEventType = flowKind === 'supply' ? 'withdraw' : 'repay';
+  const items = [
+    ...mapFlowRows(positiveRows, positiveEventType, 'positive'),
+    ...mapFlowRows(negativeRows, negativeEventType, 'negative'),
+  ].sort(sortFlowEvents);
+  const hasNextPage = rows.positiveRows.length > first || rows.negativeRows.length > first;
+  const totalCount = skip + Math.max(positiveRows.length, negativeRows.length) + Number(hasNextPage);
+
+  return {
+    items,
+    totalCount,
+    hasNextPage,
+  };
+};

--- a/src/data-sources/monarch-api/market-flow-events.ts
+++ b/src/data-sources/monarch-api/market-flow-events.ts
@@ -1,6 +1,8 @@
 import { envioMarketBorrowFlowEventsWindowQuery, envioMarketSupplyFlowEventsWindowQuery } from '@/graphql/envio-queries';
 import { monarchGraphqlFetcher } from './fetchers';
 
+const MONARCH_MARKET_FLOW_EVENTS_TIMEOUT_MS = 15_000;
+
 export type MarketFlowKind = 'supply' | 'borrow';
 export type MarketFlowDirection = 'positive' | 'negative';
 type MarketFlowEventType = 'supply' | 'withdraw' | 'borrow' | 'repay';
@@ -16,7 +18,6 @@ export type MarketFlowEvent = {
 
 export type PaginatedMarketFlowEvents = {
   items: MarketFlowEvent[];
-  totalCount: number;
   hasNextPage: boolean;
 };
 
@@ -42,7 +43,38 @@ type MonarchBorrowFlowEventsResponse = MonarchGraphqlResponse<{
   repays: MonarchFlowEventRow[];
 }>;
 
+type MonarchFlowEventsResponse = MonarchSupplyFlowEventsResponse | MonarchBorrowFlowEventsResponse;
+type FlowEventsVariables = {
+  chainId: number;
+  marketId: string;
+  startTimestamp: string;
+  endTimestamp: string;
+  limit: number;
+  offset: number;
+};
+
 const toTimestamp = (value: string | number): number => (typeof value === 'number' ? value : Number.parseInt(value, 10));
+
+const fetchFlowEventsResponse = async <T extends MonarchFlowEventsResponse>(query: string, variables: FlowEventsVariables): Promise<T> => {
+  const controller = new AbortController();
+  const timeoutId = globalThis.setTimeout(() => {
+    controller.abort();
+  }, MONARCH_MARKET_FLOW_EVENTS_TIMEOUT_MS);
+
+  try {
+    return await monarchGraphqlFetcher<T>(query, variables, {
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Monarch market flow events request timed out after ${MONARCH_MARKET_FLOW_EVENTS_TIMEOUT_MS}ms`);
+    }
+
+    throw error;
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+  }
+};
 
 const mapFlowRows = (rows: MonarchFlowEventRow[], eventType: MarketFlowEventType, direction: MarketFlowDirection): MarketFlowEvent[] =>
   rows.map((row) => ({
@@ -75,7 +107,7 @@ const fetchSupplyFlowEvents = async (
   limit: number,
   offset: number,
 ) => {
-  const response = await monarchGraphqlFetcher<MonarchSupplyFlowEventsResponse>(envioMarketSupplyFlowEventsWindowQuery, {
+  const response = await fetchFlowEventsResponse<MonarchSupplyFlowEventsResponse>(envioMarketSupplyFlowEventsWindowQuery, {
     chainId,
     marketId,
     startTimestamp: startTimestamp.toString(),
@@ -98,7 +130,7 @@ const fetchBorrowFlowEvents = async (
   limit: number,
   offset: number,
 ) => {
-  const response = await monarchGraphqlFetcher<MonarchBorrowFlowEventsResponse>(envioMarketBorrowFlowEventsWindowQuery, {
+  const response = await fetchFlowEventsResponse<MonarchBorrowFlowEventsResponse>(envioMarketBorrowFlowEventsWindowQuery, {
     chainId,
     marketId,
     startTimestamp: startTimestamp.toString(),
@@ -135,11 +167,9 @@ export const fetchMonarchMarketFlowEventsInWindow = async (
     ...mapFlowRows(negativeRows, negativeEventType, 'negative'),
   ].sort(sortFlowEvents);
   const hasNextPage = rows.positiveRows.length > first || rows.negativeRows.length > first;
-  const totalCount = skip + Math.max(positiveRows.length, negativeRows.length) + Number(hasNextPage);
 
   return {
     items,
-    totalCount,
     hasNextPage,
   };
 };

--- a/src/data-sources/monarch-api/market-tx-contexts.ts
+++ b/src/data-sources/monarch-api/market-tx-contexts.ts
@@ -1,9 +1,5 @@
 import { isAddress } from 'viem';
-import {
-  envioMarketTxContextsPageQuery,
-  envioMarketTxContextsPageWithinSnapshotQuery,
-  envioMarketTxContextsWindowQuery,
-} from '@/graphql/envio-queries';
+import { envioMarketTxContextsPageQuery, envioMarketTxContextsPageWithinSnapshotQuery } from '@/graphql/envio-queries';
 import { normalizeMarketUniqueKey } from '@/utils/markets';
 import { monarchGraphqlFetcher } from './fetchers';
 
@@ -892,47 +888,6 @@ const fetchMarketTxContextsPage = async (
   }
 };
 
-const fetchMarketTxContextsWindowPage = async (
-  marketId: string,
-  chainId: number,
-  startTimestamp: number,
-  endTimestamp: number,
-  limit: number,
-  offset: number,
-): Promise<MonarchMarketTxContextRow[]> => {
-  const controller = new AbortController();
-  const timeoutId = globalThis.setTimeout(() => {
-    controller.abort();
-  }, MONARCH_MARKET_TX_CONTEXTS_TIMEOUT_MS);
-
-  try {
-    const response = await monarchGraphqlFetcher<MonarchMarketTxContextsPageResponse>(
-      envioMarketTxContextsWindowQuery,
-      {
-        chainId,
-        marketId,
-        startTimestamp: startTimestamp.toString(),
-        endTimestamp: endTimestamp.toString(),
-        limit,
-        offset,
-      },
-      {
-        signal: controller.signal,
-      },
-    );
-
-    return response.data?.MarketTxContext ?? [];
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(`Monarch market flow activity request timed out after ${MONARCH_MARKET_TX_CONTEXTS_TIMEOUT_MS}ms`);
-    }
-
-    throw error;
-  } finally {
-    globalThis.clearTimeout(timeoutId);
-  }
-};
-
 const normalizeMarketTxContextRow = (row: MonarchMarketTxContextRow, marketId: string, chainId: number): MarketProActivity => {
   if (row.chainId !== chainId) {
     throw new Error(`Monarch market pro activity row chain mismatch for ${row.id}`);
@@ -989,27 +944,6 @@ export const fetchMonarchMarketTxContexts = async (
   ceiling?: MarketTxContextCursor,
 ): Promise<PaginatedMarketProActivities> => {
   const rows = await fetchMarketTxContextsPage(marketId, chainId, first + 1, skip, ceiling);
-  const pageRows = rows.slice(0, first);
-  const pageItems = normalizeMarketTxContextRows(pageRows, marketId, chainId);
-  const hasNextPage = rows.length > first;
-  const totalCount = skip + pageRows.length + Number(hasNextPage);
-
-  return {
-    items: pageItems,
-    totalCount,
-    hasNextPage,
-  };
-};
-
-export const fetchMonarchMarketTxContextsInWindow = async (
-  marketId: string,
-  chainId: number,
-  startTimestamp: number,
-  endTimestamp: number,
-  first = 500,
-  skip = 0,
-): Promise<PaginatedMarketProActivities> => {
-  const rows = await fetchMarketTxContextsWindowPage(marketId, chainId, startTimestamp, endTimestamp, first + 1, skip);
   const pageRows = rows.slice(0, first);
   const pageItems = normalizeMarketTxContextRows(pageRows, marketId, chainId);
   const hasNextPage = rows.length > first;

--- a/src/features/market-detail/components/charts/volume-chart.tsx
+++ b/src/features/market-detail/components/charts/volume-chart.tsx
@@ -1,5 +1,6 @@
-import { useState, useMemo } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { TbTrendingDown, TbTrendingUp, TbUsers } from 'react-icons/tb';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tooltip as HeroTooltip } from '@/components/ui/tooltip';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
@@ -19,6 +20,7 @@ import {
 } from 'recharts';
 import { formatUnits } from 'viem';
 import { Spinner } from '@/components/ui/spinner';
+import { RefetchIcon } from '@/components/ui/refetch-icon';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { useChartColors } from '@/constants/chartColors';
 import { useVaultRegistry } from '@/contexts/VaultRegistryContext';
@@ -39,7 +41,7 @@ import {
   chartLegendStyle,
   getTimeSeriesXAxisProps,
 } from './chart-utils';
-import type { MarketProActivity, MarketProActivityLeg } from '@/data-sources/monarch-api';
+import type { MarketFlowEvent, MarketFlowKind } from '@/data-sources/monarch-api';
 import type { AssetTimeseriesDataPoint, Market } from '@/utils/types';
 import type { SupportedNetworks } from '@/utils/networks';
 
@@ -54,7 +56,6 @@ const FLOW_POSITIVE_COLOR = 'oklch(0.66 0.12 154)';
 const FLOW_NEGATIVE_COLOR = 'oklch(0.62 0.13 24)';
 const FLOW_BAR_SIZE = 12;
 
-type MarketFlowKind = 'supply' | 'borrow';
 type MarketFlowDirection = 'positive' | 'negative';
 
 type FlowContributor = {
@@ -172,12 +173,6 @@ const formatBucketTimeRange = (bucket: FlowBucketData): string => {
   return `${date}-${endTime}`;
 };
 
-const getLegAddress = (activity: MarketProActivity, leg: MarketProActivityLeg): string | null => {
-  const address = leg.positionAddress ?? leg.actorAddress ?? leg.receiverAddress ?? activity.actorAddress;
-
-  return address ? address.toLowerCase() : null;
-};
-
 const getFlowConfig = (flowKind: MarketFlowKind, market: Market) => {
   if (flowKind === 'borrow') {
     return {
@@ -189,8 +184,6 @@ const getFlowConfig = (flowKind: MarketFlowKind, market: Market) => {
       tokenDecimals: market.loanAsset.decimals,
       tokenSymbol: market.loanAsset.symbol,
       currentRaw: safeBigInt(market.state.borrowAssets),
-      positiveKinds: new Set<MarketProActivityLeg['kind']>(['borrow']),
-      negativeKinds: new Set<MarketProActivityLeg['kind']>(['repay']),
     };
   }
 
@@ -203,8 +196,6 @@ const getFlowConfig = (flowKind: MarketFlowKind, market: Market) => {
     tokenDecimals: market.loanAsset.decimals,
     tokenSymbol: market.loanAsset.symbol,
     currentRaw: safeBigInt(market.state.supplyAssets),
-    positiveKinds: new Set<MarketProActivityLeg['kind']>(['supply', 'legacyVaultReallocateSupply']),
-    negativeKinds: new Set<MarketProActivityLeg['kind']>(['withdraw', 'legacyVaultReallocateWithdraw']),
   };
 };
 
@@ -268,7 +259,7 @@ const getFlowAxisMax = (buckets: FlowBucketData[]): number => {
 };
 
 const buildFlowAnalytics = (
-  activities: MarketProActivity[],
+  activities: MarketFlowEvent[],
   flowKind: MarketFlowKind,
   market: Market,
   timeframe: ChartTimeframe,
@@ -299,27 +290,14 @@ const buildFlowAnalytics = (
       continue;
     }
 
-    for (const leg of activity.legs) {
-      if (!leg.isCurrentMarket || leg.amount === '0') {
-        continue;
-      }
-
-      const isPositive = config.positiveKinds.has(leg.kind);
-      const isNegative = config.negativeKinds.has(leg.kind);
-      if (!isPositive && !isNegative) {
-        continue;
-      }
-
-      const amountRaw = safeBigInt(leg.amount);
-      if (amountRaw <= 0n) {
-        continue;
-      }
-
-      const direction: MarketFlowDirection = isPositive ? 'positive' : 'negative';
-      const address = getLegAddress(activity, leg);
-      addToAccumulator(bucket[direction], amountRaw, activity.hash, address);
-      addToAccumulator(direction === 'positive' ? positiveTotal : negativeTotal, amountRaw, activity.hash, address);
+    const amountRaw = safeBigInt(activity.amount);
+    if (amountRaw <= 0n) {
+      continue;
     }
+
+    const address = activity.address ? activity.address.toLowerCase() : null;
+    addToAccumulator(bucket[activity.direction], amountRaw, activity.hash, address);
+    addToAccumulator(activity.direction === 'positive' ? positiveTotal : negativeTotal, amountRaw, activity.hash, address);
   }
 
   const current = toDisplayAmount(config.currentRaw, config.tokenDecimals);
@@ -647,13 +625,15 @@ export function MarketFlowChart({ marketId, chainId, market }: VolumeChartProps)
     data: historicalData,
     isLoading: isHistoricalLoading,
     isFetching: isHistoricalFetching,
+    refetch: refetchHistoricalData,
   } = useMarketHistoricalData(marketId, chainId, selectedTimeRange, market, selectedTimeframe);
   const {
     data: flowActivitiesData,
     isLoading: isFlowLoading,
     isFetching: isFlowFetching,
     error: flowError,
-  } = useMarketFlowActivities(marketId, chainId, selectedTimeRange);
+    refetch: refetchFlowActivities,
+  } = useMarketFlowActivities(marketId, chainId, selectedTimeRange, flowKind);
 
   const formatYAxis = (value: number) => formatReadable(value);
   const intervalSeconds = TIMEFRAME_CONFIG[selectedTimeframe].intervalSeconds;
@@ -673,6 +653,9 @@ export function MarketFlowChart({ marketId, chainId, market }: VolumeChartProps)
   const hasFlowData = flowAnalytics.positiveAmount > 0 || flowAnalytics.negativeAmount > 0;
   const isLoading = isFlowLoading || isHistoricalLoading;
   const isFetching = isFlowFetching || isHistoricalFetching;
+  const handleRefresh = useCallback(() => {
+    void Promise.all([refetchFlowActivities(), refetchHistoricalData()]);
+  }, [refetchFlowActivities, refetchHistoricalData]);
   const flowAxisMax = useMemo(() => getFlowAxisMax(flowAnalytics.buckets), [flowAnalytics.buckets]);
   const grossFlowAmount = flowAnalytics.positiveAmount + flowAnalytics.negativeAmount;
   const positiveFlowShare = grossFlowAmount > 0 ? (flowAnalytics.positiveAmount / grossFlowAmount) * 100 : 50;
@@ -764,12 +747,26 @@ export function MarketFlowChart({ marketId, chainId, market }: VolumeChartProps)
         </div>
 
         <div className="flex gap-2">
-          {isFetching && !isLoading ? (
-            <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface px-2 py-1 text-[11px] text-secondary">
-              <Spinner size={12} />
-              <span>Updating</span>
-            </div>
-          ) : null}
+          <HeroTooltip
+            content={
+              <TooltipContent
+                title="Refresh flows"
+                detail="Fetch latest chart data"
+                icon={<RefetchIcon isLoading={isFetching} />}
+              />
+            }
+          >
+            <Button
+              aria-label="Refresh flow chart"
+              className="h-8 w-8 min-w-0 rounded border border-border bg-surface p-0 text-secondary shadow-none hover:bg-surface/70 hover:shadow-sm"
+              disabled={isFetching}
+              onClick={handleRefresh}
+              size="icon"
+              variant="default"
+            >
+              <RefetchIcon isLoading={isFetching} />
+            </Button>
+          </HeroTooltip>
           <Select
             value={flowKind}
             onValueChange={(value) => setFlowKind(value as MarketFlowKind)}

--- a/src/graphql/envio-queries.ts
+++ b/src/graphql/envio-queries.ts
@@ -426,6 +426,98 @@ export const envioBorrowRepayPageQuery = `
   }
 `;
 
+export const envioMarketSupplyFlowEventsWindowQuery = `
+  query EnvioMarketSupplyFlowEventsWindow(
+    $chainId: Int!
+    $marketId: String!
+    $startTimestamp: numeric!
+    $endTimestamp: numeric!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    supplies: Morpho_Supply(
+      where: {
+        chainId: { _eq: $chainId }
+        market_id: { _eq: $marketId }
+        timestamp: { _gte: $startTimestamp, _lt: $endTimestamp }
+        assets: { _gt: "0" }
+      }
+      limit: $limit
+      offset: $offset
+      order_by: [{ timestamp: desc }, { txHash: desc }, { id: desc }]
+    ) {
+      id
+      txHash
+      timestamp
+      assets
+      onBehalf
+    }
+    withdraws: Morpho_Withdraw(
+      where: {
+        chainId: { _eq: $chainId }
+        market_id: { _eq: $marketId }
+        timestamp: { _gte: $startTimestamp, _lt: $endTimestamp }
+        assets: { _gt: "0" }
+      }
+      limit: $limit
+      offset: $offset
+      order_by: [{ timestamp: desc }, { txHash: desc }, { id: desc }]
+    ) {
+      id
+      txHash
+      timestamp
+      assets
+      onBehalf
+    }
+  }
+`;
+
+export const envioMarketBorrowFlowEventsWindowQuery = `
+  query EnvioMarketBorrowFlowEventsWindow(
+    $chainId: Int!
+    $marketId: String!
+    $startTimestamp: numeric!
+    $endTimestamp: numeric!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    borrows: Morpho_Borrow(
+      where: {
+        chainId: { _eq: $chainId }
+        market_id: { _eq: $marketId }
+        timestamp: { _gte: $startTimestamp, _lt: $endTimestamp }
+        assets: { _gt: "0" }
+      }
+      limit: $limit
+      offset: $offset
+      order_by: [{ timestamp: desc }, { txHash: desc }, { id: desc }]
+    ) {
+      id
+      txHash
+      timestamp
+      assets
+      onBehalf
+    }
+    repays: Morpho_Repay(
+      where: {
+        chainId: { _eq: $chainId }
+        market_id: { _eq: $marketId }
+        timestamp: { _gte: $startTimestamp, _lt: $endTimestamp }
+        assets: { _gt: "0" }
+      }
+      limit: $limit
+      offset: $offset
+      order_by: [{ timestamp: desc }, { txHash: desc }, { id: desc }]
+    ) {
+      id
+      txHash
+      timestamp
+      assets
+      onBehalf
+    }
+  }
+`;
+
 export const envioLiquidationsPageQuery = `
   query EnvioLiquidationsPage($chainId: Int!, $marketId: String!, $limit: Int!, $offset: Int!) {
     Morpho_Liquidate(
@@ -638,38 +730,6 @@ export const envioMarketTxContextsPageWithinSnapshotQuery = `
         ]
       }
       order_by: [{ timestamp: desc }, { txHash: desc }, { txContext_id: desc }]
-      limit: $limit
-      offset: $offset
-    ) {
-      id
-      chainId
-      market_id
-      timestamp
-      txHash
-      txContext_id
-      txContext {
-${marketTxContextFields}
-      }
-    }
-  }
-`;
-
-export const envioMarketTxContextsWindowQuery = `
-  query EnvioMarketTxContextsWindow(
-    $chainId: Int!
-    $marketId: String!
-    $startTimestamp: numeric!
-    $endTimestamp: numeric!
-    $limit: Int!
-    $offset: Int!
-  ) {
-    MarketTxContext(
-      where: {
-        chainId: { _eq: $chainId }
-        market_id: { _eq: $marketId }
-        timestamp: { _gte: $startTimestamp, _lt: $endTimestamp }
-      }
-      order_by: [{ timestamp: asc }, { txHash: asc }, { txContext_id: asc }]
       limit: $limit
       offset: $offset
     ) {

--- a/src/hooks/useMarketFlowActivities.ts
+++ b/src/hooks/useMarketFlowActivities.ts
@@ -1,61 +1,67 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchMonarchMarketTxContextsInWindow, type MarketProActivity } from '@/data-sources/monarch-api';
+import { fetchMonarchMarketFlowEventsInWindow, type MarketFlowEvent, type MarketFlowKind } from '@/data-sources/monarch-api';
 import type { SupportedNetworks } from '@/utils/networks';
 import type { TimeseriesOptions } from '@/utils/types';
 
-const MARKET_FLOW_ACTIVITY_PAGE_SIZE = 500;
-const MARKET_FLOW_ACTIVITY_MAX_ROWS = 1250;
-const MARKET_FLOW_ACTIVITY_PAGE_OVERLAP = 3;
+const MARKET_FLOW_EVENT_PAGE_SIZE = 999;
+const MARKET_FLOW_EVENT_MAX_ROWS_PER_DIRECTION = 10_000;
+const MARKET_FLOW_EVENT_PAGE_OVERLAP = 3;
 
 type MarketFlowActivitiesResult = {
-  activities: MarketProActivity[];
+  activities: MarketFlowEvent[];
 };
 
 export const useMarketFlowActivities = (
   marketId: string | undefined,
   network: SupportedNetworks | undefined,
   timeRange: TimeseriesOptions,
+  flowKind: MarketFlowKind,
 ) => {
   return useQuery<MarketFlowActivitiesResult>({
-    queryKey: ['marketFlowActivities', marketId, network, timeRange.startTimestamp, timeRange.endTimestamp],
+    queryKey: ['marketFlowActivities', marketId, network, flowKind, timeRange.startTimestamp, timeRange.endTimestamp],
     queryFn: async () => {
       if (!marketId || !network) {
         return { activities: [] };
       }
 
-      const activitiesByKey = new Map<string, MarketProActivity>();
+      const activitiesByKey = new Map<string, MarketFlowEvent>();
       let skip = 0;
       let hasNextPage = true;
 
-      while (hasNextPage && activitiesByKey.size < MARKET_FLOW_ACTIVITY_MAX_ROWS) {
-        const page = await fetchMonarchMarketTxContextsInWindow(
+      while (hasNextPage && skip < MARKET_FLOW_EVENT_MAX_ROWS_PER_DIRECTION) {
+        const pageSize = Math.min(MARKET_FLOW_EVENT_PAGE_SIZE, MARKET_FLOW_EVENT_MAX_ROWS_PER_DIRECTION - skip);
+        const page = await fetchMonarchMarketFlowEventsInWindow(
           marketId,
           network,
+          flowKind,
           timeRange.startTimestamp,
           timeRange.endTimestamp,
-          MARKET_FLOW_ACTIVITY_PAGE_SIZE,
+          pageSize,
           skip,
         );
 
         for (const activity of page.items) {
-          activitiesByKey.set(`${activity.chainId}:${activity.id}`, activity);
+          activitiesByKey.set(activity.id, activity);
         }
 
         hasNextPage = page.hasNextPage;
-        if (page.items.length === 0) {
+        if (pageSize < MARKET_FLOW_EVENT_PAGE_SIZE) {
           break;
         }
 
-        // Re-read a small overlap so offset drift cannot double-count after dedupe.
-        skip += MARKET_FLOW_ACTIVITY_PAGE_SIZE - MARKET_FLOW_ACTIVITY_PAGE_OVERLAP;
+        // Re-read a small overlap so offset drift is deduped instead of skipping boundary rows.
+        skip += MARKET_FLOW_EVENT_PAGE_SIZE - MARKET_FLOW_EVENT_PAGE_OVERLAP;
       }
 
       return {
-        activities: [...activitiesByKey.values()].slice(0, MARKET_FLOW_ACTIVITY_MAX_ROWS),
+        activities: [...activitiesByKey.values()],
       };
     },
     enabled: !!marketId && !!network,
     staleTime: 1000 * 60 * 5,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
     retry: 1,
   });
 };


### PR DESCRIPTION
## Summary
- fetch market flow chart data from direct supply/withdraw and borrow/repay event tables instead of broad tx contexts
- page flow events with a larger efficient batch and overlap dedupe
- add a manual refresh button and use its spinning icon as the only update indicator
- remove the unused context-window flow fetch path

## Validation
- npx ultracite fix
- pnpm typecheck
- npx ultracite check
- git diff --check
- local market route smoke returned 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refresh button to volume chart for updating market flow data on demand.

* **Refactor**
  * Improved market flow data retrieval and processing to enhance reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->