### PR TITLE
Fix discovery highlight persistence

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -222,6 +222,16 @@
   --color-background-hovered: var(--palette-bg-hovered);
   --color-text: #16181a;
   --color-text-secondary: #8e8e8e;
+  --market-discovery-focus-bg: color-mix(
+    in srgb,
+    var(--palette-orange) 6%,
+    var(--color-background-secondary)
+  );
+  --market-discovery-focus-bg-hover: color-mix(
+    in srgb,
+    var(--palette-orange) 10%,
+    var(--color-background-secondary)
+  );
 
   /* shadcn variables */
   --background: 0 0% 100%;
@@ -270,6 +280,16 @@
   --color-background-hovered: var(--palette-bg-hovered);
   --color-text: #fff;
   --color-text-secondary: #8e8e8e;
+  --market-discovery-focus-bg: color-mix(
+    in srgb,
+    var(--palette-orange) 9%,
+    var(--color-background-secondary)
+  );
+  --market-discovery-focus-bg-hover: color-mix(
+    in srgb,
+    var(--palette-orange) 13%,
+    var(--color-background-secondary)
+  );
 
   /* shadcn dark variables */
   --background: 222.2 84% 4.9%;
@@ -407,12 +427,12 @@ tbody tr:not(.no-hover-effect tr):hover {
 }
 
 tbody tr.market-discovery-focused {
-  background-color: rgba(244, 95, 45, 0.06);
+  background-color: var(--market-discovery-focus-bg);
   border-left: 2px solid transparent !important;
 }
 
 tbody tr.market-discovery-focused:hover {
-  background-color: rgba(244, 95, 45, 0.1);
+  background-color: var(--market-discovery-focus-bg-hover);
   border-left: 2px solid transparent !important;
 }
 

--- a/src/features/markets/components/filters/discovery-filter.tsx
+++ b/src/features/markets/components/filters/discovery-filter.tsx
@@ -11,7 +11,7 @@ import {
   type MarketDiscoveryCategory,
 } from '@/features/markets/market-discovery';
 import { useMarketDiscoveryFlagsQuery } from '@/hooks/queries/useMarketDiscoveryFlagsQuery';
