### PR TITLE
fix: clean up header navigation

### DIFF
--- a/src/components/layout/header/HeaderMenuItems.tsx
+++ b/src/components/layout/header/HeaderMenuItems.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { GearIcon } from '@radix-ui/react-icons';
+import { useEffect, useState, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from 'next-themes';
+import { FaRegMoon } from 'react-icons/fa';
+import { LuSunMedium } from 'react-icons/lu';
+import { RiBookLine, RiBriefcaseLine, RiDiscordFill, RiLineChartLine, RiPieChart2Line, RiSwapLine } from 'react-icons/ri';
+import { useConnection } from 'wagmi';
+import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
+import { useModal } from '@/hooks/useModal';
+import { EXTERNAL_LINKS } from '@/utils/external';
+
+type HeaderMenuItemsProps = {
+  iconSide?: 'start' | 'end';
+  itemClassName?: string;
+  onSelect?: () => void;
+};
+
+export function HeaderMenuItems({ iconSide = 'end', itemClassName, onSelect }: HeaderMenuItemsProps) {
+  const router = useRouter();
+  const { open: openModal } = useModal();
+  const { address } = useConnection();
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const positionsHref = mounted && address ? `/positions/${address}` : '/positions';
+  const themeLabel = mounted && theme === 'dark' ? 'Light Theme' : 'Dark Theme';
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const iconProps = (icon: ReactNode) => (iconSide === 'start' ? { startContent: icon } : { endContent: icon });
+
+  const handleNavigation = (path: string) => {
+    router.push(path);
+    onSelect?.();
+  };
+
+  const handleExternalLink = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+    onSelect?.();
+  };
+
+  const handleSwap = () => {
+    openModal('bridgeSwap', {});
+    onSelect?.();
+  };
+
+  const handleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+    onSelect?.();
+  };
+
+  const handleSettings = () => {
+    openModal('monarchSettings', {});
+    onSelect?.();
+  };
+
+  return (
+    <>
+      <DropdownMenuItem
+        {...iconProps(<RiSwapLine className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={handleSwap}
+      >
+        Swap
+      </DropdownMenuItem>
+
+      <DropdownMenuSeparator />
+
+      <DropdownMenuItem
+        {...iconProps(<RiLineChartLine className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={() => handleNavigation('/markets')}
+      >
+        Markets
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        {...iconProps(<RiBriefcaseLine className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={() => handleNavigation(positionsHref)}
+      >
+        Positions
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        {...iconProps(<RiPieChart2Line className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={() => handleNavigation('/analysis')}
+      >
+        Analytics
+      </DropdownMenuItem>
+
+      <DropdownMenuSeparator />
+
+      <DropdownMenuItem
+        {...iconProps(<RiBookLine className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={() => handleExternalLink(EXTERNAL_LINKS.docs)}
+      >
+        Docs
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        {...iconProps(<RiDiscordFill className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={() => handleExternalLink(EXTERNAL_LINKS.discord)}
+      >
+        Discord
+      </DropdownMenuItem>
+
+      <DropdownMenuSeparator />
+
+      <DropdownMenuItem
+        {...iconProps(mounted ? theme === 'dark' ? <LuSunMedium size={16} /> : <FaRegMoon size={14} /> : undefined)}
+        className={itemClassName}
+        onClick={handleTheme}
+      >
+        {themeLabel}
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        {...iconProps(<GearIcon className="h-4 w-4" />)}
+        className={itemClassName}
+        onClick={handleSettings}
+      >
+        Settings
+      </DropdownMenuItem>
+    </>
+  );
+}

--- a/src/components/layout/header/Navbar.tsx
+++ b/src/components/layout/header/Navbar.tsx
@@ -5,18 +5,12 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { clsx } from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import { useTheme } from 'next-themes';
-import { FaRegMoon } from 'react-icons/fa';
-import { GearIcon } from '@radix-ui/react-icons';
-import { LuSunMedium } from 'react-icons/lu';
-import { RiBookLine, RiDiscordFill, RiGithubFill, RiKey2Line, RiPieChart2Line } from 'react-icons/ri';
+import { usePathname } from 'next/navigation';
 import { useConnection } from 'wagmi';
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { useModal } from '@/hooks/useModal';
-import { EXTERNAL_LINKS } from '@/utils/external';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from '@/components/ui/dropdown-menu';
 import logo from '../../imgs/logo.png';
 import AccountConnect from './AccountConnect';
+import { HeaderMenuItems } from './HeaderMenuItems';
 import { TransactionIndicator } from './TransactionIndicator';
 
 export function NavbarLink({
@@ -75,20 +69,14 @@ export function NavbarTitle() {
 }
 
 export function Navbar() {
-  const { theme, setTheme } = useTheme();
   const { address } = useConnection();
-  const router = useRouter();
-  const { open: openModal } = useModal();
   const [mounted, setMounted] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const positionsHref = mounted && address ? `/positions/${address}` : '/positions';
 
   useEffect(() => {
     setMounted(true);
   }, []);
-
-  const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
-  };
 
   return (
     <nav className="flex h-full w-full items-center justify-between">
@@ -105,45 +93,18 @@ export function Navbar() {
           </NavbarLink>
           <span className="mx-1 h-4 border-l border-dashed border-[var(--grid-cell-muted)]" />
           <NavbarLink
-            href="/autovault"
-            matchKey="/autovault"
+            href={positionsHref}
+            matchKey="/position"
           >
-            Autovault
+            Positions
           </NavbarLink>
           <span className="mx-1 h-4 border-l border-dashed border-[var(--grid-cell-muted)]" />
-          {mounted ? (
-            <>
-              <NavbarLink
-                href={address ? `/positions/${address}` : '/positions'}
-                matchKey="/position"
-              >
-                Portfolio
-              </NavbarLink>
-              <span className="mx-1 h-4 border-l border-dashed border-[var(--grid-cell-muted)]" />
-              <NavbarLink
-                href={address ? `/rewards/${address}` : '/rewards'}
-                matchKey="/rewards"
-              >
-                Rewards
-              </NavbarLink>
-            </>
-          ) : (
-            <>
-              <NavbarLink
-                href="/positions"
-                matchKey="/position"
-              >
-                Portfolio
-              </NavbarLink>
-              <span className="mx-1 h-4 border-l border-dashed border-[var(--grid-cell-muted)]" />
-              <NavbarLink
-                href="/rewards"
-                matchKey="/rewards"
-              >
-                Rewards
-              </NavbarLink>
-            </>
-          )}
+          <NavbarLink
+            href="/analysis"
+            matchKey="/analysis"
+          >
+            Analytics
+          </NavbarLink>
           <span className="mx-1 h-4 border-l border-dashed border-[var(--grid-cell-muted)]" />
 
           <DropdownMenu onOpenChange={setIsMoreOpen}>
@@ -168,48 +129,7 @@ export function Navbar() {
               align="end"
               className="min-w-[180px]"
             >
-              <DropdownMenuItem
-                endContent={<RiPieChart2Line className="h-4 w-4" />}
-                onClick={() => router.push('/analysis')}
-              >
-                Analysis
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                endContent={<RiKey2Line className="h-4 w-4" />}
-                onClick={() => router.push('/api-keys')}
-              >
-                API Keys
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                endContent={<RiBookLine className="h-4 w-4" />}
-                onClick={() => window.open(EXTERNAL_LINKS.docs, '_blank')}
-              >
-                Docs
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                endContent={<RiDiscordFill className="h-4 w-4" />}
-                onClick={() => window.open(EXTERNAL_LINKS.discord, '_blank')}
-              >
-                Discord
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                endContent={<RiGithubFill className="h-4 w-4" />}
-                onClick={() => window.open(EXTERNAL_LINKS.github, '_blank')}
-              >
-                GitHub
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                endContent={mounted && (theme === 'dark' ? <LuSunMedium size={16} /> : <FaRegMoon size={14} />)}
-                onClick={toggleTheme}
-              >
-                {theme === 'dark' ? 'Light Theme' : 'Dark Theme'}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                endContent={<GearIcon className="h-4 w-4" />}
-                onClick={() => openModal('monarchSettings', {})}
-              >
-                Settings
-              </DropdownMenuItem>
+              <HeaderMenuItems />
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/src/components/layout/header/NavbarMobile.tsx
+++ b/src/components/layout/header/NavbarMobile.tsx
@@ -1,63 +1,17 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { HamburgerMenuIcon, GearIcon } from '@radix-ui/react-icons';
+import { useState } from 'react';
+import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 import { clsx } from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useTheme } from 'next-themes';
-import { FaRegMoon } from 'react-icons/fa';
-import { LuSunMedium } from 'react-icons/lu';
-import {
-  RiBookLine,
-  RiBriefcaseLine,
-  RiDiscordFill,
-  RiGiftLine,
-  RiGithubFill,
-  RiKey2Line,
-  RiLineChartLine,
-  RiPieChart2Line,
-} from 'react-icons/ri';
-import { useConnection } from 'wagmi';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu';
-import { useModal } from '@/hooks/useModal';
-import { EXTERNAL_LINKS } from '@/utils/external';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from '@/components/ui/dropdown-menu';
 import logo from '../../imgs/logo.png';
 import AccountConnect from './AccountConnect';
+import { HeaderMenuItems } from './HeaderMenuItems';
 
 export default function NavbarMobile() {
-  const { theme, setTheme } = useTheme();
-  const { address } = useConnection();
-  const router = useRouter();
-  const { open: openModal } = useModal();
-  const [mounted, setMounted] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
-    setIsMenuOpen(false);
-  };
-
-  const handleExternalLink = (url: string) => {
-    window.open(url, '_blank');
-    setIsMenuOpen(false);
-  };
-
-  const handleNavigation = (path: string) => {
-    router.push(path);
-    setIsMenuOpen(false);
-  };
 
   return (
     <nav className="flex h-full w-full items-center justify-between px-4">
@@ -101,77 +55,11 @@ export default function NavbarMobile() {
             align="start"
             className="min-w-[200px]"
           >
-            <DropdownMenuItem
-              startContent={<RiLineChartLine className="h-5 w-5" />}
-              onClick={() => handleNavigation('/markets')}
-              className="py-3"
-            >
-              <span className="font-medium">Markets</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<RiPieChart2Line className="h-5 w-5" />}
-              onClick={() => handleNavigation('/analysis')}
-              className="py-3"
-            >
-              <span className="font-medium">Analysis</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<RiKey2Line className="h-5 w-5" />}
-              onClick={() => handleNavigation('/api-keys')}
-              className="py-3"
-            >
-              <span className="font-medium">API Keys</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<RiBriefcaseLine className="h-5 w-5" />}
-              onClick={() => handleNavigation(mounted && address ? `/positions/${address}` : '/positions')}
-              className="py-3"
-            >
-              <span className="font-medium">Portfolio</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<RiGiftLine className="h-5 w-5" />}
-              onClick={() => handleNavigation(mounted && address ? `/rewards/${address}` : '/rewards')}
-              className="py-3"
-            >
-              <span className="font-medium">Rewards</span>
-            </DropdownMenuItem>
-
-            <DropdownMenuSeparator />
-
-            <DropdownMenuItem
-              startContent={<RiBookLine className="h-4 w-4" />}
-              onClick={() => handleExternalLink(EXTERNAL_LINKS.docs)}
-            >
-              Docs
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<RiDiscordFill className="h-4 w-4" />}
-              onClick={() => handleExternalLink(EXTERNAL_LINKS.discord)}
-            >
-              Discord
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<RiGithubFill className="h-4 w-4" />}
-              onClick={() => handleExternalLink(EXTERNAL_LINKS.github)}
-            >
-              GitHub
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={mounted && (theme === 'dark' ? <LuSunMedium size={16} /> : <FaRegMoon size={14} />)}
-              onClick={toggleTheme}
-            >
-              {mounted && (theme === 'dark' ? 'Light Theme' : 'Dark Theme')}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              startContent={<GearIcon className="h-4 w-4" />}
-              onClick={() => {
-                openModal('monarchSettings', {});
-                setIsMenuOpen(false);
-              }}
-            >
-              Settings
-            </DropdownMenuItem>
+            <HeaderMenuItems
+              iconSide="start"
+              itemClassName="py-3"
+              onSelect={() => setIsMenuOpen(false)}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/components/shared/account-actions-popover.tsx
+++ b/src/components/shared/account-actions-popover.tsx
@@ -90,7 +90,7 @@ export function AccountActionsPopover({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <div className="cursor-pointer">{children}</div>
+        <div className="inline-flex cursor-pointer items-center">{children}</div>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
         <DropdownMenuItem

--- a/src/components/shared/account-identity.tsx
+++ b/src/components/shared/account-identity.tsx
@@ -27,6 +27,8 @@ import { formatVaultAdapterType, getMonarchVaultHref } from '@/utils/vaults';
 import type { Address } from 'viem';
 
 const ACCOUNT_IDENTITY_LABEL_MAX_WIDTH_CLASS = 'max-w-[22rem]';
+const FULL_ACCOUNT_CHIP_CLASS = 'inline-flex h-7 items-center rounded-sm px-2 text-xs leading-none';
+const FULL_ACCOUNT_ICON_BUTTON_CLASS = 'inline-flex h-7 w-7 items-center justify-center rounded-sm transition-colors';
 
 type AccountIdentityProps = {
   address: Address;
@@ -47,10 +49,7 @@ type AccountIdentityProps = {
 type MainTagKind = 'adapter' | 'ens' | 'kleros' | 'vault';
 
 const getMainTagClassName = (kind: MainTagKind) =>
-  clsx(
-    'inline-flex min-w-0 items-center rounded-sm px-2 py-1 font-zen text-xs text-secondary',
-    kind === 'adapter' ? 'border border-border bg-surface' : 'bg-hovered',
-  );
+  clsx(FULL_ACCOUNT_CHIP_CLASS, 'min-w-0 font-zen text-secondary', kind === 'adapter' ? 'border border-border bg-surface' : 'bg-hovered');
 
 const getEntityBadgeLabel = (vaultIdentity: VaultAccountIdentity): string | undefined => {
   if (vaultIdentity.kind === 'vault-adapter') {
@@ -412,7 +411,10 @@ export function AccountIdentity({
 
   const addressBadge = (
     <span
-      className="inline-flex cursor-pointer items-center gap-1 rounded-sm bg-hovered px-2 py-1 font-monospace text-xs text-secondary transition-colors hover:brightness-110"
+      className={clsx(
+        FULL_ACCOUNT_CHIP_CLASS,
+        'cursor-pointer gap-1 bg-hovered font-monospace text-secondary transition-colors hover:brightness-110',
+      )}
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -443,7 +445,7 @@ export function AccountIdentity({
   const metadataChips = (
     <>
       {mounted && isOwner && (
-        <span className="inline-flex items-center gap-1 rounded-sm bg-green-500/10 px-2 py-1 font-zen text-xs text-green-500">
+        <span className={clsx(FULL_ACCOUNT_CHIP_CLASS, 'gap-1 bg-green-500/10 font-zen text-green-500')}>
           <FaCircle size={6} />
           Connected
         </span>
@@ -486,15 +488,16 @@ export function AccountIdentity({
         </span>
       ) : null}
 
-      {entityBadge && (
-        <span className="inline-flex items-center rounded-sm bg-hovered px-2 py-1 text-xs text-secondary">{entityBadge}</span>
-      )}
+      {entityBadge && <span className={clsx(FULL_ACCOUNT_CHIP_CLASS, 'bg-hovered text-secondary')}>{entityBadge}</span>}
 
       {linkedVaultHref && (
         <Tooltip content={<TooltipContent title="Open vault account" />}>
           <Link
             href={linkedVaultHref}
-            className="inline-flex items-center gap-1 rounded-sm bg-hovered px-2 py-1 text-xs text-secondary no-underline transition-colors hover:text-primary hover:no-underline"
+            className={clsx(
+              FULL_ACCOUNT_CHIP_CLASS,
+              'gap-1 bg-hovered text-secondary no-underline transition-colors hover:text-primary hover:no-underline',
+            )}
             aria-label={`Open vault account for ${vaultIdentity?.displayName ?? 'linked vault'}`}
           >
             <span>Vault</span>
@@ -519,7 +522,7 @@ export function AccountIdentity({
       {showBookmark && (
         <button
           type="button"
-          className={clsx('rounded-sm p-1 transition-colors', isBookmarked ? 'text-primary' : 'text-secondary hover:text-primary')}
+          className={clsx(FULL_ACCOUNT_ICON_BUTTON_CLASS, isBookmarked ? 'text-primary' : 'text-secondary hover:text-primary')}
           aria-label={isBookmarked ? 'Remove address bookmark' : 'Bookmark address'}
           onClick={(e) => {
             e.preventDefault();
@@ -533,7 +536,7 @@ export function AccountIdentity({
     </>
   );
 
-  const fullClasses = clsx('flex items-center gap-2', className);
+  const fullClasses = clsx('flex flex-wrap items-center gap-2', className);
 
   const fullTrigger = showActions ? (
     <AccountActionsPopover

--- a/src/features/positions/components/portfolio-analytics-banner.tsx
+++ b/src/features/positions/components/portfolio-analytics-banner.tsx
@@ -1,9 +1,6 @@
 import type { ReactNode } from 'react';
 import type { Address } from 'viem';
-import { IoIosSwap } from 'react-icons/io';
-import { RiBookmarkFill, RiBookmarkLine } from 'react-icons/ri';
 import { PulseLoader } from 'react-spinners';
-import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { AccountIdentity } from '@/components/shared/account-identity';
 import { TokenIcon } from '@/components/shared/token-icon';
@@ -17,8 +14,6 @@ import { PositionsPeriodSettingsButton } from './positions-period-settings';
 interface PortfolioAnalyticsBannerProps {
   account: string;
   accountChainId?: number;
-  isBookmarked: boolean;
-  onToggleBookmark: () => void;
   period: EarningsPeriod;
   onPeriodChange: (period: EarningsPeriod) => void;
   rateLabel: string;
@@ -32,7 +27,6 @@ interface PortfolioAnalyticsBannerProps {
   isEarningsLoading: boolean;
   valueError: Error | null;
   showPortfolioStats: boolean;
-  onSwap: () => void;
 }
 
 const METRIC_VALUE_CLASS = 'font-zen text-xl font-normal leading-none tabular-nums text-primary';
@@ -192,8 +186,6 @@ function PortfolioMetricBox({
 export function PortfolioAnalyticsBanner({
   account,
   accountChainId,
-  isBookmarked,
-  onToggleBookmark,
   period,
   onPeriodChange,
   rateLabel,
@@ -207,7 +199,6 @@ export function PortfolioAnalyticsBanner({
   isEarningsLoading,
   valueError,
   showPortfolioStats,
-  onSwap,
 }: PortfolioAnalyticsBannerProps) {
   const analyticsLoading = isValueLoading || isEarningsLoading;
   const displayRate = isAprDisplay ? portfolioAnalytics.annualizedApr : portfolioAnalytics.annualizedApy;
@@ -215,37 +206,19 @@ export function PortfolioAnalyticsBanner({
 
   return (
     <div className="flex flex-col gap-3 font-zen">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 items-start">
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-2">
             <AccountIdentity
               address={account as Address}
               variant="full"
               showAddress
+              showBookmark
               chainId={accountChainId}
             />
-            <Button
-              variant="ghost"
-              size="sm"
-              className="min-w-0 px-1 text-secondary hover:bg-transparent hover:text-primary"
-              aria-label={isBookmarked ? 'Remove address bookmark' : 'Bookmark address'}
-              onClick={onToggleBookmark}
-            >
-              {isBookmarked ? <RiBookmarkFill className="h-4 w-4" /> : <RiBookmarkLine className="h-4 w-4" />}
-            </Button>
           </div>
           <AccountVaultInfo account={account as Address} />
         </div>
-
-        <Button
-          variant="primary"
-          onClick={onSwap}
-          title="Swap tokens"
-          className="shrink-0 self-start"
-        >
-          <IoIosSwap className="h-4 w-4" />
-          Swap
-        </Button>
       </div>
 
       {showPortfolioStats && (

--- a/src/features/positions/positions-view.tsx
+++ b/src/features/positions/positions-view.tsx
@@ -12,7 +12,6 @@ import { useUserVaultsV2Query } from '@/hooks/queries/useUserVaultsV2Query';
 import { useVaultHistoricalApy } from '@/hooks/useVaultHistoricalApy';
 import { useVaultAccountIdentity } from '@/hooks/useVaultAccountIdentity';
 import { useVaultRegistry } from '@/contexts/VaultRegistryContext';
-import { useModal } from '@/hooks/useModal';
 import { usePositionsFilters } from '@/stores/usePositionsFilters';
 import { usePortfolioBookmarks } from '@/stores/usePortfolioBookmarks';
 import { useAppSettings } from '@/stores/useAppSettings';
@@ -27,10 +26,9 @@ import { hasSupplyPositionHistory } from '@/utils/positions';
 
 export default function Positions() {
   const { account } = useParams<{ account: string }>();
-  const { open } = useModal();
   const period = usePositionsFilters((s) => s.period);
   const setPeriod = usePositionsFilters((s) => s.setPeriod);
-  const { addVisitedAddress, toggleAddressBookmark, isAddressBookmarked } = usePortfolioBookmarks();
+  const { addVisitedAddress } = usePortfolioBookmarks();
   const { isAprDisplay } = useAppSettings();
   const { short: rateLabel } = useRateLabel();
   const { loading: isVaultRegistryLoading } = useVaultRegistry();
@@ -100,7 +98,6 @@ export default function Positions() {
     marketPositions.some((position) => BigInt(position.state.borrowShares) > 0n || BigInt(position.state.collateral) > 0n);
   const hasVaults = showNativeAccountSections && vaults && vaults.length > 0;
   const showEmpty = showNativeAccountSections && !loading && !isVaultsLoading && !hasSuppliedMarkets && !hasBorrowPositions && !hasVaults;
-  const isBookmarked = isAddressBookmarked(account as Address);
   const showHeaderPortfolio = showNativeAccountSections && !loading;
 
   useEffect(() => {
@@ -123,8 +120,6 @@ export default function Positions() {
           <PortfolioAnalyticsBanner
             account={account}
             accountChainId={accountVaultIdentity?.chainId}
-            isBookmarked={isBookmarked}
-            onToggleBookmark={() => toggleAddressBookmark(account as Address)}
             period={period}
             onPeriodChange={setPeriod}
             rateLabel={rateLabel}
@@ -138,7 +133,6 @@ export default function Positions() {
             isEarningsLoading={isEarningsLoading || isVaultApyLoading}
             valueError={pricesError}
             showPortfolioStats={showHeaderPortfolio}
-            onSwap={() => open('bridgeSwap', {})}
           />
         </div>
 

--- a/src/modals/settings/monarch-settings/SettingsContent.tsx
+++ b/src/modals/settings/monarch-settings/SettingsContent.tsx
@@ -3,7 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideVariants, slideTransition, type SlideDirection } from '@/components/common/settings-modal';
 import { SettingsHeader } from './SettingsHeader';
-import { TransactionPanel, DisplayPanel, FiltersPanel, PreferencesPanel, ExperimentalPanel } from './panels';
+import { TransactionPanel, DisplayPanel, FiltersPanel, PreferencesPanel, DeveloperPanel, ExperimentalPanel } from './panels';
 import { CustomTagDetail, TrustedVaultsDetail, BlacklistedMarketsDetail, RpcDetail, ThresholdsDetail } from './details';
 import type { SettingsCategory, DetailView } from './constants';
 
@@ -16,6 +16,7 @@ const PANEL_COMPONENTS: Record<SettingsCategory, React.ComponentType<PanelProps>
   display: DisplayPanel,
   filters: FiltersPanel,
   preferences: PreferencesPanel,
+  developer: DeveloperPanel,
   experimental: ExperimentalPanel,
 };
 

--- a/src/modals/settings/monarch-settings/constants.ts
+++ b/src/modals/settings/monarch-settings/constants.ts
@@ -1,9 +1,9 @@
 import type { IconType } from 'react-icons';
 import { FiZap, FiEye, FiSliders } from 'react-icons/fi';
 import { MdFilterList } from 'react-icons/md';
-import { RiFlaskLine } from 'react-icons/ri';
+import { RiCodeLine, RiFlaskLine } from 'react-icons/ri';
 
-export type SettingsCategory = 'transaction' | 'display' | 'filters' | 'preferences' | 'experimental';
+export type SettingsCategory = 'transaction' | 'display' | 'filters' | 'preferences' | 'developer' | 'experimental';
 
 export type DetailView = 'custom-tag-config' | 'trusted-vaults' | 'blacklisted-markets' | 'rpc-config' | 'filter-thresholds' | null;
 
@@ -19,6 +19,7 @@ export const SETTINGS_CATEGORIES: CategoryConfig[] = [
   { id: 'display', label: 'DISPLAY', icon: FiEye },
   { id: 'filters', label: 'FILTERS', icon: MdFilterList },
   { id: 'preferences', label: 'PREFERENCES', icon: FiSliders },
+  { id: 'developer', label: 'DEVELOPER', icon: RiCodeLine },
   { id: 'experimental', label: 'EXPERIMENTAL', icon: RiFlaskLine, badge: 'Beta' },
 ];
 

--- a/src/modals/settings/monarch-settings/panels/DeveloperPanel.tsx
+++ b/src/modals/settings/monarch-settings/panels/DeveloperPanel.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useModal } from '@/hooks/useModal';
+import { useAppSettings } from '@/stores/useAppSettings';
+import { SettingActionItem, SettingToggleItem } from '../SettingItem';
+
+export function DeveloperPanel() {
+  const router = useRouter();
+  const { close } = useModal();
+  const { showDeveloperOptions, setShowDeveloperOptions } = useAppSettings();
+
+  const handleOpenApiKeys = () => {
+    close('monarchSettings');
+    router.push('/api-keys');
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 rounded bg-surface p-4">
+        <h3 className="text-xs uppercase text-secondary">API Access</h3>
+        <SettingActionItem
+          title="API Keys"
+          description="Create a Monarch API key for data access."
+          buttonLabel="Create"
+          onClick={handleOpenApiKeys}
+        />
+      </div>
+
+      <div className="flex flex-col gap-4 rounded bg-surface p-4">
+        <h3 className="text-xs uppercase text-secondary">Advanced Tools</h3>
+        <SettingToggleItem
+          title="Developer Options"
+          description="Show advanced developer tools like Accrue Interest and Liquidate in market detail views."
+          selected={showDeveloperOptions}
+          onChange={setShowDeveloperOptions}
+          ariaLabel="Toggle developer options"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/modals/settings/monarch-settings/panels/ExperimentalPanel.tsx
+++ b/src/modals/settings/monarch-settings/panels/ExperimentalPanel.tsx
@@ -12,7 +12,7 @@ type ExperimentalPanelProps = {
 
 export function ExperimentalPanel({ onNavigateToDetail }: ExperimentalPanelProps) {
   const { showOfficialTrending, setShowOfficialTrending, customTagConfig, setCustomTagEnabled } = useMarketPreferences();
-  const { showDeveloperOptions, setShowDeveloperOptions, usePublicAllocator, setUsePublicAllocator } = useAppSettings();
+  const { usePublicAllocator, setUsePublicAllocator } = useAppSettings();
 
   return (
     <div className="flex flex-col gap-4">
@@ -60,18 +60,6 @@ export function ExperimentalPanel({ onNavigateToDetail }: ExperimentalPanelProps
           selected={usePublicAllocator}
           onChange={setUsePublicAllocator}
           ariaLabel="Toggle public allocator"
-        />
-      </div>
-
-      {/* Developer */}
-      <div className="flex flex-col gap-4 rounded bg-surface p-4">
-        <h3 className="text-xs uppercase text-secondary">Developer</h3>
-        <SettingToggleItem
-          title="Developer Options"
-          description="Show advanced developer tools like Accrue Interest and Liquidate in market detail views."
-          selected={showDeveloperOptions}
-          onChange={setShowDeveloperOptions}
-          ariaLabel="Toggle developer options"
         />
       </div>
     </div>

--- a/src/modals/settings/monarch-settings/panels/index.ts
+++ b/src/modals/settings/monarch-settings/panels/index.ts
@@ -2,4 +2,5 @@ export { TransactionPanel } from './TransactionPanel';
 export { DisplayPanel } from './DisplayPanel';
 export { FiltersPanel } from './FiltersPanel';
 export { PreferencesPanel } from './PreferencesPanel';
+export { DeveloperPanel } from './DeveloperPanel';
 export { ExperimentalPanel } from './ExperimentalPanel';

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,5 +1,6 @@
 import type { Address } from 'viem';
 import { create } from 'zustand';
+import type { SettingsCategory } from '@/modals/settings/monarch-settings/constants';
 import type { Market, MarketPosition, GroupedPosition } from '@/utils/types';
 import type { SwapToken } from '@/features/swap/types';
 import type { SupportedNetworks } from '@/utils/networks';
@@ -63,7 +64,7 @@ export type ModalProps = {
   };
 
   monarchSettings: {
-    initialCategory?: 'transaction' | 'display' | 'filters' | 'preferences' | 'experimental';
+    initialCategory?: SettingsCategory;
     initialDetailView?: 'custom-tag-config' | 'trusted-vaults' | 'blacklisted-markets' | 'rpc-config' | 'filter-thresholds';
     onCloseCallback?: () => void;
   };


### PR DESCRIPTION
## Summary
- move Swap into the shared More/menu dropdown and remove the portfolio-page swap button
- unify desktop and mobile menu ordering, remove GitHub, and move API Keys into Settings > Developer
- align the position-page identity row by using shared account identity chips and bookmark handling

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check
- Playwright Chrome check: desktop/mobile menu order and Settings > Developer API Keys entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Developer settings panel with API Keys access option.

* **UI Improvements**
  * Reorganized header navigation for clearer menu structure.
  * Streamlined mobile menu navigation.
  * Enhanced account identity display with improved layout and wrapping.
  * Refined account actions popover alignment and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->