### PR TITLE
fix: include idle assets in vault live APY

### DIFF
--- a/src/features/autovault/components/vault-detail/vault-header.tsx
+++ b/src/features/autovault/components/vault-detail/vault-header.tsx
@@ -125,13 +125,14 @@ export function VaultHeader({
       ? `${formatVaultAdapterType(capsAdapterRows[0].adapterType)} ${getSlicedAddress(capsAdapterRows[0].adapter)}`
       : `${capsAdapterRows.length} configured adapters`;
   const hasRewards = rewards.length > 0;
-  const rewardsDetail = [
-    baseRateLabel ? `Base ${rateLabel} ${baseRateLabel}` : null,
+  const rateDetail = [
+    hasRewards && baseRateLabel ? `Base ${rateLabel} ${baseRateLabel}` : null,
     ...rewards.map((reward) => `${reward.assetSymbol} reward +${(reward.rate * 100).toFixed(2)}%`),
-    `Net ${rateLabel} ${apyLabel}`,
+    hasRewards ? `Net ${rateLabel} ${apyLabel}` : null,
   ]
     .filter((row): row is string => Boolean(row))
     .join('\n');
+  const hasRateDetail = rateDetail.length > 0;
 
   return (
     <div className="mt-6 mb-6 space-y-4">
@@ -239,12 +240,12 @@ export function VaultHeader({
                 <div className="flex items-center gap-2">
                   {isLoading ? (
                     <div className="h-6 w-16 animate-pulse rounded bg-hovered" />
-                  ) : hasRewards ? (
+                  ) : hasRateDetail ? (
                     <Tooltip
                       content={
                         <TooltipContent
                           title={`Vault ${rateLabel} Breakdown`}
-                          detail={rewardsDetail}
+                          detail={rateDetail}
                         />
                       }
                     >

--- a/src/features/autovault/components/vault-detail/vault-market-allocations.tsx
+++ b/src/features/autovault/components/vault-detail/vault-market-allocations.tsx
@@ -74,6 +74,7 @@ export function VaultMarketAllocations({ vaultAddress, chainId, needsInitializat
           marketAllocations={marketAllocations}
           totalAssets={totalAllocation}
           chainId={chainId}
+          allocationAssetAddress={vaultData.assetAddress}
           allocationAssetSymbol={vaultData.tokenSymbol}
           allocationAssetDecimals={vaultData.tokenDecimals}
           showExplorerLink

--- a/src/features/position-detail/components/markets-breakdown-table.tsx
+++ b/src/features/position-detail/components/markets-breakdown-table.tsx
@@ -16,7 +16,7 @@ import { MarketActionsCell } from './market-actions-cell';
 import { useAppSettings } from '@/stores/useAppSettings';
 import { useRateLabel } from '@/hooks/useRateLabel';
 import { formatReadable, formatBalance } from '@/utils/balance';
-import { convertApyToApr } from '@/utils/rateMath';
+import { formatRateAsPercentage, toDisplayRateFromApy } from '@/utils/rateMath';
 import type { MarketPositionWithEarnings } from '@/utils/types';
 import type { SupportedNetworks } from '@/utils/networks';
 import type { EarningsTimeRange } from '@/hooks/useUserPositionsSummaryData';
@@ -39,7 +39,6 @@ type MarketRowProps = {
   isEarningsLoading: boolean;
   actualBlockData: Record<number, { block: number; timestamp: number }>;
   periodLabel: string;
-  rateLabel: string;
   isAprDisplay: boolean;
   isOwner: boolean;
   totalWeightedCapital: bigint;
@@ -51,7 +50,6 @@ function MarketRow({
   isEarningsLoading,
   actualBlockData,
   periodLabel,
-  rateLabel,
   isAprDisplay,
   isOwner,
   totalWeightedCapital,
@@ -67,9 +65,15 @@ function MarketRow({
   const weightBps = totalWeightedCapital > 0n ? (weightedCapital * 10_000n) / totalWeightedCapital : 0n;
   const weightPct = Number(weightBps) / 100;
 
+  const formatDisplayRate = (apy: number | null | undefined) => {
+    if (apy === null || apy === undefined || !Number.isFinite(apy)) return '-';
+    return formatRateAsPercentage(toDisplayRateFromApy(apy, isAprDisplay));
+  };
+  const liveRate = formatDisplayRate(market.state.supplyApy);
+
   // Actual APY from earnings calculation
   const actualApy = position.actualApy ?? 0;
-  const displayActualRate = isAprDisplay ? convertApyToApr(actualApy) : actualApy;
+  const displayActualRate = toDisplayRateFromApy(actualApy, isAprDisplay);
 
   const formatTokenAmount = (value: bigint) => formatReadable(Number(formatBalance(value, loanDecimals)));
 
@@ -182,6 +186,14 @@ function MarketRow({
             height={16}
           />
         </div>
+      </TableCell>
+
+      {/* Live APY */}
+      <TableCell
+        className="px-4 py-3 text-right"
+        style={{ minWidth: '100px' }}
+      >
+        <span className="tabular-nums">{liveRate}</span>
       </TableCell>
 
       {/* Actual APY (from earnings) */}
@@ -344,6 +356,12 @@ export function MarketsBreakdownTable({
             </TableHead>
             <TableHead
               className="px-4 py-3 text-right"
+              style={{ minWidth: '100px' }}
+            >
+              Live {rateLabel}
+            </TableHead>
+            <TableHead
+              className="px-4 py-3 text-right"
               style={{ minWidth: '90px' }}
             >
               <Tooltip
@@ -434,7 +452,6 @@ export function MarketsBreakdownTable({
               isEarningsLoading={isEarningsLoading}
               actualBlockData={actualBlockData}
               periodLabel={periodLabel}
-              rateLabel={rateLabel}
               isAprDisplay={isAprDisplay}
               isOwner={isOwner}
               totalWeightedCapital={totalWeightedCapital}

--- a/src/features/position-detail/components/position-header.tsx
+++ b/src/features/position-detail/components/position-header.tsx
@@ -18,7 +18,7 @@ import { useAppSettings } from '@/stores/useAppSettings';
 import { usePortfolioBookmarks } from '@/stores/usePortfolioBookmarks';
 import { formatReadable, formatBalance } from '@/utils/balance';
 import { getNetworkImg, getNetworkName, type SupportedNetworks } from '@/utils/networks';
-import { convertApyToApr } from '@/utils/rateMath';
+import { formatRateAsPercentage, toDisplayRateFromApy } from '@/utils/rateMath';
 import { getGroupedEarnings } from '@/utils/positions';
 import { cn } from '@/utils/components';
 import type { GroupedPosition } from '@/utils/types';
@@ -79,17 +79,13 @@ export function PositionHeader({
 
   const formattedRate = (() => {
     if (!groupedPosition) return null;
-    const rate = groupedPosition.totalWeightedApy;
-    const displayRate = isAprDisplay ? convertApyToApr(rate) : rate;
-    return `${(displayRate * 100).toFixed(2)}%`;
+    return formatRateAsPercentage(toDisplayRateFromApy(groupedPosition.totalWeightedApy, isAprDisplay));
   })();
 
   // Actual/realized APY from earnings
   const formattedActualRate = (() => {
     if (!groupedPosition || !groupedPosition.actualApy) return null;
-    const rate = groupedPosition.actualApy;
-    const displayRate = isAprDisplay ? convertApyToApr(rate) : rate;
-    return `${(displayRate * 100).toFixed(2)}%`;
+    return formatRateAsPercentage(toDisplayRateFromApy(groupedPosition.actualApy, isAprDisplay));
   })();
 
   const totalSupplyFormatted = groupedPosition ? formatReadable(groupedPosition.totalSupply) : null;

--- a/src/features/vault/components/vault-adapter-position-overview.tsx
+++ b/src/features/vault/components/vault-adapter-position-overview.tsx
@@ -32,6 +32,7 @@ type VaultAdapterPositionOverviewProps = {
   transactions: UserTransaction[];
   snapshotsByChain: Record<number, Map<string, PositionSnapshot>>;
   marketAllocations: MarketAllocation[];
+  assetAddress?: Address;
   totalAssets?: bigint;
 };
 
@@ -42,6 +43,7 @@ type VaultMarketBreakdownTableProps = {
   isEarningsLoading: boolean;
   periodLabel: string;
   marketAllocations: MarketAllocation[];
+  assetAddress?: Address;
   totalAssets?: bigint;
 };
 
@@ -52,6 +54,7 @@ function VaultMarketBreakdownTable({
   isEarningsLoading,
   periodLabel,
   marketAllocations,
+  assetAddress,
   totalAssets,
 }: VaultMarketBreakdownTableProps) {
   const actions = (
@@ -81,6 +84,7 @@ function VaultMarketBreakdownTable({
         positions={positions}
         periodLabel={periodLabel}
         isEarningsLoading={isEarningsLoading}
+        allocationAssetAddress={assetAddress}
       />
     </TableContainerWithHeader>
   );
@@ -96,6 +100,7 @@ export function VaultAdapterPositionOverview({
   transactions,
   snapshotsByChain,
   marketAllocations,
+  assetAddress,
   totalAssets,
 }: VaultAdapterPositionOverviewProps) {
   const periodLabel = PERIOD_LABELS[period];
@@ -118,6 +123,7 @@ export function VaultAdapterPositionOverview({
         isEarningsLoading={isEarningsLoading}
         periodLabel={periodLabel}
         marketAllocations={marketAllocations}
+        assetAddress={assetAddress}
         totalAssets={totalAssets}
       />
     </div>

--- a/src/features/vault/components/vault-market-allocations-table.tsx
+++ b/src/features/vault/components/vault-market-allocations-table.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { PulseLoader } from 'react-spinners';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
 import { Tooltip } from '@/components/ui/tooltip';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { TokenIcon } from '@/components/shared/token-icon';
@@ -13,7 +14,7 @@ import { useRateLabel } from '@/hooks/useRateLabel';
 import type { MarketAllocation } from '@/types/vaultAllocations';
 import { formatBalance, formatReadable } from '@/utils/balance';
 import type { SupportedNetworks } from '@/utils/networks';
-import { convertApyToApr } from '@/utils/rateMath';
+import { formatRateAsPercentage, toDisplayRateFromApy } from '@/utils/rateMath';
 import type { Market, MarketPositionWithEarnings } from '@/utils/types';
 import { calculateAllocationPercent, formatVaultAbsoluteCap, parseRelativeCap } from '@/utils/vaultAllocation';
 
@@ -34,6 +35,7 @@ type VaultMarketAllocationsTableProps = {
   positions?: MarketPositionWithEarnings[];
   periodLabel?: string;
   isEarningsLoading?: boolean;
+  allocationAssetAddress?: string;
   allocationAssetSymbol?: string;
   allocationAssetDecimals?: number;
   showExplorerLink?: boolean;
@@ -55,6 +57,7 @@ export function VaultMarketAllocationsTable({
   positions = [],
   periodLabel,
   isEarningsLoading = false,
+  allocationAssetAddress,
   allocationAssetSymbol,
   allocationAssetDecimals,
   showExplorerLink = false,
@@ -87,11 +90,24 @@ export function VaultMarketAllocationsTable({
   }, [marketAllocations, positionByMarket]);
 
   const sortedRows = useMemo(() => sortRows(rows), [rows]);
+  const allocatedAssets = useMemo(() => {
+    return marketAllocations.reduce((sum, allocation) => sum + allocation.allocation, 0n);
+  }, [marketAllocations]);
   const totalAllocation = useMemo(() => {
     if (totalAssets !== undefined) return totalAssets;
-    return marketAllocations.reduce((sum, allocation) => sum + allocation.allocation, 0n);
-  }, [marketAllocations, totalAssets]);
+    return allocatedAssets;
+  }, [allocatedAssets, totalAssets]);
+  const idleAllocation = totalAssets !== undefined && totalAssets > allocatedAssets ? totalAssets - allocatedAssets : 0n;
+  const idleAsset = {
+    address: allocationAssetAddress ?? sortedRows[0]?.market.loanAsset.address,
+    decimals: allocationAssetDecimals ?? sortedRows[0]?.market.loanAsset.decimals,
+    symbol: allocationAssetSymbol ?? sortedRows[0]?.market.loanAsset.symbol,
+  };
   const isPositionMode = mode === 'position';
+  const formatDisplayRate = (apy: number | null | undefined) => {
+    if (apy === null || apy === undefined || !Number.isFinite(apy)) return '-';
+    return formatRateAsPercentage(toDisplayRateFromApy(apy, isAprDisplay));
+  };
 
   return (
     <Table className="w-full font-zen">
@@ -101,7 +117,7 @@ export function VaultMarketAllocationsTable({
           <TableHead className="px-4 py-3 text-right font-normal">Allocation</TableHead>
           {isPositionMode ? (
             <>
-              <TableHead className="px-4 py-3 text-right font-normal">Liquidity</TableHead>
+              <TableHead className="px-4 py-3 text-right font-normal">Live {rateLabel}</TableHead>
               <TableHead className="px-4 py-3 text-right font-normal">
                 <Tooltip
                   content={
@@ -133,10 +149,7 @@ export function VaultMarketAllocationsTable({
               </TableHead>
             </>
           ) : (
-            <>
-              <TableHead className="px-4 py-3 text-right font-normal">{rateLabel}</TableHead>
-              <TableHead className="px-4 py-3 text-right font-normal">Liquidity</TableHead>
-            </>
+            <TableHead className="px-4 py-3 text-right font-normal">Live {rateLabel}</TableHead>
           )}
         </TableRow>
       </TableHeader>
@@ -154,10 +167,9 @@ export function VaultMarketAllocationsTable({
             assetDecimals,
             assetSymbol,
           )}`;
-          const displayRate = isAprDisplay ? convertApyToApr(market.state.supplyApy) : market.state.supplyApy;
-          const realizedRate = isAprDisplay ? convertApyToApr(row.realizedApy ?? 0) : (row.realizedApy ?? 0);
+          const liveRate = formatDisplayRate(market.state.supplyApy);
+          const realizedRate = toDisplayRateFromApy(row.realizedApy ?? 0, isAprDisplay);
           const earnedAssets = row.earnedAssets ?? 0n;
-          const liquidity = formatReadable(formatBalance(BigInt(market.state.liquidityAssets || 0), market.loanAsset.decimals).toString());
 
           return (
             <TableRow
@@ -196,10 +208,10 @@ export function VaultMarketAllocationsTable({
               {isPositionMode ? (
                 <>
                   <TableCell
-                    className="px-4 py-3 text-right text-xs text-secondary whitespace-nowrap"
-                    style={{ minWidth: '130px' }}
+                    className="px-4 py-3 text-right text-xs whitespace-nowrap"
+                    style={{ minWidth: '110px' }}
                   >
-                    {liquidity}
+                    {liveRate}
                   </TableCell>
                   <TableCell
                     className="px-4 py-3 text-right"
@@ -251,16 +263,76 @@ export function VaultMarketAllocationsTable({
                   </TableCell>
                 </>
               ) : (
-                <>
-                  <TableCell className="px-4 py-3 text-right text-xs text-secondary whitespace-nowrap">
-                    {(displayRate * 100).toFixed(2)}%
-                  </TableCell>
-                  <TableCell className="px-4 py-3 text-right text-xs text-secondary whitespace-nowrap">{liquidity}</TableCell>
-                </>
+                <TableCell className="px-4 py-3 text-right text-xs whitespace-nowrap">{liveRate}</TableCell>
               )}
             </TableRow>
           );
         })}
+        {idleAllocation > 0n && idleAsset.decimals !== undefined && idleAsset.symbol && (
+          <TableRow className="hover:bg-hovered">
+            <TableCell
+              className="px-4 py-3"
+              style={{ minWidth: '220px' }}
+            >
+              <div className="flex items-center gap-2">
+                {idleAsset.address && (
+                  <TokenIcon
+                    address={idleAsset.address}
+                    chainId={chainId}
+                    symbol={idleAsset.symbol}
+                    width={18}
+                    height={18}
+                  />
+                )}
+                <span className="whitespace-nowrap text-primary">{idleAsset.symbol}</span>
+                <span className="text-secondary">/</span>
+                <span className="whitespace-nowrap text-secondary">empty</span>
+                <Badge
+                  variant="default"
+                  size="sm"
+                  className="ml-1 font-normal"
+                >
+                  idle
+                </Badge>
+              </div>
+            </TableCell>
+            <TableCell
+              className="px-4 py-3"
+              style={{ minWidth: '150px' }}
+            >
+              <AllocationCell
+                amount={formatBalance(idleAllocation, idleAsset.decimals)}
+                symbol={idleAsset.symbol}
+                percentage={totalAllocation > 0n ? Number.parseFloat(calculateAllocationPercent(idleAllocation, totalAllocation)) : 0}
+                compact
+              />
+            </TableCell>
+            {isPositionMode ? (
+              <>
+                <TableCell
+                  className="px-4 py-3 text-right text-xs whitespace-nowrap"
+                  style={{ minWidth: '110px' }}
+                >
+                  {formatDisplayRate(0)}
+                </TableCell>
+                <TableCell
+                  className="px-4 py-3 text-right text-secondary"
+                  style={{ minWidth: '130px' }}
+                >
+                  -
+                </TableCell>
+                <TableCell
+                  className="px-4 py-3 text-right text-secondary"
+                  style={{ minWidth: '120px' }}
+                >
+                  -
+                </TableCell>
+              </>
+            ) : (
+              <TableCell className="px-4 py-3 text-right text-xs whitespace-nowrap">{formatDisplayRate(0)}</TableCell>
+            )}
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   );

--- a/src/features/vault/vault-view.tsx
+++ b/src/features/vault/vault-view.tsx
@@ -39,7 +39,7 @@ import { getSlicedAddress } from '@/utils/address';
 import { getVaultURL, supportsMorphoAppLinks } from '@/utils/external';
 import { parseCapIdParams } from '@/utils/morpho';
 import { groupPositionsByLoanAsset, processCollaterals } from '@/utils/positions';
-import { convertAprToApy, convertApyToApr } from '@/utils/rateMath';
+import { convertAprToApy, formatRateAsPercentage, toDisplayRateFromApy } from '@/utils/rateMath';
 import { ALL_SUPPORTED_NETWORKS, getNetworkConfig, SupportedNetworks } from '@/utils/networks';
 import { formatVaultAdapterType } from '@/utils/vaults';
 
@@ -185,6 +185,7 @@ function VaultAdapterPositionDetail({
             transactions={relevantTransactions}
             snapshotsByChain={snapshotsByChain}
             marketAllocations={marketAllocations}
+            assetAddress={assetAddress}
             totalAssets={totalAssets}
           />
         </div>
@@ -336,7 +337,7 @@ export default function VaultContent() {
   const baseVaultApy = vaultRewardsData?.apy ?? vaultAPY;
   const baseVaultRate = useMemo(() => {
     if (baseVaultApy === null || baseVaultApy === undefined) return null;
-    return isAprDisplay ? convertApyToApr(baseVaultApy) : baseVaultApy;
+    return toDisplayRateFromApy(baseVaultApy, isAprDisplay);
   }, [baseVaultApy, isAprDisplay]);
 
   const displayedVaultRate = useMemo(() => {
@@ -354,7 +355,7 @@ export default function VaultContent() {
 
   const baseRateLabel = useMemo(() => {
     if (baseVaultRate === null || baseVaultRate === undefined) return undefined;
-    return `${(baseVaultRate * 100).toFixed(2)}%`;
+    return formatRateAsPercentage(baseVaultRate);
   }, [baseVaultRate]);
 
   const totalAssetsLabel = useMemo(() => {

--- a/src/hooks/useUserPositions.ts
+++ b/src/hooks/useUserPositions.ts
@@ -34,6 +34,7 @@ type UseUserPositionsOptions = {
 };
 
 const EMPTY_MARKET_HINTS: UserPositionMarketHint[] = [];
+const POSITION_MARKET_DETAIL_STALE_TIME_MS = 30_000;
 
 type PositionsFetchSource = 'morpho-api';
 
@@ -306,21 +307,6 @@ const useUserPositions = (
     return chainIds ? cachedMarkets.filter((market) => chainIds.includes(market.chainId as SupportedNetworks)) : cachedMarkets;
   }, [chainIds, getUserMarkets, hasMarketHints]);
 
-  const cachedMarketDataMap = useMemo(() => {
-    const marketMap = new Map<string, Market>();
-
-    for (const cachedResponse of Object.values(cachedMarketDetailsByKey)) {
-      const market = cachedResponse.data;
-      if (!market?.uniqueKey || !market.morphoBlue?.chain?.id) {
-        continue;
-      }
-
-      marketMap.set(getMarketIdentityKey(market.morphoBlue.chain.id, market.uniqueKey), market);
-    }
-
-    return marketMap;
-  }, [cachedMarketDetailsByKey]);
-
   const initialPositionData = useMemo<InitialDataResponse | undefined>(() => {
     const seedMarkets = hasMarketHints ? marketHints : cachedPositionMarkets;
     const finalMarketKeys = filterBlacklistedPositionMarkets(seedMarkets);
@@ -392,7 +378,19 @@ const useUserPositions = (
         }
       }
 
-      for (const [key, market] of cachedMarketDataMap) {
+      for (const cachedResponse of Object.values(cachedMarketDetailsByKey)) {
+        // Position live APY comes from market state, so persisted details must
+        // follow the same short freshness window as the market-detail query.
+        if (Date.now() - cachedResponse.updatedAt > POSITION_MARKET_DETAIL_STALE_TIME_MS) {
+          continue;
+        }
+
+        const market = cachedResponse.data;
+        if (!market?.uniqueKey || !market.morphoBlue?.chain?.id) {
+          continue;
+        }
+
+        const key = getMarketIdentityKey(market.morphoBlue.chain.id, market.uniqueKey);
         if (!marketDataMap.has(key)) {
           marketDataMap.set(key, market);
         }

--- a/src/hooks/useVaultPage.ts
+++ b/src/hooks/useVaultPage.ts
@@ -51,8 +51,8 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
     [adapterQuery.primaryAdapter, hasResolvedAdapterState],
   );
 
-  // Weighted average across configured market allocations. This avoids position
-  // discovery and historical RPC reads on the first vault paint.
+  // Weighted average across current vault assets. Idle vault assets are part of
+  // the denominator at 0% yield, matching the vault's real deployed capital.
   const vaultAPY = useMemo(() => {
     if (allocationsQuery.marketAllocations.length === 0) return null;
 
@@ -68,9 +68,11 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
       weightedAPY += allocated * (allocation.market.state.supplyApy ?? 0);
     }
 
-    if (totalAllocated === 0) return null;
-    return weightedAPY / totalAllocated;
-  }, [allocationsQuery.marketAllocations, vaultDataQuery.data?.tokenDecimals]);
+    const totalVaultAssets = contract.totalAssets > 0n ? formatBalance(contract.totalAssets, tokenDecimals) : 0;
+    const denominator = Math.max(totalVaultAssets, totalAllocated);
+    if (denominator === 0) return null;
+    return weightedAPY / denominator;
+  }, [allocationsQuery.marketAllocations, contract.totalAssets, vaultDataQuery.data?.tokenDecimals]);
 
   // Complex derived state: needsInitialization
   const needsInitialization = useMemo(() => {

--- a/src/hooks/useVaultSharePriceHistory.ts
+++ b/src/hooks/useVaultSharePriceHistory.ts
@@ -43,6 +43,21 @@ type VaultSharePriceHistory = {
   source: 'morpho-api' | 'none' | 'rpc';
 };
 
+export function selectNearestVaultSharePricePoint(points: VaultSharePricePoint[], targetTimestamp: number) {
+  let nearestPoint: VaultSharePricePoint | undefined;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const point of points) {
+    const distance = Math.abs(point.timestamp - targetTimestamp);
+    if (distance >= nearestDistance) continue;
+
+    nearestPoint = point;
+    nearestDistance = distance;
+  }
+
+  return nearestPoint;
+}
+
 function getMorphoSharePriceOptions(timeframe: ChartTimeframe, timeRange: TimeseriesOptions): TimeseriesOptions {
   return {
     ...timeRange,

--- a/src/utils/rateMath.ts
+++ b/src/utils/rateMath.ts
@@ -85,6 +85,25 @@ export function formatRateAsPercentage(rate: number, precision = 2): string {
   return `${(rate * 100).toFixed(precision)}%`;
 }
 
+export function computeAnnualizedApyFromValueGrowth({
+  currentValue,
+  pastValue,
+  periodSeconds,
+}: {
+  currentValue: number;
+  pastValue: number;
+  periodSeconds: number;
+}): number | null {
+  if (!Number.isFinite(currentValue) || !Number.isFinite(pastValue) || currentValue <= 0 || pastValue <= 0 || periodSeconds <= 0) {
+    return null;
+  }
+
+  const annualizationFactor = SECONDS_PER_YEAR / periodSeconds;
+  const annualizedApy = (currentValue / pastValue) ** annualizationFactor - 1;
+
+  return Number.isFinite(annualizedApy) ? annualizedApy : null;
+}
+
 export function computeAnnualizedApyFromGrowth({
   currentValue,
   pastValue,
@@ -99,8 +118,9 @@ export function computeAnnualizedApyFromGrowth({
   const growthRatio = toScaledRatio(currentValue, pastValue);
   if (growthRatio == null || growthRatio <= 0) return null;
 
-  const annualizationFactor = SECONDS_PER_YEAR / periodSeconds;
-  const annualizedApy = growthRatio ** annualizationFactor - 1;
-
-  return Number.isFinite(annualizedApy) ? annualizedApy : null;
+  return computeAnnualizedApyFromValueGrowth({
+    currentValue: growthRatio,
+    pastValue: 1,
+    periodSeconds,
+  });
 }


### PR DESCRIPTION
## Summary
- include idle vault assets in the vault live APY denominator at 0% yield
- add an idle asset row to vault market breakdown tables so users can see the idle allocation diluting the live APY
- keep the base vault APY on Monarch/on-chain data: Monarch caps + market state, RPC allocation(capId), and RPC totalAssets()
- remove redundant Live APY hover details from vault and position APY surfaces while keeping useful reward and period-metric details
- keep the position live APY cache fix so vault and position views do not disagree because of stale persisted market data

## Root cause
The vault APY was dividing weighted market yield by allocated market assets only. For the reported mainnet vault, current live data shows about 34.57M USDC allocated and 62.18M USDC total assets, leaving about 27.61M USDC idle. Ignoring that idle balance produced an allocation-only APY around 75.59%; including idle assets at 0% yield gives an idle-aware APY around 42.03%.

The breakdown table now renders that idle balance as an `idle` row with the vault asset, allocation share, and 0.00% live rate, making the dilution visible beside the market rows.

## Validation
- direct live validation for vault `0x0bf0164d17469241b6e086da4016dcc54feaa334`: 34.57M USDC allocated, 62.18M USDC total assets, 27.61M USDC idle
- allocation-only APY: 75.59%; idle-aware APY: 42.03%
- `npx ultracite fix`
- `git diff --check`
- `npx ultracite check`
- `pnpm typecheck`