### PR TITLE
Use Morpho asset price max lag

### DIFF
--- a/src/graphql/morpho-api-queries.ts
+++ b/src/graphql/morpho-api-queries.ts
@@ -542,7 +542,7 @@ export const assetPricesQuery = `
         chain {
           id
         }
-        price {
+        price(maxLag: 24) {
           usd
         }
       }


### PR DESCRIPTION
## Summary
- keep asset price fetching inside the Morpho API data source
- request Morpho asset prices with an explicit 24h max lag
- remove the DefiLlama fallback layer from the PR

## Verification
- npx ultracite fix
- npx ultracite check
- pnpm typecheck