### PR TITLE
Fix Safe wallet connection flows

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,27 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: '/manifest.json',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: '*',
+          },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value: 'X-Requested-With, content-type, Authorization',
+          },
+        ],
+      },
+    ];
+  },
   // temp fix for reown package issue: https://github.com/MetaMask/metamask-sdk/issues/1376
   webpack: (config) => {
     config.resolve.fallback = {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,20 +1,12 @@
 {
   "name": "Monarch",
+  "description": "A DeFi dashboard for inspecting and managing Morpho lending markets and vault positions.",
   "short_name": "Monarch",
+  "iconPath": "icon.png",
   "icons": [
     {
-      "src": "/icons/16x16.png",
-      "sizes": "16x16",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/48x48.png",
-      "sizes": "48x48",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/96x96.png",
-      "sizes": "96x96",
+      "src": "/icon.png",
+      "sizes": "309x308",
       "type": "image/png"
     }
   ],

--- a/src/config/wagmi.ts
+++ b/src/config/wagmi.ts
@@ -123,6 +123,8 @@ type WalletConnectWalletOptions = {
 const isMobileBrowser = () =>
   typeof navigator !== 'undefined' && /Android|BlackBerry|iPad|iPhone|iPod|IEMobile|Mobile|Opera Mini/i.test(navigator.userAgent);
 
+const isSafeAppFrame = () => typeof window !== 'undefined' && window.parent !== window;
+
 const rabbyMobileWalletConnect = ({ projectId, walletConnectParameters }: WalletConnectWalletOptions): Wallet => {
   const rabbyExtensionWallet = rabbyWallet();
   const getUri = (uri: string) => `rabby://wc?uri=${encodeURIComponent(uri)}`;
@@ -146,7 +148,15 @@ const rabbyMobileWalletConnect = ({ projectId, walletConnectParameters }: Wallet
 
 const safeWalletConnect = ({ projectId, walletConnectParameters }: WalletConnectWalletOptions): Wallet => {
   const safeAppWallet = safeWallet();
-  const getUri = (uri: string) => `https://app.safe.global/wc?uri=${encodeURIComponent(uri)}`;
+  const openSafeWithWalletConnect = (uri: string) => `https://app.safe.global/wc?uri=${encodeURIComponent(uri)}`;
+  const openSafeWithWalletConnectDesktop = (uri: string) => {
+    if (typeof window !== 'undefined') {
+      window.open(openSafeWithWalletConnect(uri), '_blank', 'noopener,noreferrer');
+    }
+
+    // RainbowKit 2.2 opens desktop URIs in _self. We already opened Safe in a new tab.
+    return '';
+  };
 
   return {
     id: 'safe-walletconnect',
@@ -154,25 +164,26 @@ const safeWalletConnect = ({ projectId, walletConnectParameters }: WalletConnect
     iconAccent: safeAppWallet.iconAccent,
     iconBackground: safeAppWallet.iconBackground,
     iconUrl: safeAppWallet.iconUrl,
+    hidden: isSafeAppFrame,
     downloadUrls: {
       desktop: 'https://app.safe.global',
       mobile: 'https://safe.global/mobile',
     },
-    desktop: {
-      getUri,
+    desktop: { getUri: openSafeWithWalletConnectDesktop },
+    mobile: { getUri: openSafeWithWalletConnect },
+    qrCode: {
+      getUri: (uri) => uri,
       instructions: {
         learnMoreUrl: 'https://help.safe.global/articles/6643739210-how-to-connect-a-safe-to-a-dapp-using-walletconnect',
         steps: [
           {
             step: 'connect',
-            title: 'Open Safe',
-            description: 'Open Safe and approve the WalletConnect request.',
+            title: 'Connect with Safe',
+            description: 'Open Safe WalletConnect and approve the connection request.',
           },
         ],
       },
     },
-    mobile: { getUri },
-    qrCode: { getUri },
     createConnector: getWalletConnectConnector({ projectId, walletConnectParameters }),
   };
 };
@@ -189,6 +200,7 @@ const connectors = connectorsForWallets(
         trustWallet,
         rainbowWallet,
         safeWalletConnect,
+        safeWallet,
         walletConnectWallet,
       ],
     },
@@ -208,7 +220,6 @@ const connectors = connectorsForWallets(
         enkryptWallet,
         backpackWallet,
         injectedWallet,
-        safeWallet,
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- add a Safe WalletConnect option that opens Safe's `/wc?uri=...` flow in a new tab instead of replacing Monarch
- keep the official RainbowKit Safe connector available for Safe App iframe usage while hiding the WalletConnect Safe row in that context
- update the web manifest and CORS headers so Monarch can be loaded as a custom Safe App

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check
- pnpm build
- local browser smoke: Connect -> Safe kept Monarch on localhost and opened `https://app.safe.global/wc?uri=wc%3A...` in a new tab
- local manifest check: `/manifest.json` returned Safe-required CORS headers and Safe-required manifest fields

## Notes
- Current production still serves the old manifest until this PR is deployed.
- Full WalletConnect approval requires choosing a real Safe inside Safe Wallet; locally I verified the handoff URL and tab behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Safe wallet now featured in Recommended wallets section for greater visibility
  * Enhanced Safe wallet integration with improved iframe detection and optimized WalletConnect handling

* **Updates**
  * Updated application icon from raster to SVG format
  * Refreshed application manifest metadata and description

<!-- end of auto-generated comment: release notes by coderabbit.ai -->