### PR TITLE
Show market price debt risk indicators

### DIFF
--- a/docs/MARKET_FLAGS.md
+++ b/docs/MARKET_FLAGS.md
@@ -1,0 +1,40 @@
+# Market Flags Direction
+
+Market-list flags should be backend-defined by default. The frontend should not need to fetch every market's full metrics payload just to decide which compact badges or filters to show.
+
+## Current Split
+
+- Backend flags: liquidation/protection marker, official trending/popular marker, and market-price bad-debt warning.
+- Frontend warnings: oracle/feed warnings, asset recognition warnings, and simple state warnings that are already available on the market object.
+- Legacy metrics: `/v1/markets/metrics` still carries flows and custom-tag inputs, but custom tags are not a core market-list feature.
+
+## Target Shape
+
+Keep `/v1/markets/metrics` for compatibility, then add a smaller market-flags response for list screens. It should return market IDs grouped by flag, with `chainId` included for every ID:
+
+```ts
+type MarketFlagsResponse = {
+  protected: MarketFlagId[];
+  trending: MarketFlagId[];
+  newMarkets: MarketFlagId[];
+  warnings: Array<MarketFlagId & {
+    code: string;
+    severity: 'warning' | 'alert';
+    summary: string;
+  }>;
+};
+
+type MarketFlagId = {
+  chainId: number;
+  marketUniqueKey: string;
+};
+```
+
+The frontend can turn this into a lookup map and merge it with client-side oracle/asset warnings for the existing risk indicators and filters.
+
+## Follow-Ups
+
+- Remove the custom tag feature and make all market-list badges backend-defined.
+- Add filters such as "protected", "trending", "warning", and "no risk".
+- Define "no risk" as no backend warning flags plus no client-side asset/oracle/state warnings.
+- Add more opinionated backend flags over time, such as new market and popular market.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -204,7 +204,7 @@ Market metrics: external data API via `/v1/markets/metrics`
 |-----------|--------|---------|------------|
 | Markets list | Monarch multi-chain → Morpho per supported missing chain | 5 min stale | `useMarketsQuery` |
 | Rolling market `24h/7d/30d` rates | Morpho API rolling fields → archive RPC snapshots + Morpho SDK math fallback | 15 min stale | `useMarketRateEnrichmentQuery` |
-| Market metrics (flows, trending) | Monarch API | 5 min stale | `useMarketMetricsQuery` |
+| Market metrics and flags | Monarch API | 5 min stale | `useMarketMetricsQuery`; see `docs/MARKET_FLAGS.md` for the target compact flags shape |
 | Market state (APY, utilization, balances) | Monarch market state + Morpho shell + RPC snapshot | 30s stale | `useMarketData` |
 | Market historical chart series | Monarch GraphQL → Morpho API | 5 min stale | `useMarketHistoricalData` |
 | User positions | Monarch position discovery + on-chain snapshots + market registry from `useProcessedMarkets` | 5 min | `useUserPositions` |
@@ -276,7 +276,7 @@ Hooks omitted from this matrix are local-state hooks or pure view/composition he
 | `useUserBalancesQuery` | ERC20 wallet balances across chains | Pure RPC multicall via wagmi | No Envio gap |
 | `useTokensQuery` | Token metadata lookup for app UI | Local token registry + Pendle assets API | Not part of Monarch migration |
 | `useOracleMetadata` / `useAllOracleMetadata` | Oracle classification and feed metadata | Scanner gist JSON | Not part of Monarch migration |
-| `useMarketMetricsQuery` | Enhanced market metrics, flows, trending, scores | External data API via `/v1/markets/metrics` | Already Monarch-backed |
+| `useMarketMetricsQuery` | Enhanced market metrics, flows, trending, scores, and current backend market flags | External data API via `/v1/markets/metrics` | Already Monarch-backed; target compact flags shape is in `docs/MARKET_FLAGS.md` |
 | `useUserRewardsQuery` | User claimable rewards and Merkl proofs | Merkl API through the server-side `/api/merkl` API-key proxy | Outside Monarch/Envio scope today |
 | `useMerklCampaignsQuery` / `useMerklHoldIncentivesQuery` | Campaign and HOLD incentive enrichment | Merkl API through `/api/merkl` + hardcoded opportunity mapping | Outside Monarch/Envio scope today |
 

