### PR TITLE
Fix positions refresh loading flash

### DIFF
--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -76,6 +76,7 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 - Domain matching, token resolution, unit conversion, entity ID normalization, address normalization, and formatting should live in shared chokepoints.
 - Multi-chain logic must respect chain ID and address together; do not match by address alone across chains.
 - Address grouping/comparison must normalize case at the shared domain chokepoint; mixed primary/fallback sources may return the same token with different casing.
+- Address equality checks must compare lowercase-normalized values, or use a helper that normalizes both sides; do not compare raw wallet, SDK, or API address strings directly.
 - Fallback data should be marked or shaped consistently with primary data so downstream components can reason about it safely.
 - Metadata-backed display guards must expose readiness through the shared dependency-status layer, must not treat missing metadata as a negative match, and must preserve the list or previous data while the guard cannot be evaluated.
 - Market-table data enrichments that affect visible columns or sorting must report degraded readiness to the shared market-data notice surface instead of silently replacing values with empty placeholders.

--- a/src/hooks/useUserPositions.ts
+++ b/src/hooks/useUserPositions.ts
@@ -456,7 +456,10 @@ const useUserPositions = (
     enabled: !!initialData && !!user,
     placeholderData: (previousData, previousQuery) => {
       // Keep mounted rows during same-account market-key refreshes, but never across account changes.
-      if (previousQuery?.queryKey[1] !== user || !previousData || previousData.length === 0) {
+      const previousUser = typeof previousQuery?.queryKey[1] === 'string' ? previousQuery.queryKey[1].toLowerCase() : undefined;
+      const currentUser = user?.toLowerCase();
+
+      if (!currentUser || previousUser !== currentUser || !previousData || previousData.length === 0) {
         return undefined;
       }
 

--- a/src/hooks/useUserPositions.ts
+++ b/src/hooks/useUserPositions.ts
@@ -454,6 +454,14 @@ const useUserPositions = (
       return validPositions;
     },
     enabled: !!initialData && !!user,
+    placeholderData: (previousData, previousQuery) => {
+      // Keep mounted rows during same-account market-key refreshes, but never across account changes.
+      if (previousQuery?.queryKey[1] !== user || !previousData || previousData.length === 0) {
+        return undefined;
+      }
+
+      return previousData;
+    },
     staleTime: 30_000,
     gcTime: 5 * 60 * 1000,
   });


### PR DESCRIPTION
## Summary
- keep previous enhanced positions while same-account market-key refreshes resolve
- avoid remounting the full positions loading screen after rows have already appeared
- guard placeholder data so account switches never show another account's rows

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check
- browser smoke on /positions/0x2D745A6596d47A0fe28A7dB7Bd9dc7BDbCa4E476: rows appeared and Loading user positions did not reappear after rows mounted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data refresh experience to preserve previously displayed results when updating the same account.
  * Fixed placeholder data clearing when switching accounts.
  * Enhanced UI stability by maintaining interface elements mounted during same-account data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->