### PR TITLE
Standardize table density

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -375,10 +375,13 @@ thead {
   color: grey;
 }
 
+thead tr {
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
 thead th {
-  padding: 1rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding: 0.75rem 1rem;
+  white-space: nowrap;
 }
 
 tbody {
@@ -387,9 +390,7 @@ tbody {
 }
 
 tbody td {
-  padding: 1rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding: 0.875rem 1rem;
 }
 
 tbody tr:not(.no-hover-effect tr) {
@@ -408,9 +409,7 @@ tbody tr:not(.no-hover-effect tr):hover {
 
 /* Compact table variant - less padding for simpler tables */
 .table-body-compact td {
-  padding: 0.625rem;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
+  padding: 0.75rem 1rem;
 }
 
 svg {

--- a/src/components/common/table-container-with-header.tsx
+++ b/src/components/common/table-container-with-header.tsx
@@ -11,7 +11,7 @@ type TableContainerWithHeaderProps = {
  * Provides consistent styling for tables with:
  * - Title on the left (uppercase, monospace font)
  * - Optional actions on the right (filters, refresh, settings, etc.)
- * - Separator border between header and content
+ * - Compact utility header that sits close to the table content
  * - Responsive overflow handling
  *
  * @example
@@ -32,11 +32,11 @@ type TableContainerWithHeaderProps = {
 export function TableContainerWithHeader({ title, actions, children, className = '' }: TableContainerWithHeaderProps) {
   return (
     <div className={`rounded border border-border bg-surface font-zen shadow-sm ${className}`}>
-      <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 px-6 py-3">
-        <h3 className="font-monospace text-xs uppercase text-secondary">{title}</h3>
+      <div className="flex min-h-9 items-center justify-between px-4 pt-2 pb-0">
+        <h3 className="font-monospace text-[11px] uppercase leading-4 tracking-[0.08em] text-secondary">{title}</h3>
         {actions && <div className="flex items-center gap-2">{actions}</div>}
       </div>
-      <div className="overflow-x-auto pb-4">{children}</div>
+      <div className="overflow-x-auto pb-2">{children}</div>
     </div>
   );
 }
@@ -53,9 +53,8 @@ type TableContainerWithDescriptionProps = {
  * Expanded table container variant with description support.
  *
  * Features:
- * - Larger title with primary color (not secondary)
  * - Description text below title
- * - More vertical padding in header
+ * - Compact utility header that matches standard table containers
  * - Actions are vertically centered
  *
  * @example
@@ -76,14 +75,14 @@ export function TableContainerWithDescription({
 }: TableContainerWithDescriptionProps) {
   return (
     <div className={`rounded border border-border bg-surface font-zen shadow-sm ${className}`}>
-      <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 px-6 py-4">
-        <div className="flex-1">
-          <h3 className="mb-1 font-monospace text-xs uppercase text-secondary">{title}</h3>
-          {description && <p className="text-xs text-secondary">{description}</p>}
+      <div className="flex min-h-10 items-start justify-between gap-4 px-4 pt-3 pb-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="font-monospace text-[11px] uppercase leading-4 tracking-[0.08em] text-secondary">{title}</h3>
+          {description && <p className="mt-1 text-xs leading-4 text-secondary">{description}</p>}
         </div>
-        {actions && <div className="flex items-center gap-2 ml-4">{actions}</div>}
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
       </div>
-      <div className="overflow-x-auto">{children}</div>
+      <div className="overflow-x-auto pb-2">{children}</div>
     </div>
   );
 }

--- a/src/features/admin-v2/components/stats-asset-table.tsx
+++ b/src/features/admin-v2/components/stats-asset-table.tsx
@@ -39,9 +39,8 @@ type SortableHeaderProps = {
 function SortableHeader({ label, sortKeyValue, currentSortKey, sortDirection, onSort }: SortableHeaderProps) {
   return (
     <TableHead
-      className={`whitespace-nowrap px-2 py-2 font-normal ${currentSortKey === sortKeyValue ? 'text-primary' : ''}`}
+      className={`font-normal ${currentSortKey === sortKeyValue ? 'text-primary' : ''}`}
       onClick={() => onSort(sortKeyValue)}
-      style={{ padding: '0.5rem' }}
     >
       <div className="flex cursor-pointer items-center justify-center gap-1 hover:text-primary">
         <div>{label}</div>
@@ -136,7 +135,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
             <Table className="responsive w-full min-w-full rounded-md font-zen">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Asset</TableHead>
+                  <TableHead className="font-normal">Asset</TableHead>
                   <SortableHeader
                     label="Total Volume"
                     sortKeyValue="totalVolumeUsd"
@@ -188,10 +187,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
                     className="hover:bg-hovered"
                   >
                     {/* Asset */}
-                    <TableCell
-                      className="px-2 py-3"
-                      style={{ minWidth: '120px' }}
-                    >
+                    <TableCell style={{ minWidth: '120px' }}>
                       <div className="flex items-center justify-center gap-1.5">
                         <TokenIcon
                           address={asset.loanAssetAddress}
@@ -206,7 +202,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
 
                     {/* Total Volume */}
                     <TableCell
-                      className="px-2 py-3 text-center"
+                      className="text-center"
                       style={{ minWidth: '120px' }}
                     >
                       <span className="tabular-nums text-sm">${formatReadable(asset.totalVolumeUsd)}</span>
@@ -214,7 +210,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
 
                     {/* Supply Volume */}
                     <TableCell
-                      className="px-2 py-3 text-center"
+                      className="text-center"
                       style={{ minWidth: '120px' }}
                     >
                       <span className="tabular-nums text-sm">${formatReadable(asset.supplyVolumeUsd)}</span>
@@ -222,7 +218,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
 
                     {/* Withdraw Volume */}
                     <TableCell
-                      className="px-2 py-3 text-center"
+                      className="text-center"
                       style={{ minWidth: '120px' }}
                     >
                       <span className="tabular-nums text-sm">${formatReadable(asset.withdrawVolumeUsd)}</span>
@@ -230,7 +226,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
 
                     {/* Total Txns */}
                     <TableCell
-                      className="px-2 py-3 text-center"
+                      className="text-center"
                       style={{ minWidth: '100px' }}
                     >
                       <span className="text-sm">{asset.totalCount.toLocaleString()}</span>
@@ -238,7 +234,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
 
                     {/* Supply Txns */}
                     <TableCell
-                      className="px-2 py-3 text-center"
+                      className="text-center"
                       style={{ minWidth: '100px' }}
                     >
                       <span className="text-sm">{asset.supplyCount.toLocaleString()}</span>
@@ -246,7 +242,7 @@ export function StatsAssetTable({ transactions, isLoading }: StatsAssetTableProp
 
                     {/* Withdraw Txns */}
                     <TableCell
-                      className="px-2 py-3 text-center"
+                      className="text-center"
                       style={{ minWidth: '100px' }}
                     >
                       <span className="text-sm">{asset.withdrawCount.toLocaleString()}</span>

--- a/src/features/admin-v2/components/stats-market-table.tsx
+++ b/src/features/admin-v2/components/stats-market-table.tsx
@@ -45,9 +45,8 @@ type SortableHeaderProps = {
 function SortableHeader({ label, sortKeyValue, currentSortKey, sortDirection, onSort }: SortableHeaderProps) {
   return (
     <TableHead
-      className={`whitespace-nowrap px-2 py-2 font-normal ${currentSortKey === sortKeyValue ? 'text-primary' : ''}`}
+      className={`font-normal ${currentSortKey === sortKeyValue ? 'text-primary' : ''}`}
       onClick={() => onSort(sortKeyValue)}
-      style={{ padding: '0.5rem' }}
     >
       <div className="flex cursor-pointer items-center justify-center gap-1 hover:text-primary">
         <div>{label}</div>
@@ -150,7 +149,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
             <Table className="responsive w-full min-w-full rounded-md font-zen">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Market</TableHead>
+                  <TableHead className="font-normal">Market</TableHead>
                   <SortableHeader
                     label="Loan Asset"
                     sortKeyValue="loanSymbol"
@@ -212,10 +211,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
                       className="hover:bg-hovered"
                     >
                       {/* Market */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '200px' }}
-                      >
+                      <TableCell style={{ minWidth: '200px' }}>
                         {marketStats.market && marketPath ? (
                           <Link
                             href={marketPath}
@@ -243,10 +239,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
                       </TableCell>
 
                       {/* Loan Asset */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '120px' }}
-                      >
+                      <TableCell style={{ minWidth: '120px' }}>
                         <div className="flex items-center justify-center gap-1.5">
                           <TokenIcon
                             address={marketStats.loanAssetAddress}
@@ -261,7 +254,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
 
                       {/* Total Volume */}
                       <TableCell
-                        className="px-2 py-3 text-center"
+                        className="text-center"
                         style={{ minWidth: '120px' }}
                       >
                         <span className="tabular-nums text-sm">${formatReadable(marketStats.totalVolumeUsd)}</span>
@@ -269,7 +262,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
 
                       {/* Supply Volume */}
                       <TableCell
-                        className="px-2 py-3 text-center"
+                        className="text-center"
                         style={{ minWidth: '120px' }}
                       >
                         <span className="tabular-nums text-sm">${formatReadable(marketStats.supplyVolumeUsd)}</span>
@@ -277,7 +270,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
 
                       {/* Withdraw Volume */}
                       <TableCell
-                        className="px-2 py-3 text-center"
+                        className="text-center"
                         style={{ minWidth: '120px' }}
                       >
                         <span className="tabular-nums text-sm">${formatReadable(marketStats.withdrawVolumeUsd)}</span>
@@ -285,7 +278,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
 
                       {/* Total Txns */}
                       <TableCell
-                        className="px-2 py-3 text-center"
+                        className="text-center"
                         style={{ minWidth: '100px' }}
                       >
                         <span className="text-sm">{marketStats.totalCount.toLocaleString()}</span>
@@ -293,7 +286,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
 
                       {/* Supply Txns */}
                       <TableCell
-                        className="px-2 py-3 text-center"
+                        className="text-center"
                         style={{ minWidth: '100px' }}
                       >
                         <span className="text-sm">{marketStats.supplyCount.toLocaleString()}</span>
@@ -301,7 +294,7 @@ export function StatsMarketTable({ transactions, isLoading }: StatsMarketTablePr
 
                       {/* Withdraw Txns */}
                       <TableCell
-                        className="px-2 py-3 text-center"
+                        className="text-center"
                         style={{ minWidth: '100px' }}
                       >
                         <span className="text-sm">{marketStats.withdrawCount.toLocaleString()}</span>

--- a/src/features/admin-v2/components/stats-transactions-table.tsx
+++ b/src/features/admin-v2/components/stats-transactions-table.tsx
@@ -51,9 +51,8 @@ function getTypeFilterLabel(selectedTypes: ('supply' | 'withdraw')[]): string {
 function SortableHeader({ label, sortKeyValue, currentSortKey, sortDirection, onSort }: SortableHeaderProps) {
   return (
     <TableHead
-      className={`whitespace-nowrap px-2 py-2 font-normal ${currentSortKey === sortKeyValue ? 'text-primary' : ''}`}
+      className={`font-normal ${currentSortKey === sortKeyValue ? 'text-primary' : ''}`}
       onClick={() => onSort(sortKeyValue)}
-      style={{ padding: '0.5rem' }}
     >
       <div className="flex cursor-pointer items-center justify-center gap-1 hover:text-primary">
         <div>{label}</div>
@@ -227,11 +226,11 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
             <Table className="responsive w-full min-w-full rounded-md font-zen">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Chain</TableHead>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Type</TableHead>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">User</TableHead>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Asset</TableHead>
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Market</TableHead>
+                  <TableHead className="font-normal">Chain</TableHead>
+                  <TableHead className="font-normal">Type</TableHead>
+                  <TableHead className="font-normal">User</TableHead>
+                  <TableHead className="font-normal">Asset</TableHead>
+                  <TableHead className="font-normal">Market</TableHead>
                   <SortableHeader
                     label="Amount (USD)"
                     sortKeyValue="usdValue"
@@ -239,7 +238,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                     sortDirection={sortDirection}
                     onSort={handleSort}
                   />
-                  <TableHead className="whitespace-nowrap px-2 py-2 font-normal">Tx Hash</TableHead>
+                  <TableHead className="font-normal">Tx Hash</TableHead>
                   <SortableHeader
                     label="Time"
                     sortKeyValue="timestamp"
@@ -261,10 +260,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       className="hover:bg-hovered"
                     >
                       {/* Chain */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '100px' }}
-                      >
+                      <TableCell style={{ minWidth: '100px' }}>
                         <div className="flex items-center gap-2">
                           {networkImg && (
                             <Image
@@ -280,10 +276,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       </TableCell>
 
                       {/* Type */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '80px' }}
-                      >
+                      <TableCell style={{ minWidth: '80px' }}>
                         <span
                           className={`inline-flex items-center rounded bg-hovered px-2 py-1 text-xs ${
                             tx.type === 'supply' ? 'text-green-500' : 'text-red-500'
@@ -294,10 +287,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       </TableCell>
 
                       {/* User */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '140px' }}
-                      >
+                      <TableCell style={{ minWidth: '140px' }}>
                         <AccountIdentity
                           address={tx.onBehalf as Address}
                           chainId={tx.chainId}
@@ -307,10 +297,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       </TableCell>
 
                       {/* Asset */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '100px' }}
-                      >
+                      <TableCell style={{ minWidth: '100px' }}>
                         <div className="flex items-center gap-1.5">
                           {tx.market && (
                             <TokenIcon
@@ -326,10 +313,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       </TableCell>
 
                       {/* Market */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '200px' }}
-                      >
+                      <TableCell style={{ minWidth: '200px' }}>
                         {tx.market && marketPath ? (
                           <Link
                             href={marketPath}
@@ -358,7 +342,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
 
                       {/* Amount (USD) */}
                       <TableCell
-                        className="px-2 py-3 text-right"
+                        className="text-right"
                         style={{ minWidth: '120px' }}
                       >
                         <span className="tabular-nums text-sm">
@@ -370,10 +354,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       </TableCell>
 
                       {/* Tx Hash */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '120px' }}
-                      >
+                      <TableCell style={{ minWidth: '120px' }}>
                         <TransactionIdentity
                           txHash={tx.txHash}
                           chainId={tx.chainId as SupportedNetworks}
@@ -381,10 +362,7 @@ export function StatsTransactionsTable({ transactions, isLoading }: StatsTransac
                       </TableCell>
 
                       {/* Time */}
-                      <TableCell
-                        className="px-2 py-3"
-                        style={{ minWidth: '90px' }}
-                      >
+                      <TableCell style={{ minWidth: '90px' }}>
                         <span className="whitespace-nowrap text-xs text-secondary">{moment.unix(tx.timestamp).fromNow()}</span>
                       </TableCell>
                     </TableRow>

--- a/src/features/analysis/analysis-view.tsx
+++ b/src/features/analysis/analysis-view.tsx
@@ -1013,16 +1013,16 @@ function MarketExposureTable({
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-10 whitespace-nowrap px-3 py-3 text-center font-normal">Chain</TableHead>
-              <TableHead className="whitespace-nowrap px-4 py-3 font-normal">Market</TableHead>
-              <TableHead className="whitespace-nowrap px-4 py-3 text-right font-normal">{usdHeader}</TableHead>
-              <TableHead className="whitespace-nowrap px-4 py-3 text-right font-normal">{amountHeader}</TableHead>
+              <TableHead className="w-10 text-center font-normal">Chain</TableHead>
+              <TableHead className="font-normal">Market</TableHead>
+              <TableHead className="text-right font-normal">{usdHeader}</TableHead>
+              <TableHead className="text-right font-normal">{amountHeader}</TableHead>
               {showFeeds ? (
-                <TableHead className="whitespace-nowrap px-4 py-3 font-normal">Feeds</TableHead>
+                <TableHead className="font-normal">Feeds</TableHead>
               ) : (
-                <TableHead className="whitespace-nowrap px-4 py-3 text-center font-normal">Oracle</TableHead>
+                <TableHead className="text-center font-normal">Oracle</TableHead>
               )}
-              {showAssumptions && <TableHead className="whitespace-nowrap px-4 py-3 font-normal">{riskColumnHeader}</TableHead>}
+              {showAssumptions && <TableHead className="font-normal">{riskColumnHeader}</TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody className="text-sm">
@@ -1032,7 +1032,7 @@ function MarketExposureTable({
 
               return (
                 <TableRow key={row.id}>
-                  <TableCell className="px-3 py-3 text-center">
+                  <TableCell className="text-center">
                     <Tooltip content={<span className="text-xs">{getNetworkName(row.chainId) ?? row.chainId}</span>}>
                       <span className="inline-flex items-center justify-center">
                         <NetworkIcon
@@ -1042,7 +1042,7 @@ function MarketExposureTable({
                       </span>
                     </Tooltip>
                   </TableCell>
-                  <TableCell className="px-4 py-3">
+                  <TableCell>
                     <Link
                       href={getMarketHref(row)}
                       className="no-underline"
@@ -1058,16 +1058,16 @@ function MarketExposureTable({
                       />
                     </Link>
                   </TableCell>
-                  <TableCell className="px-4 py-3 text-right tabular-nums">
+                  <TableCell className="text-right tabular-nums">
                     <UsdWithPercent
                       valueUsd={forceSupplyAmounts ? row.supplyUsd : row.exposureUsd}
                       totalUsd={totalUsd}
                     />
                   </TableCell>
-                  <TableCell className="whitespace-nowrap px-4 py-3 text-right tabular-nums">
+                  <TableCell className="whitespace-nowrap text-right tabular-nums">
                     {formatLoanAssetAmount(row, exposureMetric, forceSupplyAmounts)}
                   </TableCell>
-                  <TableCell className={cn('px-4 py-3', !showFeeds && 'text-center')}>
+                  <TableCell className={cn(!showFeeds && 'text-center')}>
                     {showFeeds ? (
                       <OracleFeedsCell
                         row={row}
@@ -1080,7 +1080,7 @@ function MarketExposureTable({
                     )}
                   </TableCell>
                   {showAssumptions && (
-                    <TableCell className={cn('max-w-[260px] px-4 py-3', centerRiskCell && 'text-center')}>
+                    <TableCell className={cn('max-w-[260px]', centerRiskCell && 'text-center')}>
                       {assumptionMode === 'vault' ? <VaultDependencyBadges row={row} /> : <AssumptionBadges assumptions={assumptions} />}
                     </TableCell>
                   )}

--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -416,10 +416,10 @@ export function OracleCoverageSection({ occurrences, chainId }: { occurrences: F
           <Table>
             <TableHeader>
               <TableRow className="border-b text-left text-xs text-secondary">
-                <TableHead className="px-3 py-2">Oracle</TableHead>
-                <TableHead className="px-3 py-2">Type</TableHead>
-                <TableHead className="px-3 py-2">Upgradeability</TableHead>
-                <TableHead className="px-3 py-2 text-right">Last scanned</TableHead>
+                <TableHead>Oracle</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Upgradeability</TableHead>
+                <TableHead className="text-right">Last scanned</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody className="table-body-compact text-sm">
@@ -486,11 +486,11 @@ export function MarketsSection({ dependencies, chainId }: { dependencies: FeedMa
             </colgroup>
             <TableHeader>
               <TableRow className="border-b text-left text-xs text-secondary">
-                <TableHead className="min-w-[15rem] px-3 py-2">Market</TableHead>
-                <TableHead className="px-3 py-2 text-center align-middle">Supplied</TableHead>
-                <TableHead className="px-3 py-2 text-center align-middle">Borrowed</TableHead>
-                <TableHead className="px-3 py-2 text-right">Utilization</TableHead>
-                <TableHead className="px-3 py-2 text-right">Market ID</TableHead>
+                <TableHead className="min-w-[15rem]">Market</TableHead>
+                <TableHead className="text-center align-middle">Supplied</TableHead>
+                <TableHead className="text-center align-middle">Borrowed</TableHead>
+                <TableHead className="text-right">Utilization</TableHead>
+                <TableHead className="text-right">Market ID</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody className="table-body-compact text-sm">
@@ -509,10 +509,10 @@ export function MarketsSection({ dependencies, chainId }: { dependencies: FeedMa
                       showLltv
                     />
                   </TableCell>
-                  <TableCell className="px-3 py-2 text-center align-middle tabular-nums whitespace-nowrap">
+                  <TableCell className="text-center align-middle tabular-nums whitespace-nowrap">
                     {formatUsdCompact(market.state.supplyAssetsUsd)}
                   </TableCell>
-                  <TableCell className="px-3 py-2 text-center align-middle tabular-nums whitespace-nowrap">
+                  <TableCell className="text-center align-middle tabular-nums whitespace-nowrap">
                     {formatUsdCompact(market.state.borrowAssetsUsd)}
                   </TableCell>
                   <TableCell className="text-right tabular-nums">{formatPercentValue(market.state.utilization)}</TableCell>

--- a/src/features/market-detail/components/pro-activities-table.tsx
+++ b/src/features/market-detail/components/pro-activities-table.tsx
@@ -694,12 +694,12 @@ export function ProActivitiesTable({ chainId, market, onSwitchToBasic }: ProActi
           >
             <TableHeader>
               <TableRow className="text-secondary">
-                <TableHead className="w-[18%] px-4 py-3 text-left">ACCOUNT</TableHead>
-                <TableHead className="w-[14%] px-4 py-3 text-left">ACTION</TableHead>
-                <TableHead className="w-[18%] px-4 py-3 text-left">INTERMEDIARY</TableHead>
-                <TableHead className="w-[18%] px-4 py-3 text-right">NET FLOW</TableHead>
-                <TableHead className="w-[18%] px-4 py-3 text-left whitespace-nowrap">TIME</TableHead>
-                <TableHead className="w-[14%] px-4 py-3 text-right">TRANSACTION</TableHead>
+                <TableHead className="w-[18%] text-left">ACCOUNT</TableHead>
+                <TableHead className="w-[14%] text-left">ACTION</TableHead>
+                <TableHead className="w-[18%] text-left">INTERMEDIARY</TableHead>
+                <TableHead className="w-[18%] text-right">NET FLOW</TableHead>
+                <TableHead className="w-[18%] text-left">TIME</TableHead>
+                <TableHead className="w-[14%] text-right">TRANSACTION</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody className="table-body-compact text-sm">
@@ -735,7 +735,7 @@ export function ProActivitiesTable({ chainId, market, onSwitchToBasic }: ProActi
                   return (
                     <Fragment key={activity.id}>
                       <TableRow
-                        className="cursor-pointer hover:bg-gray-50"
+                        className="cursor-pointer hover:bg-hovered"
                         tabIndex={0}
                         aria-controls={detailRowId}
                         aria-expanded={isExpanded}
@@ -751,10 +751,7 @@ export function ProActivitiesTable({ chainId, market, onSwitchToBasic }: ProActi
                           }
                         }}
                       >
-                        <TableCell
-                          className="px-4 py-3"
-                          onClick={(event) => event.stopPropagation()}
-                        >
+                        <TableCell onClick={(event) => event.stopPropagation()}>
                           {displayActorAddress ? (
                             <AccountIdentity
                               address={displayActorAddress}
@@ -767,7 +764,7 @@ export function ProActivitiesTable({ chainId, market, onSwitchToBasic }: ProActi
                           )}
                         </TableCell>
 
-                        <TableCell className="px-4 py-3">
+                        <TableCell>
                           <Badge
                             variant={activityMeta.variant}
                             className="whitespace-nowrap"
@@ -776,10 +773,7 @@ export function ProActivitiesTable({ chainId, market, onSwitchToBasic }: ProActi
                           </Badge>
                         </TableCell>
 
-                        <TableCell
-                          className="px-4 py-3"
-                          onClick={(event) => event.stopPropagation()}
-                        >
+                        <TableCell onClick={(event) => event.stopPropagation()}>
                           {intermediaryAddress ? (
                             <AccountIdentity
                               address={intermediaryAddress}
@@ -790,14 +784,12 @@ export function ProActivitiesTable({ chainId, market, onSwitchToBasic }: ProActi
                           ) : null}
                         </TableCell>
 
-                        <TableCell className="px-4 py-3 text-right">{renderRowFlow(activity)}</TableCell>
+                        <TableCell className="text-right">{renderRowFlow(activity)}</TableCell>
 
-                        <TableCell className="px-4 py-3 text-sm whitespace-nowrap text-gray-500">
-                          {formatActivityTime(activity.timestamp)}
-                        </TableCell>
+                        <TableCell className="text-sm whitespace-nowrap text-gray-500">{formatActivityTime(activity.timestamp)}</TableCell>
 
                         <TableCell
-                          className="px-4 py-3 text-right"
+                          className="text-right"
                           onClick={(event) => event.stopPropagation()}
                         >
                           <TransactionIdentity

--- a/src/features/markets/components/markets-table-same-loan.tsx
+++ b/src/features/markets/components/markets-table-same-loan.tsx
@@ -90,9 +90,8 @@ function HTSortable({
   const isSorting = sortColumn === column;
   return (
     <th
-      className={`cursor-pointer select-none text-center font-normal px-2 py-2 ${isSorting ? 'text-primary' : ''}`}
+      className={`cursor-pointer select-none text-center font-normal ${isSorting ? 'text-primary' : ''}`}
       onClick={() => onSort(column)}
-      style={{ padding: '0.5rem', paddingTop: '1rem', paddingBottom: '1rem' }}
     >
       <div className="flex items-center justify-center gap-1">
         <div>{label}</div>
@@ -144,7 +143,7 @@ function MarketRow({
       }}
     >
       {showSelectColumn && (
-        <td className="z-50 py-1">
+        <td className="z-50">
           <div className="flex items-center justify-center">
             <Checkbox
               checked={isSelected}
@@ -157,7 +156,7 @@ function MarketRow({
         </td>
       )}
       <td
-        className="z-50 py-1 text-center"
+        className="z-50 text-center"
         style={{ minWidth: '80px' }}
       >
         <MarketIdBadge
@@ -166,7 +165,7 @@ function MarketRow({
         />
       </td>
       <td
-        className="z-50 py-1 pl-4"
+        className="z-50"
         style={{ minWidth: '240px' }}
       >
         <MarketIdentity
@@ -183,7 +182,7 @@ function MarketRow({
       {columnVisibility.trustedBy && (
         <td
           data-label="Trusted By"
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '110px' }}
         >
           <TrustedByCell vaults={trustedVaults} />
@@ -192,7 +191,7 @@ function MarketRow({
       {columnVisibility.totalSupply && (
         <td
           data-label="Total Supply"
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '120px' }}
         >
           <p className="text-xs">{formatAmountDisplay(market.state.supplyAssets, market.loanAsset.decimals)}</p>
@@ -201,7 +200,7 @@ function MarketRow({
       {columnVisibility.totalBorrow && (
         <td
           data-label="Total Borrow"
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '120px' }}
         >
           <p className="text-xs">{formatAmountDisplay(market.state.borrowAssets, market.loanAsset.decimals)}</p>
@@ -210,7 +209,7 @@ function MarketRow({
       {columnVisibility.liquidity && (
         <td
           data-label="Liquidity"
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '120px' }}
         >
           <p className="text-xs">{formatAmountDisplay(market.state.liquidityAssets, market.loanAsset.decimals)}</p>
@@ -219,7 +218,7 @@ function MarketRow({
       {columnVisibility.supplyAPY && (
         <td
           data-label={supplyRateLabel}
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '100px' }}
         >
           <div className="flex items-center justify-center">
@@ -235,7 +234,7 @@ function MarketRow({
       {columnVisibility.borrowAPY && (
         <td
           data-label={borrowRateLabel}
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '100px' }}
         >
           <p className="text-sm">
@@ -248,7 +247,7 @@ function MarketRow({
       {columnVisibility.rateAtTarget && (
         <td
           data-label="Target Rate"
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '110px' }}
         >
           <p className="text-sm">
@@ -261,7 +260,7 @@ function MarketRow({
       {columnVisibility.utilizationRate && (
         <td
           data-label="Utilization"
-          className="z-50 py-1 text-center"
+          className="z-50 text-center"
           style={{ minWidth: '100px' }}
         >
           <p className="text-sm">{`${(market.state.utilization * 100).toFixed(2)}%`}</p>
@@ -269,7 +268,7 @@ function MarketRow({
       )}
       <td
         data-label="Indicators"
-        className="z-50 py-1 text-center"
+        className="z-50 text-center"
         style={{ minWidth: '100px' }}
       >
         <MarketIndicators
@@ -589,28 +588,8 @@ export function MarketsTableWithSameLoanAsset({
           <table className="responsive rounded-md font-zen text-sm">
             <thead className="">
               <tr>
-                {showSelectColumn && (
-                  <th
-                    className="text-center font-normal px-2 py-2"
-                    style={{
-                      padding: '0.5rem',
-                      paddingTop: '1rem',
-                      paddingBottom: '1rem',
-                    }}
-                  >
-                    Select
-                  </th>
-                )}
-                <th
-                  className="text-center font-normal px-2 py-2"
-                  style={{
-                    padding: '0.5rem',
-                    paddingTop: '1rem',
-                    paddingBottom: '1rem',
-                  }}
-                >
-                  Id
-                </th>
+                {showSelectColumn && <th className="text-center font-normal">Select</th>}
+                <th className="text-center font-normal">Id</th>
                 <HTSortable
                   label="Market"
                   column={SortColumn.COLLATSYMBOL}
@@ -618,14 +597,7 @@ export function MarketsTableWithSameLoanAsset({
                   sortDirection={sortDirection}
                   onSort={handleSort}
                 />
-                {columnVisibility.trustedBy && (
-                  <th
-                    className="text-center font-normal px-2 py-2"
-                    style={{ padding: '0.5rem', paddingTop: '1rem', paddingBottom: '1rem' }}
-                  >
-                    Trusted By
-                  </th>
-                )}
+                {columnVisibility.trustedBy && <th className="text-center font-normal">Trusted By</th>}
                 {columnVisibility.totalSupply && (
                   <HTSortable
                     label="Total Supply"
@@ -689,12 +661,7 @@ export function MarketsTableWithSameLoanAsset({
                     onSort={handleSort}
                   />
                 )}
-                <th
-                  className="text-center font-normal px-2 py-2"
-                  style={{ padding: '0.5rem' }}
-                >
-                  Indicators
-                </th>
+                <th className="text-center font-normal">Indicators</th>
               </tr>
             </thead>
             <tbody>

--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -164,7 +164,7 @@ export function MarketTableBody({
               <TableCell
                 data-label="LLTV"
                 className="z-50"
-                style={{ minWidth: '60px', padding: 5 }}
+                style={{ minWidth: '60px' }}
               >
                 {Number(item.lltv) / 1e16}%
               </TableCell>
@@ -172,7 +172,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="Trusted By"
                   className="z-50 text-center"
-                  style={{ minWidth: '110px', paddingLeft: 6, paddingRight: 6 }}
+                  style={{ minWidth: '110px' }}
                 >
                   <TrustedByCell vaults={getTrustedVaultsForMarket(item, trustedVaultMap, v2SupplyingVaultsLookup)} />
                 </TableCell>
@@ -211,7 +211,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label={supplyRateLabel}
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <APYCell market={item} />
                 </TableCell>
@@ -220,7 +220,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label={borrowRateLabel}
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <p className="text-sm">
                     {item.state.borrowApy == null ? (
@@ -238,7 +238,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="Target Rate"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">
                     {item.state.apyAtTarget == null ? (
@@ -257,7 +257,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="Utilization"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <p className="text-sm">{`${(item.state.utilization * 100).toFixed(2)}%`}</p>
                 </TableCell>
@@ -266,7 +266,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="24h Supply"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">{renderHistoricalRateCell(item, 'dailySupplyApy')}</div>
                 </TableCell>
@@ -275,7 +275,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="24h Borrow"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">{renderHistoricalRateCell(item, 'dailyBorrowApy')}</div>
                 </TableCell>
@@ -284,7 +284,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="7d Supply"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">{renderHistoricalRateCell(item, 'weeklySupplyApy')}</div>
                 </TableCell>
@@ -293,7 +293,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="7d Borrow"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">{renderHistoricalRateCell(item, 'weeklyBorrowApy')}</div>
                 </TableCell>
@@ -302,7 +302,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="30d Supply"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">{renderHistoricalRateCell(item, 'monthlySupplyApy')}</div>
                 </TableCell>
@@ -311,7 +311,7 @@ export function MarketTableBody({
                 <TableCell
                   data-label="30d Borrow"
                   className="z-50 text-center"
-                  style={{ minWidth: '85px', paddingLeft: 3, paddingRight: 3 }}
+                  style={{ minWidth: '85px' }}
                 >
                   <div className="flex justify-center text-sm">{renderHistoricalRateCell(item, 'monthlyBorrowApy')}</div>
                 </TableCell>
@@ -322,7 +322,7 @@ export function MarketTableBody({
               <TableCell
                 data-label="Indicators"
                 className="z-50"
-                style={{ maxWidth: '40px', padding: 0 }}
+                style={{ maxWidth: '40px' }}
               >
                 <MarketIndicators
                   market={item}
@@ -331,7 +331,7 @@ export function MarketTableBody({
               </TableCell>
               <TableCell
                 data-label="Actions"
-                className="justify-center px-4 py-3"
+                className="text-center"
               >
                 <div className="flex items-center justify-center">
                   <MarketActionsDropdown market={item} />

--- a/src/features/markets/components/table/market-table-utils.tsx
+++ b/src/features/markets/components/table/market-table-utils.tsx
@@ -20,9 +20,8 @@ export function HTSortable({ label, sortColumn, titleOnclick, sortDirection, tar
 
   return (
     <TableHead
-      className={`px-2 py-1 ${sortingCurrent ? 'text-primary' : ''}`}
+      className={sortingCurrent ? 'text-primary' : ''}
       onClick={() => titleOnclick(targetColumn)}
-      style={{ padding: '0.5rem' }}
     >
       <div className="flex items-center justify-center gap-1 font-normal hover:cursor-pointer whitespace-nowrap">
         <div>{label}</div>

--- a/src/features/markets/components/table/markets-table.tsx
+++ b/src/features/markets/components/table/markets-table.tsx
@@ -180,7 +180,7 @@ function MarketsTable({
                   targetColumn={SortColumn.Starred}
                   showDirection={false}
                 />
-                <TableHead className="font-normal px-2 py-2 whitespace-nowrap"> Id </TableHead>
+                <TableHead className="font-normal"> Id </TableHead>
                 <HTSortable
                   label="Loan"
                   sortColumn={sortColumn}
@@ -195,7 +195,7 @@ function MarketsTable({
                   sortDirection={sortDirection}
                   targetColumn={SortColumn.CollateralAsset}
                 />
-                <TableHead className="font-normal px-2 py-2 whitespace-nowrap">Oracle</TableHead>
+                <TableHead className="font-normal">Oracle</TableHead>
                 <HTSortable
                   label="LLTV"
                   sortColumn={sortColumn}
@@ -203,7 +203,7 @@ function MarketsTable({
                   sortDirection={sortDirection}
                   targetColumn={SortColumn.LLTV}
                 />
-                {columnVisibility.trustedBy && <TableHead className="font-normal px-2 py-2 whitespace-nowrap">Trusted By</TableHead>}
+                {columnVisibility.trustedBy && <TableHead className="font-normal">Trusted By</TableHead>}
                 {columnVisibility.totalSupply && (
                   <HTSortable
                     label="Total Supply"
@@ -321,27 +321,9 @@ function MarketsTable({
                     targetColumn={SortColumn.MonthlyBorrowAPY}
                   />
                 )}
-                <TableHead
-                  className="font-normal px-2 py-2 whitespace-nowrap"
-                  style={{ padding: '0.35rem 0.8rem' }}
-                >
-                  {' '}
-                  Risk{' '}
-                </TableHead>
-                <TableHead
-                  className="font-normal px-2 py-2 whitespace-nowrap"
-                  style={{ padding: '0.35rem 0.8rem' }}
-                >
-                  {' '}
-                  Indicators{' '}
-                </TableHead>
-                <TableHead
-                  className="font-normal px-2 py-2 whitespace-nowrap"
-                  style={{ padding: '0.35rem 0.8rem' }}
-                >
-                  {' '}
-                  Actions{' '}
-                </TableHead>
+                <TableHead className="font-normal"> Risk </TableHead>
+                <TableHead className="font-normal"> Indicators </TableHead>
+                <TableHead className="font-normal"> Actions </TableHead>
               </TableRow>
             </TableHeader>
             <MarketTableBody

--- a/src/features/position-detail/components/history-tab.tsx
+++ b/src/features/position-detail/components/history-tab.tsx
@@ -149,24 +149,18 @@ export function HistoryTab({
   const renderSkeletonRows = (count = 8) => {
     return Array.from({ length: count }).map((_, idx) => (
       <TableRow key={`skeleton-${idx}`}>
-        <TableCell
-          className="px-4 py-3"
-          style={{ minWidth: '100px' }}
-        >
+        <TableCell style={{ minWidth: '100px' }}>
           <div className="flex justify-start">
             <div className="bg-hovered h-6 w-16 rounded animate-pulse" />
           </div>
         </TableCell>
-        <TableCell
-          className="px-4 py-3"
-          style={{ minWidth: '200px' }}
-        >
+        <TableCell style={{ minWidth: '200px' }}>
           <div className="flex items-center justify-start gap-2">
             <div className="bg-hovered h-4 w-32 rounded animate-pulse" />
           </div>
         </TableCell>
         <TableCell
-          className="px-4 py-3 text-right"
+          className="text-right"
           style={{ minWidth: '120px' }}
         >
           <div className="flex justify-end">
@@ -174,7 +168,7 @@ export function HistoryTab({
           </div>
         </TableCell>
         <TableCell
-          className="px-4 py-3 text-center"
+          className="text-center"
           style={{ minWidth: '120px' }}
         >
           <div className="flex justify-center">
@@ -182,7 +176,7 @@ export function HistoryTab({
           </div>
         </TableCell>
         <TableCell
-          className="px-4 py-3 text-right"
+          className="text-right"
           style={{ minWidth: '90px' }}
         >
           <div className="flex justify-end">
@@ -286,31 +280,31 @@ export function HistoryTab({
           <TableHeader>
             <TableRow className="text-secondary">
               <TableHead
-                className="px-4 py-3 text-left"
+                className="text-left"
                 style={{ minWidth: '100px' }}
               >
                 Action
               </TableHead>
               <TableHead
-                className="px-4 py-3 text-left"
+                className="text-left"
                 style={{ minWidth: '200px' }}
               >
                 Market
               </TableHead>
               <TableHead
-                className="px-4 py-3 text-right"
+                className="text-right"
                 style={{ minWidth: '120px' }}
               >
                 Amount
               </TableHead>
               <TableHead
-                className="px-4 py-3 text-center"
+                className="text-center"
                 style={{ minWidth: '120px' }}
               >
                 Tx Hash
               </TableHead>
               <TableHead
-                className="px-4 py-3 text-right"
+                className="text-right"
                 style={{ minWidth: '90px' }}
               >
                 Time
@@ -324,7 +318,7 @@ export function HistoryTab({
               <TableRow>
                 <TableCell
                   colSpan={5}
-                  className="px-4 py-3 text-center text-gray-400"
+                  className="text-center text-gray-400"
                 >
                   No transactions found
                 </TableCell>
@@ -347,17 +341,11 @@ export function HistoryTab({
                     key={`${tx.hash}-${index}`}
                     className="hover:bg-hovered"
                   >
-                    <TableCell
-                      className="px-4 py-3"
-                      style={{ minWidth: '100px' }}
-                    >
+                    <TableCell style={{ minWidth: '100px' }}>
                       <span className={`inline-flex items-center rounded bg-hovered px-2 py-1 text-xs ${actionClass}`}>{actionLabel}</span>
                     </TableCell>
 
-                    <TableCell
-                      className="px-4 py-3"
-                      style={{ minWidth: '200px' }}
-                    >
+                    <TableCell style={{ minWidth: '200px' }}>
                       <div className="flex items-center justify-start gap-2">
                         <MarketIdentity
                           market={market}
@@ -373,7 +361,7 @@ export function HistoryTab({
                     </TableCell>
 
                     <TableCell
-                      className="px-4 py-3 text-right"
+                      className="text-right"
                       style={{ minWidth: '120px' }}
                     >
                       <div className="flex items-center justify-end gap-1.5 text-sm">
@@ -391,10 +379,7 @@ export function HistoryTab({
                       </div>
                     </TableCell>
 
-                    <TableCell
-                      className="px-4 py-3"
-                      style={{ minWidth: '120px' }}
-                    >
+                    <TableCell style={{ minWidth: '120px' }}>
                       <div className="flex justify-center">
                         <TransactionIdentity
                           txHash={tx.hash}
@@ -404,7 +389,7 @@ export function HistoryTab({
                     </TableCell>
 
                     <TableCell
-                      className="px-4 py-3 text-right"
+                      className="text-right"
                       style={{ minWidth: '90px' }}
                     >
                       <span className="text-xs text-secondary whitespace-nowrap">{moment.unix(tx.timestamp).fromNow()}</span>

--- a/src/features/position-detail/components/markets-breakdown-table.tsx
+++ b/src/features/position-detail/components/markets-breakdown-table.tsx
@@ -151,10 +151,7 @@ function MarketRow({
   return (
     <TableRow className="hover:bg-hovered">
       {/* Market */}
-      <TableCell
-        className="px-4 py-3"
-        style={{ minWidth: '200px' }}
-      >
+      <TableCell style={{ minWidth: '200px' }}>
         <MarketIdentity
           market={market}
           chainId={chainId}
@@ -169,7 +166,7 @@ function MarketRow({
 
       {/* Supply Amount */}
       <TableCell
-        className="px-4 py-3 text-right"
+        className="text-right"
         style={{ minWidth: '120px' }}
       >
         <div className="flex items-center justify-end gap-1.5">
@@ -186,7 +183,7 @@ function MarketRow({
 
       {/* Actual APY (from earnings) */}
       <TableCell
-        className="px-4 py-3 text-right"
+        className="text-right"
         style={{ minWidth: '90px' }}
       >
         {isEarningsLoading ? (
@@ -206,7 +203,7 @@ function MarketRow({
 
       {/* Interest Earned */}
       <TableCell
-        className="px-4 py-3 text-right"
+        className="text-right"
         style={{ minWidth: '110px' }}
       >
         {isEarningsLoading ? (
@@ -238,7 +235,7 @@ function MarketRow({
 
       {/* Net Flow */}
       <TableCell
-        className="px-4 py-3 text-right"
+        className="text-right"
         style={{ minWidth: '140px' }}
       >
         {flowDisplay}
@@ -246,7 +243,7 @@ function MarketRow({
 
       {/* Time-weighted share */}
       <TableCell
-        className="px-4 py-3 text-right"
+        className="text-right"
         style={{ minWidth: '120px' }}
       >
         {weightDisplay}
@@ -254,7 +251,7 @@ function MarketRow({
 
       {/* Actions */}
       <TableCell
-        className="px-4 py-3 text-right"
+        className="text-right"
         style={{ minWidth: '180px' }}
       >
         <MarketActionsCell
@@ -331,19 +328,19 @@ export function MarketsBreakdownTable({
         <TableHeader>
           <TableRow className="text-secondary">
             <TableHead
-              className="px-4 py-3 text-left"
+              className="text-left"
               style={{ minWidth: '200px' }}
             >
               Market
             </TableHead>
             <TableHead
-              className="px-4 py-3 text-right"
+              className="text-right"
               style={{ minWidth: '120px' }}
             >
               Supply
             </TableHead>
             <TableHead
-              className="px-4 py-3 text-right"
+              className="text-right"
               style={{ minWidth: '90px' }}
             >
               <Tooltip
@@ -360,7 +357,7 @@ export function MarketsBreakdownTable({
               </Tooltip>
             </TableHead>
             <TableHead
-              className="px-4 py-3 text-right"
+              className="text-right"
               style={{ minWidth: '110px' }}
             >
               <Tooltip
@@ -384,7 +381,7 @@ export function MarketsBreakdownTable({
               </Tooltip>
             </TableHead>
             <TableHead
-              className="px-4 py-3 text-right"
+              className="text-right"
               style={{ minWidth: '140px' }}
             >
               <Tooltip
@@ -401,7 +398,7 @@ export function MarketsBreakdownTable({
               </Tooltip>
             </TableHead>
             <TableHead
-              className="px-4 py-3 text-right"
+              className="text-right"
               style={{ minWidth: '120px' }}
             >
               <Tooltip
@@ -418,7 +415,7 @@ export function MarketsBreakdownTable({
               </Tooltip>
             </TableHead>
             <TableHead
-              className="px-4 py-3 text-right"
+              className="text-right"
               style={{ minWidth: '180px' }}
             >
               Actions

--- a/src/features/positions/components/borrowed-morpho-blue-table.tsx
+++ b/src/features/positions/components/borrowed-morpho-blue-table.tsx
@@ -125,7 +125,7 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
               <TableHead>Actions</TableHead>
             </TableRow>
           </TableHeader>
-          <TableBody className="text-sm">
+          <TableBody className="table-body-compact text-sm">
             {borrowRows.map((row) => {
               const rowKey = `${row.market.uniqueKey}-${row.market.morphoBlue.chain.id}`;
               const detailRowId = `${rowKey}-detail`;
@@ -135,7 +135,7 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
               return (
                 <Fragment key={rowKey}>
                   <TableRow
-                    className="cursor-pointer hover:bg-gray-50"
+                    className="cursor-pointer hover:bg-hovered"
                     tabIndex={0}
                     aria-controls={detailRowId}
                     aria-expanded={isExpanded}
@@ -256,7 +256,7 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
 
                     <TableCell
                       data-label="Actions"
-                      className="justify-center px-4 py-3"
+                      className="text-center"
                       onClick={(event) => event.stopPropagation()}
                     >
                       <div className="flex items-center justify-center">

--- a/src/features/positions/components/from-markets-table.tsx
+++ b/src/features/positions/components/from-markets-table.tsx
@@ -57,13 +57,13 @@ export function FromMarketsTable({ positions, selectedMarketUniqueKey, onSelectM
               </colgroup>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="px-4 py-2 text-left">Market</TableHead>
-                  <TableHead className="px-4 py-2 text-right">{rateLabel}</TableHead>
-                  <TableHead className="px-4 py-2 text-right">Util</TableHead>
-                  <TableHead className="px-4 py-2 text-left">Supplied Amount</TableHead>
+                  <TableHead className="text-left">Market</TableHead>
+                  <TableHead className="text-right">{rateLabel}</TableHead>
+                  <TableHead className="text-right">Util</TableHead>
+                  <TableHead className="text-left">Supplied Amount</TableHead>
                 </TableRow>
               </TableHeader>
-              <TableBody>
+              <TableBody className="text-sm">
                 {paginatedPositions.map((position) => {
                   const userConfirmedSupply = BigInt(position.state.supplyAssets);
                   const userNetSupply = userConfirmedSupply + position.pendingDelta;
@@ -79,11 +79,11 @@ export function FromMarketsTable({ positions, selectedMarketUniqueKey, onSelectM
                     <TableRow
                       key={position.market.uniqueKey}
                       onClick={() => onSelectMarket(position.market.uniqueKey)}
-                      className={`cursor-pointer border-b border-l-2 border-l-transparent border-gray-200 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 ${
+                      className={`cursor-pointer border-b border-l-2 border-l-transparent border-gray-200 transition-colors hover:bg-hovered dark:border-gray-700 ${
                         isSelected ? 'bg-primary/5 border-l-primary' : ''
                       }`}
                     >
-                      <TableCell className="px-4 py-2">
+                      <TableCell>
                         <div className="flex items-center justify-start">
                           <MarketIdentity
                             market={position.market}
@@ -98,7 +98,7 @@ export function FromMarketsTable({ positions, selectedMarketUniqueKey, onSelectM
                           />
                         </div>
                       </TableCell>
-                      <TableCell className="px-4 py-2 text-right">
+                      <TableCell className="text-right">
                         {apyPreview ? (
                           <span className="whitespace-nowrap text-sm text-foreground">
                             <span className="line-through opacity-50">
@@ -121,7 +121,7 @@ export function FromMarketsTable({ positions, selectedMarketUniqueKey, onSelectM
                           </span>
                         )}
                       </TableCell>
-                      <TableCell className="px-4 py-2 text-right">
+                      <TableCell className="text-right">
                         {apyPreview ? (
                           <span className="whitespace-nowrap text-sm text-foreground">
                             <span className="line-through opacity-50">{formatReadable(position.market.state.utilization * 100)}%</span>
@@ -134,7 +134,7 @@ export function FromMarketsTable({ positions, selectedMarketUniqueKey, onSelectM
                           </span>
                         )}
                       </TableCell>
-                      <TableCell className="px-4 py-2">
+                      <TableCell>
                         <div className="flex items-center gap-2 justify-end">
                           <div>
                             {formatReadable(

--- a/src/features/positions/components/portfolio-analytics-banner.tsx
+++ b/src/features/positions/components/portfolio-analytics-banner.tsx
@@ -35,7 +35,7 @@ interface PortfolioAnalyticsBannerProps {
   onSwap: () => void;
 }
 
-const METRIC_VALUE_CLASS = 'font-zen text-xl font-normal leading-none tabular-nums text-primary';
+const METRIC_VALUE_CLASS = 'font-zen text-[1.375rem] font-normal leading-none tabular-nums text-primary';
 
 function formatRate(value: number | null): string {
   if (value === null || !Number.isFinite(value)) {
@@ -146,7 +146,7 @@ function PortfolioMetricBox({
   tooltip?: ReactNode;
 }) {
   const content = (
-    <div className="flex h-full min-h-[5.5rem] min-w-0 flex-col rounded border border-border bg-surface px-3 py-2.5 shadow-[0_1px_1px_rgb(0_0_0_/_0.025)] dark:shadow-none">
+    <div className="flex h-full min-h-[5.25rem] min-w-0 flex-col rounded border border-border bg-surface px-4 py-3 shadow-[0_1px_1px_rgb(0_0_0_/_0.025)] dark:shadow-none">
       <div className="flex min-w-0 items-center justify-between gap-2">
         <span className="truncate font-monospace text-[10px] uppercase leading-4 tracking-[0.14em] text-secondary">{label}</span>
         {action}
@@ -165,7 +165,7 @@ function PortfolioMetricBox({
         )}
       </div>
       {caption ? (
-        <span className="mt-1 break-words text-xs leading-4 text-secondary">{caption}</span>
+        <span className="mt-1 break-words text-[11px] leading-4 text-secondary">{caption}</span>
       ) : (
         <span
           className="mt-1 min-h-4"
@@ -241,7 +241,7 @@ export function PortfolioAnalyticsBanner({
           variant="primary"
           onClick={onSwap}
           title="Swap tokens"
-          className="shrink-0 self-start"
+          className="hidden h-9 shrink-0 self-start sm:inline-flex"
         >
           <IoIosSwap className="h-4 w-4" />
           Swap
@@ -249,7 +249,7 @@ export function PortfolioAnalyticsBanner({
       </div>
 
       {showPortfolioStats && (
-        <div className="grid w-full min-w-0 grid-cols-1 items-stretch gap-2 sm:grid-cols-3">
+        <div className="grid w-full min-w-0 grid-cols-1 items-stretch gap-2 sm:grid-cols-[1.08fr_0.92fr_0.92fr]">
           <PortfolioMetricBox
             label="TOTAL DEPOSIT"
             value={formatUsdValue(totalUsd)}

--- a/src/features/positions/components/supplied-markets-detail.tsx
+++ b/src/features/positions/components/supplied-markets-detail.tsx
@@ -116,7 +116,7 @@ function MarketRow({
       </TableCell>
       <TableCell
         data-label="Actions"
-        className="justify-end px-4 py-3"
+        className="text-right"
         style={{ minWidth: '180px' }}
       >
         {isOwner ? (

--- a/src/features/positions/components/supplied-morpho-blue-grouped-table.tsx
+++ b/src/features/positions/components/supplied-morpho-blue-grouped-table.tsx
@@ -207,7 +207,7 @@ function SuppliedMarketPositionsTable({
           <TableHead className="w-20">Actions</TableHead>
         </TableRow>
       </TableHeader>
-      <TableBody className="text-sm">
+      <TableBody className="table-body-compact text-sm">
         {positions.length === 0 && (
           <TableRow>
             <TableCell
@@ -228,7 +228,7 @@ function SuppliedMarketPositionsTable({
           return (
             <TableRow
               key={rowKey}
-              className="hover:bg-gray-50"
+              className="hover:bg-hovered"
             >
               <TableCell className="w-16">
                 <div className="flex items-center justify-center">
@@ -328,7 +328,7 @@ function SuppliedMarketPositionsTable({
 
               <TableCell
                 data-label="Actions"
-                className="justify-center px-4 py-3"
+                className="text-center"
               >
                 <div className="flex items-center justify-center">
                   <SuppliedMarketPositionActionsDropdown
@@ -532,7 +532,7 @@ export function SuppliedMorphoBlueGroupedTable({
                 <TableHead>Actions</TableHead>
               </TableRow>
             </TableHeader>
-            <TableBody className="text-sm">
+            <TableBody className="table-body-compact text-sm">
               {processedPositions.length === 0 && (
                 <TableRow>
                   <TableCell
@@ -553,7 +553,7 @@ export function SuppliedMorphoBlueGroupedTable({
                 return (
                   <Fragment key={rowKey}>
                     <TableRow
-                      className="cursor-pointer hover:bg-gray-50"
+                      className="cursor-pointer hover:bg-hovered"
                       onClick={() => toggleRow(rowKey)}
                     >
                       {/* Chain image */}
@@ -657,7 +657,7 @@ export function SuppliedMorphoBlueGroupedTable({
                       {/* Actions button */}
                       <TableCell
                         data-label="Actions"
-                        className="justify-center px-4 py-3"
+                        className="text-center"
                       >
                         <div className="flex items-center justify-center gap-2">
                           <PositionActionsDropdown

--- a/src/features/positions/components/user-vaults-table.tsx
+++ b/src/features/positions/components/user-vaults-table.tsx
@@ -186,7 +186,7 @@ export function UserVaultsTable({ vaults, period, isEarningsLoading = false, ref
                 return (
                   <Fragment key={rowKey}>
                     <TableRow
-                      className="cursor-pointer hover:bg-gray-50"
+                      className="cursor-pointer hover:bg-hovered"
                       onClick={() => toggleRow(rowKey)}
                     >
                       {/* Network */}

--- a/src/features/positions/components/vault-allocation-detail.tsx
+++ b/src/features/positions/components/vault-allocation-detail.tsx
@@ -148,7 +148,7 @@ export function VaultAllocationDetail({ vault }: VaultAllocationDetailProps) {
 
                   <TableCell
                     data-label="Actions"
-                    className="justify-end px-4 py-3"
+                    className="text-right"
                     style={{ minWidth: '180px' }}
                   >
                     <div className="flex items-center justify-end gap-2">

--- a/src/features/vault/components/vault-market-allocations-table.tsx
+++ b/src/features/vault/components/vault-market-allocations-table.tsx
@@ -97,12 +97,12 @@ export function VaultMarketAllocationsTable({
     <Table className="w-full font-zen">
       <TableHeader>
         <TableRow className="text-xs text-secondary">
-          <TableHead className="px-4 py-3 text-left font-normal">Market</TableHead>
-          <TableHead className="px-4 py-3 text-right font-normal">Allocation</TableHead>
+          <TableHead className="text-left font-normal">Market</TableHead>
+          <TableHead className="text-right font-normal">Allocation</TableHead>
           {isPositionMode ? (
             <>
-              <TableHead className="px-4 py-3 text-right font-normal">Liquidity</TableHead>
-              <TableHead className="px-4 py-3 text-right font-normal">
+              <TableHead className="text-right font-normal">Liquidity</TableHead>
+              <TableHead className="text-right font-normal">
                 <Tooltip
                   content={
                     <TooltipContent
@@ -117,7 +117,7 @@ export function VaultMarketAllocationsTable({
                   </span>
                 </Tooltip>
               </TableHead>
-              <TableHead className="px-4 py-3 text-right font-normal">
+              <TableHead className="text-right font-normal">
                 <Tooltip
                   content={
                     <TooltipContent
@@ -134,8 +134,8 @@ export function VaultMarketAllocationsTable({
             </>
           ) : (
             <>
-              <TableHead className="px-4 py-3 text-right font-normal">{rateLabel}</TableHead>
-              <TableHead className="px-4 py-3 text-right font-normal">Liquidity</TableHead>
+              <TableHead className="text-right font-normal">{rateLabel}</TableHead>
+              <TableHead className="text-right font-normal">Liquidity</TableHead>
             </>
           )}
         </TableRow>
@@ -164,10 +164,7 @@ export function VaultMarketAllocationsTable({
               key={`${chainId}:${market.uniqueKey}`}
               className="hover:bg-hovered"
             >
-              <TableCell
-                className="px-4 py-3"
-                style={{ minWidth: '220px' }}
-              >
+              <TableCell style={{ minWidth: '220px' }}>
                 <MarketIdentity
                   market={market}
                   chainId={chainId}
@@ -180,10 +177,7 @@ export function VaultMarketAllocationsTable({
                   showExplorerLink={showExplorerLink}
                 />
               </TableCell>
-              <TableCell
-                className="px-4 py-3"
-                style={{ minWidth: '150px' }}
-              >
+              <TableCell style={{ minWidth: '150px' }}>
                 <AllocationCell
                   amount={allocationValue}
                   symbol={assetSymbol}
@@ -196,13 +190,13 @@ export function VaultMarketAllocationsTable({
               {isPositionMode ? (
                 <>
                   <TableCell
-                    className="px-4 py-3 text-right text-xs text-secondary whitespace-nowrap"
+                    className="text-right text-xs text-secondary whitespace-nowrap"
                     style={{ minWidth: '130px' }}
                   >
                     {liquidity}
                   </TableCell>
                   <TableCell
-                    className="px-4 py-3 text-right"
+                    className="text-right"
                     style={{ minWidth: '130px' }}
                   >
                     {isEarningsLoading ? (
@@ -220,7 +214,7 @@ export function VaultMarketAllocationsTable({
                     )}
                   </TableCell>
                   <TableCell
-                    className="px-4 py-3 text-right"
+                    className="text-right"
                     style={{ minWidth: '120px' }}
                   >
                     {isEarningsLoading ? (
@@ -252,10 +246,8 @@ export function VaultMarketAllocationsTable({
                 </>
               ) : (
                 <>
-                  <TableCell className="px-4 py-3 text-right text-xs text-secondary whitespace-nowrap">
-                    {(displayRate * 100).toFixed(2)}%
-                  </TableCell>
-                  <TableCell className="px-4 py-3 text-right text-xs text-secondary whitespace-nowrap">{liquidity}</TableCell>
+                  <TableCell className="text-right text-xs text-secondary whitespace-nowrap">{(displayRate * 100).toFixed(2)}%</TableCell>
+                  <TableCell className="text-right text-xs text-secondary whitespace-nowrap">{liquidity}</TableCell>
                 </>
               )}
             </TableRow>


### PR DESCRIPTION
## Summary
- move table header/body density to the shared global table styling with a middle-density row rhythm, closer to the old Monarch table spacing
- remove one-off table padding overrides across markets, positions, market detail, analysis, rewards, feed detail, vault/autovault allocation, and admin stats tables
- tighten shared table container headers and polish the positions portfolio metric strip without adding new abstractions

## Validation
- npx impeccable --json app/global.css src/components/common/table-container-with-header.tsx src/features/markets/components/table/markets-table.tsx src/features/positions/components/supplied-morpho-blue-grouped-table.tsx
- npx ultracite check
- git diff --check
- route smoke: /positions/:account, /markets, and /market/:chainId/:marketId returned 200 on localhost after the padding adjustment
- earlier branch validation also passed pnpm typecheck and broader route smoke across rewards, vault, and autovault

## Notes
- Default body cell padding is now 0.875rem 1rem, between the previous PR version and the old 1rem spacing. Compact rows use 0.75rem 1rem.
- Headless Chrome screenshot probing did not hydrate the data-ready tables reliably in this environment, so screenshots from that attempt were not used as validation evidence.
- Rebalance modal micro-table spacing was left intentionally compact; it is a modal review grid rather than a full product data table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized table styling app-wide: tighter header borders, reduced cell padding, and consistent whitespace handling for cleaner layouts.
  * Introduced more compact headers and compact table-body variants for denser, utility-focused rows.
  * Unified numeric/text alignment and centered actions across tables; refined hover backgrounds to the project “hovered” style.
  * Adjusted portfolio banner responsiveness and metric typography for improved mobile presentation.
  * Moved transaction timestamp to a single “time” column and simplified transaction identity placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->