### PR TITLE
Add msY depeg market warning

### DIFF
--- a/src/utils/markets.ts
+++ b/src/utils/markets.ts
@@ -156,7 +156,10 @@ export const marketOverrideRules: MarketOverrideRule[] = [
     ],
   },
   {
-    marketIds: ['0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8'],
+    marketIds: [
+      '0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8',
+      '0xb317d11c2bc2c0c8e6ea3c6517731cf667c86f2c716624be50319a6d32a97e8d',
+    ],
     warnings: [
       {
         code: 'msy_depeg',

--- a/src/utils/markets.ts
+++ b/src/utils/markets.ts
@@ -155,6 +155,17 @@ export const marketOverrideRules: MarketOverrideRule[] = [
       },
     ],
   },
+  {
+    marketIds: ['0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8'],
+    warnings: [
+      {
+        code: 'msy_depeg',
+        level: 'alert',
+        description: 'msY is experiencing a depeg. This market carries elevated risk and may result in losses.',
+        category: 'general',
+      },
+    ],
+  },
 ];
 
 // Helper functions to query the override rules


### PR DESCRIPTION
## Summary
- add alert-level override warnings for the msY depeg markets
- reuses the existing market override warning path used by other flagged markets

## Validation
- pnpm exec ultracite fix src/utils/markets.ts
- pnpm exec ultracite check src/utils/markets.ts
- pnpm typecheck
- source check confirmed the msY warning rule includes both market IDs and keeps alert level