### PR TITLE
fix: show market price debt warnings in details

### DIFF
--- a/src/features/market-detail/market-view.tsx
+++ b/src/features/market-detail/market-view.tsx
@@ -29,6 +29,8 @@ import TransactionFiltersModal from '@/features/market-detail/components/filters
 import { useMarketWarnings } from '@/hooks/useMarketWarnings';
 import { useMarketLiquiditySourcing } from '@/hooks/useMarketLiquiditySourcing';
 import { useAllMarketBorrowers, useAllMarketSuppliers } from '@/hooks/useAllMarketPositions';
+import { getMetricsKey, useMarketMetricsMap } from '@/hooks/queries/useMarketMetricsQuery';
+import { withMarketPriceBadDebtWarning } from '@/features/markets/utils/market-price-debt-risk';
 import { normalizeMarketUniqueKey } from '@/utils/markets';
 import { ProActivitiesTable } from './components/pro-activities-table';
 import { MarketHeader } from './components/market-header';
@@ -99,7 +101,14 @@ function MarketContent() {
   const { position: userPosition, refetch: refetchUserPosition } = useUserPosition(address, network, marketKey);
 
   // Get all warnings for this market (hook handles undefined market)
-  const allWarnings = useMarketWarnings(market);
+  const baseWarnings = useMarketWarnings(market);
+  const { metricsMap } = useMarketMetricsMap({
+    chainId: network,
+    enabled: Boolean(market),
+    defer: true,
+  });
+  const marketMetrics = market ? (metricsMap.get(getMetricsKey(market.morphoBlue.chain.id, market.uniqueKey)) ?? null) : null;
+  const allWarnings = useMemo(() => withMarketPriceBadDebtWarning(marketMetrics, baseWarnings), [baseWarnings, marketMetrics]);
 
   // Pre-fetch Public Allocator data eagerly so modals have instant access
   const liquiditySourcing = useMarketLiquiditySourcing(market ?? undefined, network);

--- a/src/features/markets/components/table/market-row-detail.tsx
+++ b/src/features/markets/components/table/market-row-detail.tsx
@@ -1,6 +1,7 @@
 import { Info } from '@/components/Info/info';
 import { EstimatedValueTooltip } from '@/components/shared/estimated-value-tooltip';
 import { OracleTypeInfo } from '@/features/markets/components/oracle';
+import { withMarketPriceBadDebtWarning } from '@/features/markets/utils/market-price-debt-risk';
 import type { MarketMetrics } from '@/hooks/queries/useMarketMetricsQuery';
 import { useMarketWarnings } from '@/hooks/useMarketWarnings';
 import { formatReadable } from '@/utils/balance';
@@ -43,7 +44,8 @@ function getMarketCreatedDisplay(createdAt: string | null | undefined) {
 }
 
 export function ExpandedMarketDetail({ market, marketMetrics }: ExpandedMarketDetailProps) {
-  const warningsWithDetail = useMarketWarnings(market);
+  const baseWarnings = useMarketWarnings(market);
+  const warningsWithDetail = withMarketPriceBadDebtWarning(marketMetrics, baseWarnings);
   const marketCreatedDisplay = getMarketCreatedDisplay(marketMetrics?.marketCreatedAt);
 
   return (

--- a/src/features/markets/utils/market-price-debt-risk.ts
+++ b/src/features/markets/utils/market-price-debt-risk.ts
@@ -54,3 +54,15 @@ export function getMarketPriceBadDebtWarning(metrics: MarketMetrics | null | und
     category: WarningCategory.debt,
   };
 }
+
+export function withMarketPriceBadDebtWarning(
+  metrics: MarketMetrics | null | undefined,
+  warnings: WarningWithDetail[],
+): WarningWithDetail[] {
+  const marketPriceBadDebtWarning = getMarketPriceBadDebtWarning(metrics);
+  if (!marketPriceBadDebtWarning || warnings.some((warning) => warning.code === marketPriceBadDebtWarning.code)) {
+    return warnings;
+  }
+
+  return [marketPriceBadDebtWarning, ...warnings];
+}


### PR DESCRIPTION
## Summary
- merge metrics-derived market price bad debt warnings through a shared helper
- show the independent price warning in expanded market rows
- show the same warning set in market detail Advanced Details

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- pnpm lint:check
- git diff --check

## Scope cleanup
- removed the local msY override diff from this PR because it is already on master via #589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Market warnings now incorporate market price and bad debt metrics, providing more detailed risk information in market detail and market overview views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->