--- a/src/features/markets/components/market-indicators.tsx
+++ b/src/features/markets/components/market-indicators.tsx
@@ -6,11 +6,18 @@ import { IoWarningOutline } from 'react-icons/io5';
 import { AiOutlineFire } from 'react-icons/ai';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { CustomTagIcon } from '@/components/shared/custom-tag-icons';
-import { getMetricsKey, useMarketMetricsMap, matchesCustomTag, type FlowTimeWindow } from '@/hooks/queries/useMarketMetricsQuery';
+import {
+  getMetricsKey,
+  useMarketMetricsMap,
+  matchesCustomTag,
+  type FlowTimeWindow,
+  type MarketMetrics,
+} from '@/hooks/queries/useMarketMetricsQuery';
 import { useMarketWarnings } from '@/hooks/useMarketWarnings';
 import { useMarketPreferences, type CustomTagConfig } from '@/stores/useMarketPreferences';
 import type { Market } from '@/utils/types';
 import { RewardsIndicator } from '@/features/markets/components/rewards-indicator';
+import { getMarketPriceBadDebtWarning } from '@/features/markets/utils/market-price-debt-risk';
 
 const ICON_SIZE = 14;
 
@@ -60,18 +67,26 @@ function buildCustomTagDetail(
 
 type MarketIndicatorsProps = {
   market: Market;
+  marketMetrics?: MarketMetrics | null;
   showRisk?: boolean;
   isStared?: boolean;
   hasUserPosition?: boolean;
 };
 
-export function MarketIndicators({ market, showRisk = false, isStared = false, hasUserPosition = false }: MarketIndicatorsProps) {
+export function MarketIndicators({
+  market,
+  marketMetrics,
+  showRisk = false,
+  isStared = false,
+  hasUserPosition = false,
+}: MarketIndicatorsProps) {
   const { showOfficialTrending, customTagConfig } = useMarketPreferences();
-  const shouldLoadMetrics = showOfficialTrending || customTagConfig.enabled;
+  const shouldResolveMarketMetrics = marketMetrics === undefined;
+  const shouldLoadMetrics = shouldResolveMarketMetrics && (showOfficialTrending || customTagConfig.enabled || showRisk);
   const { metricsMap } = useMarketMetricsMap({ enabled: shouldLoadMetrics, defer: true });
 
   const marketKey = getMetricsKey(market.morphoBlue.chain.id, market.uniqueKey);
-  const metrics = metricsMap.get(marketKey);
+  const metrics = marketMetrics ?? metricsMap.get(marketKey);
   const hasLiquidationProtection = Boolean(metrics?.everLiquidated);
 
   // Official trending (backend-computed)
@@ -82,7 +97,8 @@ export function MarketIndicators({ market, showRisk = false, isStared = false, h
   const hasCustomTag = customTagConfig.enabled && metrics ? matchesCustomTag(metrics, customTagConfig) : false;
 
   const marketWarnings = useMarketWarnings(showRisk ? market : null);
-  const warnings = showRisk ? marketWarnings : [];
+  const marketPriceBadDebtWarning = showRisk ? getMarketPriceBadDebtWarning(metrics) : null;
+  const warnings = showRisk ? [...(marketPriceBadDebtWarning ? [marketPriceBadDebtWarning] : []), ...marketWarnings] : [];
   const hasWarnings = warnings.length > 0;
   const alertWarning = warnings.find((w) => w.level === 'alert');
   const warningLevel = alertWarning ? 'alert' : warnings.length > 0 ? 'warning' : null;

--- a/src/features/markets/components/market-risk-indicators.tsx
+++ b/src/features/markets/components/market-risk-indicators.tsx
@@ -1,8 +1,10 @@
 import type { Market } from '@/utils/types';
+import { getMetricsKey, type MarketMetrics, useMarketMetricsMap } from '@/hooks/queries/useMarketMetricsQuery';
 import { MarketAssetIndicator, MarketOracleIndicator, MarketStatusIndicator } from './risk-indicator';
 
 type MarketRiskIndicatorsProps = {
   market: Market;
+  marketMetrics?: MarketMetrics | null;
   isBatched?: boolean;
   mode?: 'simple' | 'complex';
 };
@@ -11,7 +13,11 @@ type MarketRiskIndicatorsProps = {
  * Standard risk indicators component showing asset, oracle, and debt risk tiers.
  * This component provides a consistent way to display market risk across the application.
  */
-export function MarketRiskIndicators({ market, isBatched = false, mode = 'simple' }: MarketRiskIndicatorsProps) {
+export function MarketRiskIndicators({ market, marketMetrics, isBatched = false, mode = 'simple' }: MarketRiskIndicatorsProps) {
+  const shouldResolveMarketMetrics = marketMetrics === undefined;
+  const { metricsMap } = useMarketMetricsMap({ enabled: shouldResolveMarketMetrics, defer: true });
+  const resolvedMarketMetrics = marketMetrics ?? metricsMap.get(getMetricsKey(market.morphoBlue.chain.id, market.uniqueKey)) ?? null;
+
   return (
     <div className="flex items-center justify-center gap-1">
       <MarketAssetIndicator
@@ -26,6 +32,7 @@ export function MarketRiskIndicators({ market, isBatched = false, mode = 'simple
       />
       <MarketStatusIndicator
         market={market}
+        marketMetrics={resolvedMarketMetrics}
         isBatched={isBatched}
         mode={mode}
       />

--- a/src/features/markets/components/markets-table-same-loan.tsx
+++ b/src/features/markets/components/markets-table-same-loan.tsx
@@ -12,6 +12,7 @@ import { ClearFiltersButton } from '@/components/shared/clear-filters-button';
 import { TablePagination } from '@/components/shared/table-pagination';
 import { useMarketV2SupplyingVaultsQuery } from '@/hooks/queries/useMarketV2SupplyingVaultsQuery';
 import { useTokensQuery } from '@/hooks/queries/useTokensQuery';
+import { getMetricsKey, type MarketMetrics, useMarketMetricsMap } from '@/hooks/queries/useMarketMetricsQuery';
 import { TrustedByCell } from '@/features/autovault/components/trusted-vault-badges';
 import type { TrustedVault } from '@/constants/vaults/known_vaults';
 import type { MarketV2SupplyingVault } from '@/data-sources/monarch-api/vaults';
@@ -109,6 +110,7 @@ function MarketRow({
   showSelectColumn,
   trustedVaultMap,
   v2SupplyingVaultsLookup,
+  marketMetrics,
   supplyRateLabel,
   borrowRateLabel,
   isAprDisplay,
@@ -119,6 +121,7 @@ function MarketRow({
   showSelectColumn: boolean;
   trustedVaultMap: Map<string, TrustedVault>;
   v2SupplyingVaultsLookup: Map<string, MarketV2SupplyingVault[]>;
+  marketMetrics?: MarketMetrics | null;
   supplyRateLabel: string;
   borrowRateLabel: string;
   isAprDisplay: boolean;
@@ -274,6 +277,7 @@ function MarketRow({
       >
         <MarketIndicators
           market={market}
+          marketMetrics={marketMetrics}
           showRisk
         />
       </td>
@@ -510,6 +514,9 @@ export function MarketsTableWithSameLoanAsset({
   const safePage = Math.min(Math.max(1, currentPage), totalPages);
   const startIndex = (safePage - 1) * safePerPage;
   const paginatedMarkets = processedMarkets.slice(startIndex, startIndex + safePerPage);
+  const { metricsMap } = useMarketMetricsMap({
+    enabled: paginatedMarkets.length > 0,
+  });
   const { lookup: v2SupplyingVaultsLookup } = useMarketV2SupplyingVaultsQuery({
     enabled: shouldLoadTrustedVaultMetadata,
     markets: paginatedMarkets.map((marketWithSelection) => marketWithSelection.market),
@@ -707,6 +714,10 @@ export function MarketsTableWithSameLoanAsset({
                   showSelectColumn={showSelectColumn}
                   trustedVaultMap={trustedVaultMap}
                   v2SupplyingVaultsLookup={v2SupplyingVaultsLookup}
+                  marketMetrics={
+                    metricsMap.get(getMetricsKey(marketWithSelection.market.morphoBlue.chain.id, marketWithSelection.market.uniqueKey)) ??
+                    null
+                  }
                   supplyRateLabel={supplyRateLabel}
                   borrowRateLabel={borrowRateLabel}
                   isAprDisplay={isAprDisplay}

--- a/src/features/markets/components/risk-indicator.tsx
+++ b/src/features/markets/components/risk-indicator.tsx
@@ -4,6 +4,8 @@ import { MdError } from 'react-icons/md';
 import { IoWarningOutline } from 'react-icons/io5';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { useMarketWarnings } from '@/hooks/useMarketWarnings';
+import type { MarketMetrics } from '@/hooks/queries/useMarketMetricsQuery';
+import { getMarketPriceBadDebtWarning } from '@/features/markets/utils/market-price-debt-risk';
 import type { WarningWithDetail, Market } from '@/utils/types';
 import { WarningCategory } from '@/utils/types';
 
@@ -195,17 +197,23 @@ export function MarketOracleIndicator({
 
 export function MarketStatusIndicator({
   market,
+  marketMetrics,
   isBatched = false,
   mode = 'simple',
 }: {
   market: Market;
+  marketMetrics?: MarketMetrics | null;
   isBatched?: boolean;
   mode?: 'simple' | 'complex';
 }) {
   const warningsWithDetail = useMarketWarnings(market);
+  const marketPriceBadDebtWarning = getMarketPriceBadDebtWarning(marketMetrics);
 
   // Combine debt + general category warnings
-  const warnings = warningsWithDetail.filter((w) => w.category === WarningCategory.debt || w.category === WarningCategory.general);
+  const warnings = [
+    ...(marketPriceBadDebtWarning ? [marketPriceBadDebtWarning] : []),
+    ...warningsWithDetail.filter((w) => w.category === WarningCategory.debt || w.category === WarningCategory.general),
+  ];
 
   if (warnings.length === 0) {
     return (
@@ -222,7 +230,7 @@ export function MarketStatusIndicator({
     return (
       <RiskIndicator
         level="red"
-        description={isBatched ? 'One or more markets have warnings' : 'Market has critical warning'}
+        description={isBatched ? 'One or more markets have warnings' : (alertWarning?.description ?? 'Market has critical warning')}
         mode={mode}
         warningDetail={alertWarning}
       />

--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -13,6 +13,7 @@ import type { MarketV2SupplyingVault } from '@/data-sources/monarch-api/vaults';
 import { useRateLabel } from '@/hooks/useRateLabel';
 import { useStyledToast } from '@/hooks/useStyledToast';
 import { useMarketPreferences } from '@/stores/useMarketPreferences';
+import { getMetricsKey, useMarketMetricsMap } from '@/hooks/queries/useMarketMetricsQuery';
 import type { MarketRateEnrichment } from '@/utils/market-rate-enrichment';
 import type { Market } from '@/utils/types';
 import { getTrustedVaultsForMarket } from '@/utils/vaults';
@@ -44,6 +45,9 @@ export function MarketTableBody({
 }: MarketTableBodyProps) {
   const { columnVisibility, starredMarkets, starMarket, unstarMarket } = useMarketPreferences();
   const { success: toastSuccess } = useStyledToast();
+  const { metricsMap } = useMarketMetricsMap({
+    enabled: currentEntries.length > 0,
+  });
 
   const { label: supplyRateLabel } = useRateLabel({ prefix: 'Supply' });
   const { label: borrowRateLabel } = useRateLabel({ prefix: 'Borrow' });
@@ -94,6 +98,7 @@ export function MarketTableBody({
       {currentEntries.map((item) => {
         const collatToShow = item.collateralAsset.symbol.slice(0, 6).concat(item.collateralAsset.symbol.length > 6 ? '...' : '');
         const isStared = starredMarkets.includes(item.uniqueKey);
+        const metrics = metricsMap.get(getMetricsKey(item.morphoBlue.chain.id, item.uniqueKey));
 
         return (
           <React.Fragment key={item.uniqueKey}>
@@ -317,7 +322,10 @@ export function MarketTableBody({
                 </TableCell>
               )}
               <TableCell style={{ minWidth: '90px' }}>
-                <MarketRiskIndicators market={item} />
+                <MarketRiskIndicators
+                  market={item}
+                  marketMetrics={metrics ?? null}
+                />
               </TableCell>
               <TableCell
                 data-label="Indicators"
@@ -326,6 +334,7 @@ export function MarketTableBody({
               >
                 <MarketIndicators
                   market={item}
+                  marketMetrics={metrics ?? null}
                   showRisk={false}
                 />
               </TableCell>

--- a/src/features/markets/utils/market-price-debt-risk.ts
+++ b/src/features/markets/utils/market-price-debt-risk.ts
@@ -1,0 +1,56 @@
+import type { MarketMetrics } from '@/hooks/queries/useMarketMetricsQuery';
+import { formatUsdValue } from '@/utils/portfolio';
+import { WarningCategory, type WarningWithDetail } from '@/utils/types';
+
+export const MARKET_PRICE_BAD_DEBT_WARNING_CODE = 'market_price_bad_debt';
+
+function formatBadDebtRatio(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return '0%';
+  }
+
+  if (value >= 10) {
+    return `${value.toFixed(1)}%`;
+  }
+
+  return `${value.toFixed(2)}%`;
+}
+
+function formatBorrowerCount(count: number | null): string {
+  if (count == null) {
+    return 'sampled borrowers';
+  }
+
+  return count === 1 ? '1 borrower' : `${count} borrowers`;
+}
+
+export function getMarketPriceBadDebtWarning(metrics: MarketMetrics | null | undefined): WarningWithDetail | null {
+  if (!metrics) {
+    return null;
+  }
+
+  const risk = metrics?.marketPriceDebtRisk;
+  if (!risk?.hasWarning) {
+    return null;
+  }
+
+  const badDebtUsd = risk.unrealizedBadDebtUsd ?? 0;
+  if (badDebtUsd <= 0) {
+    return null;
+  }
+
+  const borrowUsd = metrics.currentState?.borrowUsd ?? 0;
+  const badDebtRatio = borrowUsd > 0 ? (badDebtUsd / borrowUsd) * 100 : null;
+  const debtAtRiskUsd = risk.debtAtRiskUsd ?? badDebtUsd;
+  const ratioText = badDebtRatio == null ? '' : ` (${formatBadDebtRatio(badDebtRatio)} of total borrow)`;
+  const sourceText = risk.priceSource ? ` Price source: ${risk.priceSource}.` : '';
+
+  return {
+    code: MARKET_PRICE_BAD_DEBT_WARNING_CODE,
+    level: 'alert',
+    description: `Independent market prices imply ${formatUsdValue(badDebtUsd)} bad debt${ratioText}, with ${formatUsdValue(
+      debtAtRiskUsd,
+    )} debt at risk across ${formatBorrowerCount(risk.borrowerCount)}.${sourceText}`,
+    category: WarningCategory.debt,
+  };
+}

--- a/src/hooks/queries/useMarketMetricsQuery.ts
+++ b/src/hooks/queries/useMarketMetricsQuery.ts
@@ -36,6 +36,18 @@ export type MarketCurrentState = {
   individualSupplyUsd: number;
 };
 
+export type MarketPriceDebtRisk = {
+  hasWarning: boolean;
+  unrealizedBadDebtUsd: number | null;
+  debtAtRiskUsd: number | null;
+  borrowerCount: number | null;
+  worstBorrower: string | null;
+  worstBorrowerLtv: number | null;
+  minCollateralRatio: number | null;
+  sampledBorrowerCount: number | null;
+  priceSource: string | null;
+};
+
 // Enhanced market metrics from Monarch API
 export type MarketMetrics = {
   marketUniqueKey: string;
@@ -46,6 +58,7 @@ export type MarketMetrics = {
   // Key flags
   everLiquidated: boolean;
   marketScore: number | null;
+  marketPriceDebtRisk?: MarketPriceDebtRisk;
   // Backend-computed trending (official)
   isTrending: boolean;
   trendingReason: string | null;
@@ -76,6 +89,7 @@ type MarketMetricsParams = {
 
 const PAGE_SIZE = 1000;
 const MARKET_METRICS_REFRESH_MS = 15 * 60 * 1000;
+const MARKET_METRICS_QUERY_SCHEMA_VERSION = 2;
 
 const getMarketMetricsClientUrl = (searchParams?: URLSearchParams): string => {
   if (!DATA_API_BASE_URL) {
@@ -167,7 +181,7 @@ export const useMarketMetricsQuery = (params: MarketMetricsParams = {}) => {
   const queryEnabled = useDeferredQueryEnable(enabled, defer, 2000);
 
   return useQuery({
-    queryKey: ['market-metrics', { chainId, sortBy, sortOrder }],
+    queryKey: ['market-metrics', MARKET_METRICS_QUERY_SCHEMA_VERSION, { chainId, sortBy, sortOrder }],
     queryFn: () => fetchAllMarketMetrics({ chainId, sortBy, sortOrder }),
     staleTime: MARKET_METRICS_REFRESH_MS,
     refetchInterval: MARKET_METRICS_REFRESH_MS,

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -79,6 +79,8 @@ const BAD_DEBT: WarningWithDetail = {
   category: WarningCategory.debt,
 };
 
+const OVER_UTILIZATION_ALERT_THRESHOLD = 1.01;
+
 const UNRECOGNIZED_ORACLE: WarningWithDetail = {
   code: 'unrecognized_oracle',
   level: 'alert',
@@ -153,6 +155,16 @@ export const getMarketWarningsWithDetail = (market: Market, optionsOrWhitelist?:
     }
   } catch {
     // ignore invalid BigInt values (e.g., decimal strings like "0.00")
+  }
+
+  const utilization = market.state.utilization;
+  if (Number.isFinite(utilization) && utilization > OVER_UTILIZATION_ALERT_THRESHOLD) {
+    result.push({
+      code: 'over_utilized_market',
+      level: 'alert',
+      description: `Market utilization is ${(utilization * 100).toFixed(2)}%, which means borrowed assets exceed supplied assets.`,
+      category: WarningCategory.debt,
+    });
   }
 
   // Append our own oracle warnings


### PR DESCRIPTION
## Summary
- add Monarch API market-price debt-risk typing
- surface backend `marketPriceDebtRisk.hasWarning` in the market-state risk indicator
- mark markets above 101% utilization as market-state debt alerts, so rows like 638.91% utilization cannot show a green status bar
- include the same backend bad-debt warning in compact market indicators when risk warnings are enabled
- document the target backend-defined market flags direction in `docs/MARKET_FLAGS.md`

## Validation
- `npx ultracite fix`
- `pnpm typecheck`
- `npx ultracite check`
- `curl http://localhost:3007/markets` returned 200 after route compilation
- authenticated data API smoke confirmed top bad-debt rows still have `hasWarning=true` under the 1% bad-debt-to-borrow rule

## Notes
- API threshold update was pushed separately to data-api/master in commit `bd8acf7`.
- Browser plugin was not exposed in this thread, so UI verification used local route compile plus API smoke rather than an in-app browser screenshot.