-import { useMarketsFilters } from '@/stores/useMarketsFilters';
+import { useMarketFilterPreferences } from '@/stores/useMarketFilterPreferences';
 import { cn } from '@/utils/components';
 
 const CATEGORY_ICONS: Record<MarketDiscoveryCategory, ReactNode> = {
@@ -27,9 +27,9 @@ type DiscoveryFilterProps = {
 export default function DiscoveryFilter({ showLabelPrefix = false }: DiscoveryFilterProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const discoveryCategories = useMarketsFilters((state) => state.discoveryCategories);
-  const toggleDiscoveryCategory = useMarketsFilters((state) => state.toggleDiscoveryCategory);
-  const clearDiscoveryCategories = useMarketsFilters((state) => state.clearDiscoveryCategories);
+  const discoveryCategories = useMarketFilterPreferences((state) => state.discoveryCategories);
+  const toggleDiscoveryCategory = useMarketFilterPreferences((state) => state.toggleDiscoveryCategory);
+  const clearDiscoveryCategories = useMarketFilterPreferences((state) => state.clearDiscoveryCategories);
   const { data, isLoading } = useMarketDiscoveryFlagsQuery({ defer: true });
   const selectedCategorySet = new Set(discoveryCategories);
 

--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -14,8 +14,8 @@ import type { MarketDiscoveryCategory } from '@/features/markets/market-discover
 import { useMarketDiscoveryFlagsMap } from '@/hooks/queries/useMarketDiscoveryFlagsQuery';
 import { useRateLabel } from '@/hooks/useRateLabel';
 import { useStyledToast } from '@/hooks/useStyledToast';
+import { useMarketFilterPreferences } from '@/stores/useMarketFilterPreferences';
 import { useMarketPreferences } from '@/stores/useMarketPreferences';
-import { useMarketsFilters } from '@/stores/useMarketsFilters';
 import { getMetricsKey, useMarketMetricsMap } from '@/hooks/queries/useMarketMetricsQuery';
 import type { MarketRateEnrichment } from '@/utils/market-rate-enrichment';
 import type { Market } from '@/utils/types';
@@ -48,7 +48,7 @@ export function MarketTableBody({
   rateEnrichmentLoading,
 }: MarketTableBodyProps) {
   const { columnVisibility, starredMarkets, starMarket, unstarMarket } = useMarketPreferences();
-  const discoveryCategories = useMarketsFilters((state) => state.discoveryCategories);
+  const discoveryCategories = useMarketFilterPreferences((state) => state.discoveryCategories);
   const { success: toastSuccess } = useStyledToast();
   const { metricsMap } = useMarketMetricsMap({
     enabled: currentEntries.length > 0,

--- a/src/features/markets/markets-view.tsx
+++ b/src/features/markets/markets-view.tsx
@@ -165,6 +165,9 @@ export default function Markets() {
     persistedFilters.discoveryCategories,
     filters.selectedOracles,
     filters.searchQuery,
+    filters.trendingMode,
+    filters.customTagMode,
+    filters.starredOnly,
     resetPage,
   ]);
 

--- a/src/features/markets/markets-view.tsx
+++ b/src/features/markets/markets-view.tsx
@@ -162,9 +162,9 @@ export default function Markets() {
     persistedFilters.selectedNetwork,
     persistedFilters.selectedCollaterals,
     persistedFilters.selectedLoanAssets,
+    persistedFilters.discoveryCategories,
     filters.selectedOracles,
     filters.searchQuery,
-    filters.discoveryCategories,
     resetPage,
   ]);
 
@@ -224,7 +224,7 @@ export default function Markets() {
             collateralItems={uniqueCollaterals}
             selectedOracles={filters.selectedOracles}
             setSelectedOracles={filters.setSelectedOracles}
-            selectedDiscoveryCategories={filters.discoveryCategories}
+            selectedDiscoveryCategories={persistedFilters.discoveryCategories}
             loading={loading}
             onClearAll={handleClearAll}
           />

--- a/src/hooks/useFilteredMarkets.ts
+++ b/src/hooks/useFilteredMarkets.ts
@@ -170,8 +170,8 @@ export const useFilteredMarkets = (options?: UseFilteredMarketsOptions): UseFilt
   const officialTrendingKeys = useOfficialTrendingMarketKeys({ enabled: filters.trendingMode, defer: true });
   const customTagKeys = useCustomTagMarketKeys({ enabled: filters.customTagMode, defer: true });
   const discoveryPriorityMap = useMarketDiscoveryPriorityMap({
-    categories: filters.discoveryCategories,
-    enabled: filters.discoveryCategories.length > 0,
+    categories: persistedFilters.discoveryCategories,
+    enabled: persistedFilters.discoveryCategories.length > 0,
     defer: true,
   });
 

--- a/src/stores/useMarketFilterPreferences.ts
+++ b/src/stores/useMarketFilterPreferences.ts
@@ -24,6 +24,18 @@ type MarketFilterPreferencesStore = MarketFilterPreferencesState & MarketFilterP
 
 const dedupeSelections = (values: string[]) => [...new Set(values)];
 
+const normalizeStringSelections = (values: unknown): string[] => {
+  if (typeof values === 'string') {
+    return [values];
+  }
+
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return dedupeSelections(values.filter((value): value is string => typeof value === 'string'));
+};
+
 const isMarketDiscoveryCategory = (value: unknown): value is MarketDiscoveryCategory =>
   typeof value === 'string' && (MARKET_DISCOVERY_CATEGORIES as readonly string[]).includes(value);
 
@@ -62,9 +74,9 @@ export const useMarketFilterPreferences = create<MarketFilterPreferencesStore>()
             'discoveryCategories' in state ? normalizeDiscoveryCategories(state.discoveryCategories) : currentState.discoveryCategories,
           selectedNetwork: 'selectedNetwork' in state ? (state.selectedNetwork ?? null) : currentState.selectedNetwork,
           selectedLoanAssets:
-            'selectedLoanAssets' in state ? dedupeSelections(state.selectedLoanAssets ?? []) : currentState.selectedLoanAssets,
+            'selectedLoanAssets' in state ? normalizeStringSelections(state.selectedLoanAssets) : currentState.selectedLoanAssets,
           selectedCollaterals:
-            'selectedCollaterals' in state ? dedupeSelections(state.selectedCollaterals ?? []) : currentState.selectedCollaterals,
+            'selectedCollaterals' in state ? normalizeStringSelections(state.selectedCollaterals) : currentState.selectedCollaterals,
         })),
       toggleDiscoveryCategory: (category) =>
         set((state) => ({
@@ -87,8 +99,8 @@ export const useMarketFilterPreferences = create<MarketFilterPreferencesStore>()
           ...DEFAULT_STATE,
           ...savedState,
           discoveryCategories: normalizeDiscoveryCategories(savedState.discoveryCategories),
-          selectedCollaterals: dedupeSelections(savedState.selectedCollaterals ?? []),
-          selectedLoanAssets: dedupeSelections(savedState.selectedLoanAssets ?? []),
+          selectedCollaterals: normalizeStringSelections(savedState.selectedCollaterals),
+          selectedLoanAssets: normalizeStringSelections(savedState.selectedLoanAssets),
           selectedNetwork: savedState.selectedNetwork ?? null,
         };
       },

--- a/src/stores/useMarketFilterPreferences.ts
+++ b/src/stores/useMarketFilterPreferences.ts
@@ -1,8 +1,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { MARKET_DISCOVERY_CATEGORIES, type MarketDiscoveryCategory } from '@/features/markets/market-discovery';
 import type { SupportedNetworks } from '@/utils/supported-networks';
 
 export type MarketFilterPreferencesState = {
+  discoveryCategories: MarketDiscoveryCategory[];
   selectedCollaterals: string[];
   selectedLoanAssets: string[];
   selectedNetwork: SupportedNetworks | null;
@@ -10,17 +12,37 @@ export type MarketFilterPreferencesState = {
 
 type MarketFilterPreferencesActions = {
   applySelections: (state: Partial<MarketFilterPreferencesState>) => void;
+  clearDiscoveryCategories: () => void;
   reset: () => void;
   setSelectedCollaterals: (collaterals: string[]) => void;
   setSelectedLoanAssets: (assets: string[]) => void;
   setSelectedNetwork: (network: SupportedNetworks | null) => void;
+  toggleDiscoveryCategory: (category: MarketDiscoveryCategory) => void;
 };
 
 type MarketFilterPreferencesStore = MarketFilterPreferencesState & MarketFilterPreferencesActions;
 
 const dedupeSelections = (values: string[]) => [...new Set(values)];
 
+const isMarketDiscoveryCategory = (value: unknown): value is MarketDiscoveryCategory =>
+  typeof value === 'string' && (MARKET_DISCOVERY_CATEGORIES as readonly string[]).includes(value);
+
+const normalizeDiscoveryCategories = (values: unknown): MarketDiscoveryCategory[] => {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  const categories: MarketDiscoveryCategory[] = [];
+  for (const value of values) {
+    if (isMarketDiscoveryCategory(value) && !categories.includes(value)) {
+      categories.push(value);
+    }
+  }
+  return categories;
+};
+
 const DEFAULT_STATE: MarketFilterPreferencesState = {
+  discoveryCategories: [],
   selectedCollaterals: [],
   selectedLoanAssets: [],
   selectedNetwork: null,
@@ -36,22 +58,39 @@ export const useMarketFilterPreferences = create<MarketFilterPreferencesStore>()
       setSelectedNetwork: (network) => set({ selectedNetwork: network }),
       applySelections: (state) =>
         set((currentState) => ({
+          discoveryCategories:
+            'discoveryCategories' in state ? normalizeDiscoveryCategories(state.discoveryCategories) : currentState.discoveryCategories,
           selectedNetwork: 'selectedNetwork' in state ? (state.selectedNetwork ?? null) : currentState.selectedNetwork,
           selectedLoanAssets:
             'selectedLoanAssets' in state ? dedupeSelections(state.selectedLoanAssets ?? []) : currentState.selectedLoanAssets,
           selectedCollaterals:
             'selectedCollaterals' in state ? dedupeSelections(state.selectedCollaterals ?? []) : currentState.selectedCollaterals,
         })),
+      toggleDiscoveryCategory: (category) =>
+        set((state) => ({
+          discoveryCategories: state.discoveryCategories.includes(category)
+            ? state.discoveryCategories.filter((item) => item !== category)
+            : [...state.discoveryCategories, category],
+        })),
+      clearDiscoveryCategories: () => set({ discoveryCategories: [] }),
       reset: () => set(DEFAULT_STATE),
     }),
     {
       name: 'monarch_store_marketFilterPreferences',
-      version: 1,
+      version: 2,
       migrate: (state) => {
         if (!state || typeof state !== 'object') {
           return DEFAULT_STATE;
         }
-        return { ...DEFAULT_STATE, ...(state as Partial<MarketFilterPreferencesState>) };
+        const savedState = state as Partial<MarketFilterPreferencesState>;
+        return {
+          ...DEFAULT_STATE,
+          ...savedState,
+          discoveryCategories: normalizeDiscoveryCategories(savedState.discoveryCategories),
+          selectedCollaterals: dedupeSelections(savedState.selectedCollaterals ?? []),
+          selectedLoanAssets: dedupeSelections(savedState.selectedLoanAssets ?? []),
+          selectedNetwork: savedState.selectedNetwork ?? null,
+        };
       },
     },
   ),

--- a/src/stores/useMarketsFilters.ts
+++ b/src/stores/useMarketsFilters.ts
@@ -1,12 +1,11 @@
 import { create } from 'zustand';
-import type { MarketDiscoveryCategory } from '@/features/markets/market-discovery';
 import type { PriceFeedVendors } from '@/utils/oracle';
 
 /**
  * Session-only filter state for the markets page.
  *
- * Persisted market selections (network, loan asset, collateral) live in
- * useMarketFilterPreferences. This store holds the transient filters that
+ * Persisted market selections (network, loan asset, collateral, discovery)
+ * live in useMarketFilterPreferences. This store holds transient filters that
  * should reset naturally between sessions or when the user clears the page.
  */
 type MarketsFiltersState = {
@@ -15,7 +14,6 @@ type MarketsFiltersState = {
   trendingMode: boolean; // Official growing filter (legacy API key)
   customTagMode: boolean; // User's custom tag filter
   starredOnly: boolean; // Show only starred markets
-  discoveryCategories: MarketDiscoveryCategory[];
 };
 
 type MarketsFiltersActions = {
@@ -24,8 +22,6 @@ type MarketsFiltersActions = {
   toggleTrendingMode: () => void;
   toggleCustomTagMode: () => void;
   toggleStarredOnly: () => void;
-  toggleDiscoveryCategory: (category: MarketDiscoveryCategory) => void;
-  clearDiscoveryCategories: () => void;
   resetFilters: () => void;
 };
 
@@ -37,7 +33,6 @@ const DEFAULT_STATE: MarketsFiltersState = {
   trendingMode: false,
   customTagMode: false,
   starredOnly: false,
-  discoveryCategories: [],
 };
 
 /**
@@ -56,13 +51,6 @@ export const useMarketsFilters = create<MarketsFiltersStore>()((set) => ({
   toggleTrendingMode: () => set((state) => ({ trendingMode: !state.trendingMode })),
   toggleCustomTagMode: () => set((state) => ({ customTagMode: !state.customTagMode })),
   toggleStarredOnly: () => set((state) => ({ starredOnly: !state.starredOnly })),
-  toggleDiscoveryCategory: (category) =>
-    set((state) => ({
-      discoveryCategories: state.discoveryCategories.includes(category)
-        ? state.discoveryCategories.filter((item) => item !== category)
-        : [...state.discoveryCategories, category],
-    })),
-  clearDiscoveryCategories: () => set({ discoveryCategories: [] }),
 
   resetFilters: () => set(DEFAULT_STATE),
 }));


### PR DESCRIPTION
## Summary
- persist discovery filter selections with the other market filter preferences so refresh keeps the selected label and row priority
- normalize persisted discovery categories during store migration
- make discovery-focused rows use theme-aware background tint only, with no highlight borders

## Verification
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- pnpm stylelint:check
- git diff --check
- Browser verified on http://localhost:3001/markets: selected all discovery categories, refreshed in dark mode, confirmed Discovery: 3 selected and focused rows returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market discovery category filter selections are now persisted across sessions, so your preferences will be saved and remembered when you return.

* **Style**
  * CSS styling for market discovery highlighting has been improved with new theme-scoped color variables, ensuring consistent visual appearance across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->