### PR TITLE
Fix Ultracite config and image module types

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,6 +2,10 @@
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": ["ultracite/core"],
 
+  "files": {
+    "includes": ["**", "!src/imgs/**/*.svg", "!public/imgs/**/*.svg"]
+  },
+
   "formatter": {
     "enabled": true,
     "lineWidth": 140  // Increased to 140 to allow longer one-line code
@@ -172,12 +176,7 @@
       "nursery": {
         // Disable aggressive nursery rules during migration
         // "noShadow": "off",
-        "useSortedClasses": "off",
-
-        // These are too aggressive for migration
-        "noLeakedRender": "off",
-        "noEqualsToNull": "off",
-        "noIncrementDecrement": "off"
+        "useSortedClasses": "off"
       }
     }
   },

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -2,3 +2,43 @@ declare module '*.svg' {
   const src: string;
   export default src;
 }
+
+declare module '*.png' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.gif' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.webp' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.avif' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.ico' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}
+
+declare module '*.bmp' {
+  const src: import('next/dist/shared/lib/image-external').StaticImageData;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- remove unsupported Ultracite/Biome nursery rule keys from biome.jsonc
- exclude SVG assets from Biome scanning so static SVGs do not block global Ultracite checks
- add tracked PNG/JPG/JPEG module declarations for clean-checkout typecheck

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration and refined rule settings.
  * Enhanced TypeScript support for additional image file formats (PNG, JPG, JPEG).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->