### PR TITLE
Remove tab focus rings from shared tabs

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -18,7 +18,7 @@ const TabsTrigger = forwardRef<ElementRef<typeof Trigger>, ComponentPropsWithout
   <Trigger
     ref={ref}
     className={cn(
-      'relative inline-flex h-full items-center justify-center whitespace-nowrap px-0 text-lg font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground',
+      'relative inline-flex h-full items-center justify-center whitespace-nowrap px-0 text-lg font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground',
       'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary',
       'first:mr-6 mr-6',
       className,
@@ -32,7 +32,7 @@ const TabsContent = forwardRef<ElementRef<typeof Content>, ComponentPropsWithout
   <Content
     ref={ref}
     className={cn(
-      'mt-6 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'mt-6 focus-visible:outline-none',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- remove the primary focus ring from shared Radix tab triggers
- remove the tab-content focus ring so tabbed surfaces do not show screenshot-visible orange focus boxes
- preserve the existing active underline as the selected-tab signal across market detail, analysis, position detail, and UI lab tabs

## Root cause
The shared `TabsTrigger` and `TabsContent` primitives applied `focus-visible:ring-ring`, and `--ring` resolves to Monarch orange. Keyboard-driven screenshot shortcuts can leave the active tab in that visible focus state, producing the rounded orange border seen on market-detail tabs.

## Review note
Gemini raised a general accessibility concern about removing focus rings. For this shared tab primitive, current usages do not set manual tab activation, so the active tab underline and active text state are the app-level focus/selection cue. Adding a second focus-specific line or panel shadow would be extra UI state and would reintroduce the screenshot-oriented problem in another form.

## Validation
- `npx ultracite fix`
- `npx ultracite check`
- `pnpm typecheck`
- `git diff --check`
- Browser smoke on `/market/8453/0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836`: selected `Analysis` tab computed with `outlineStyle: none`, `boxShadow: none`, and zero border widths