### PR TITLE
Add asset blacklist controls

### DIFF
--- a/src/features/markets/components/blacklist-assets-modal.tsx
+++ b/src/features/markets/components/blacklist-assets-modal.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { IoWarningOutline } from 'react-icons/io5';
+import { Button } from '@/components/ui/button';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '@/components/common/Modal';
+import { TokenIcon } from '@/components/shared/token-icon';
+import { SettingToggleItem } from '@/modals/settings/monarch-settings/SettingItem';
+import { getAssetBlacklistKey, useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
+import type { Market, TokenInfo } from '@/utils/types';
+
+function AssetSwitchRow({
+  asset,
+  chainId,
+  selected,
+  onChange,
+  roleLabel,
+}: {
+  asset: TokenInfo;
+  chainId: number;
+  selected: boolean;
+  onChange: (selected: boolean) => void;
+  roleLabel: string;
+}) {
+  return (
+    <div className="rounded bg-surface-soft p-3">
+      <SettingToggleItem
+        title={`${asset.symbol} ${roleLabel}`}
+        description={
+          <div className="flex min-w-0 items-center gap-2">
+            <TokenIcon
+              address={asset.address}
+              chainId={chainId}
+              width={18}
+              height={18}
+              symbol={asset.symbol}
+            />
+            <span className="truncate">{asset.name}</span>
+          </div>
+        }
+        selected={selected}
+        onChange={onChange}
+        ariaLabel={`Toggle ${asset.symbol} asset blacklist`}
+        color="destructive"
+      />
+    </div>
+  );
+}
+
+type BlacklistAssetsModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  market: Market | null;
+  onAssetAdded?: (symbol: string) => void;
+  onAssetRemoved?: (symbol: string) => void;
+};
+
+export function BlacklistAssetsModal({ isOpen, onOpenChange, market, onAssetAdded, onAssetRemoved }: BlacklistAssetsModalProps) {
+  const { addBlacklistedAsset, removeBlacklistedAsset, isAssetBlacklisted } = useBlacklistedAssets();
+
+  if (!market) return null;
+
+  const chainId = market.morphoBlue.chain.id;
+  const assets = [
+    { token: market.loanAsset, label: 'loan asset' },
+    { token: market.collateralAsset, label: 'collateral asset' },
+  ];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      size="md"
+    >
+      <ModalHeader
+        variant="compact"
+        mainIcon={<IoWarningOutline className="h-5 w-5 text-orange-500" />}
+        title="Blacklist Assets"
+        description="Hide every market that uses these assets"
+        className="border-b border-primary/10"
+        onClose={() => onOpenChange(false)}
+      />
+      <ModalBody
+        variant="compact"
+        className="py-6"
+      >
+        <div className="flex flex-col gap-3">
+          <div className="rounded bg-orange-500/10 p-3 text-xs text-secondary">
+            Switch on an asset to hide all markets where it appears as loan or collateral. You can remove assets later in Settings.
+          </div>
+
+          {assets.map(({ token, label }) => {
+            const selected = isAssetBlacklisted(chainId, token.address);
+
+            return (
+              <AssetSwitchRow
+                key={getAssetBlacklistKey(chainId, token.address)}
+                asset={token}
+                chainId={chainId}
+                roleLabel={label}
+                selected={selected}
+                onChange={(nextSelected) => {
+                  if (nextSelected) {
+                    const added = addBlacklistedAsset({
+                      address: token.address,
+                      chainId,
+                      symbol: token.symbol,
+                      name: token.name,
+                    });
+                    if (added) onAssetAdded?.(token.symbol);
+                    return;
+                  }
+
+                  removeBlacklistedAsset(chainId, token.address);
+                  onAssetRemoved?.(token.symbol);
+                }}
+              />
+            );
+          })}
+        </div>
+      </ModalBody>
+      <ModalFooter className="border-t border-primary/10">
+        <Button
+          variant="primary"
+          size="md"
+          onClick={() => onOpenChange(false)}
+        >
+          Done
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/features/markets/components/blacklist-assets-modal.tsx
+++ b/src/features/markets/components/blacklist-assets-modal.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { IoWarningOutline } from 'react-icons/io5';
 import { Button } from '@/components/ui/button';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '@/components/common/Modal';
 import { TokenIcon } from '@/components/shared/token-icon';
+import { useStyledToast } from '@/hooks/useStyledToast';
 import { SettingToggleItem } from '@/modals/settings/monarch-settings/SettingItem';
 import { getAssetBlacklistKey, useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
 import type { Market, TokenInfo } from '@/utils/types';
@@ -21,10 +21,13 @@ function AssetSwitchRow({
   onChange: (selected: boolean) => void;
   roleLabel: string;
 }) {
+  const assetSymbol = asset.symbol || 'Unknown';
+  const assetName = asset.name || 'Unknown asset';
+
   return (
-    <div className="rounded bg-surface-soft p-3">
+    <div className="rounded bg-surface p-3">
       <SettingToggleItem
-        title={`${asset.symbol} ${roleLabel}`}
+        title={`${assetSymbol} ${roleLabel}`}
         description={
           <div className="flex min-w-0 items-center gap-2">
             <TokenIcon
@@ -32,14 +35,14 @@ function AssetSwitchRow({
               chainId={chainId}
               width={18}
               height={18}
-              symbol={asset.symbol}
+              symbol={assetSymbol}
             />
-            <span className="truncate">{asset.name}</span>
+            <span className="truncate">{assetName}</span>
           </div>
         }
         selected={selected}
         onChange={onChange}
-        ariaLabel={`Toggle ${asset.symbol} asset blacklist`}
+        ariaLabel={`Toggle ${assetSymbol} asset blacklist`}
         color="destructive"
       />
     </div>
@@ -50,20 +53,26 @@ type BlacklistAssetsModalProps = {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   market: Market | null;
-  onAssetAdded?: (symbol: string) => void;
-  onAssetRemoved?: (symbol: string) => void;
 };
 
-export function BlacklistAssetsModal({ isOpen, onOpenChange, market, onAssetAdded, onAssetRemoved }: BlacklistAssetsModalProps) {
-  const { addBlacklistedAsset, removeBlacklistedAsset, isAssetBlacklisted } = useBlacklistedAssets();
+export function BlacklistAssetsModal({ isOpen, onOpenChange, market }: BlacklistAssetsModalProps) {
+  const addBlacklistedAsset = useBlacklistedAssets((state) => state.addBlacklistedAsset);
+  const removeBlacklistedAsset = useBlacklistedAssets((state) => state.removeBlacklistedAsset);
+  const isAssetBlacklisted = useBlacklistedAssets((state) => state.isAssetBlacklisted);
+  const { success: toastSuccess } = useStyledToast();
 
   if (!market) return null;
 
   const chainId = market.morphoBlue.chain.id;
-  const assets = [
-    { token: market.loanAsset, label: 'loan asset' },
-    { token: market.collateralAsset, label: 'collateral asset' },
-  ];
+  const loanAssetKey = getAssetBlacklistKey(chainId, market.loanAsset.address);
+  const collateralAssetKey = getAssetBlacklistKey(chainId, market.collateralAsset.address);
+  const assets =
+    loanAssetKey === collateralAssetKey
+      ? [{ key: loanAssetKey, token: market.loanAsset, label: 'loan and collateral asset' }]
+      : [
+          { key: loanAssetKey, token: market.loanAsset, label: 'loan asset' },
+          { key: collateralAssetKey, token: market.collateralAsset, label: 'collateral asset' },
+        ];
 
   return (
     <Modal
@@ -73,27 +82,19 @@ export function BlacklistAssetsModal({ isOpen, onOpenChange, market, onAssetAdde
     >
       <ModalHeader
         variant="compact"
-        mainIcon={<IoWarningOutline className="h-5 w-5 text-orange-500" />}
         title="Blacklist Assets"
-        description="Hide every market that uses these assets"
-        className="border-b border-primary/10"
+        description="Hide markets that use this loan or collateral asset."
         onClose={() => onOpenChange(false)}
       />
-      <ModalBody
-        variant="compact"
-        className="py-6"
-      >
+      <ModalBody variant="compact">
         <div className="flex flex-col gap-3">
-          <div className="rounded bg-orange-500/10 p-3 text-xs text-secondary">
-            Switch on an asset to hide all markets where it appears as loan or collateral. You can remove assets later in Settings.
-          </div>
-
-          {assets.map(({ token, label }) => {
+          {assets.map(({ key, token, label }) => {
             const selected = isAssetBlacklisted(chainId, token.address);
+            const assetSymbol = token.symbol || 'Asset';
 
             return (
               <AssetSwitchRow
-                key={getAssetBlacklistKey(chainId, token.address)}
+                key={key}
                 asset={token}
                 chainId={chainId}
                 roleLabel={label}
@@ -106,19 +107,19 @@ export function BlacklistAssetsModal({ isOpen, onOpenChange, market, onAssetAdde
                       symbol: token.symbol,
                       name: token.name,
                     });
-                    if (added) onAssetAdded?.(token.symbol);
+                    if (added) toastSuccess('Asset blacklisted', `${assetSymbol} markets are now hidden`);
                     return;
                   }
 
                   removeBlacklistedAsset(chainId, token.address);
-                  onAssetRemoved?.(token.symbol);
+                  toastSuccess('Asset removed from blacklist', `${assetSymbol} markets are now visible`);
                 }}
               />
             );
           })}
         </div>
       </ModalBody>
-      <ModalFooter className="border-t border-primary/10">
+      <ModalFooter>
         <Button
           variant="primary"
           size="md"

--- a/src/features/markets/components/market-actions-dropdown.tsx
+++ b/src/features/markets/components/market-actions-dropdown.tsx
@@ -11,6 +11,7 @@ import { TbTrendingUp } from 'react-icons/tb';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import type { Market } from '@/utils/types';
+import { BlacklistAssetsModal } from './blacklist-assets-modal';
 import { BlacklistConfirmationModal } from './blacklist-confirmation-modal';
 import { useModal } from '@/hooks/useModal';
 import { useStyledToast } from '@/hooks/useStyledToast';
@@ -23,6 +24,7 @@ type MarketActionsDropdownProps = {
 
 export function MarketActionsDropdown({ market }: MarketActionsDropdownProps) {
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [isAssetsModalOpen, setIsAssetsModalOpen] = useState(false);
   const { open: openModal } = useModal();
   const { starredMarkets, starMarket, unstarMarket } = useMarketPreferences();
   const { isBlacklisted, addBlacklistedMarket } = useBlacklistedMarkets();
@@ -137,6 +139,13 @@ export function MarketActionsDropdown({ market }: MarketActionsDropdownProps) {
           >
             {isBlacklisted(market.uniqueKey) ? 'Blacklisted' : 'Blacklist'}
           </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={() => setIsAssetsModalOpen(true)}
+            startContent={<AiOutlineStop className="h-4 w-4" />}
+          >
+            Blacklist Assets
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -145,6 +154,13 @@ export function MarketActionsDropdown({ market }: MarketActionsDropdownProps) {
         onOpenChange={setIsConfirmModalOpen}
         onConfirm={handleConfirmBlacklist}
         market={market}
+      />
+      <BlacklistAssetsModal
+        isOpen={isAssetsModalOpen}
+        onOpenChange={setIsAssetsModalOpen}
+        market={market}
+        onAssetAdded={(symbol) => toastSuccess('Asset blacklisted', `${symbol} markets are now hidden`)}
+        onAssetRemoved={(symbol) => toastSuccess('Asset removed from blacklist', `${symbol} markets are now visible`)}
       />
     </div>
   );

--- a/src/features/markets/components/market-actions-dropdown.tsx
+++ b/src/features/markets/components/market-actions-dropdown.tsx
@@ -159,8 +159,6 @@ export function MarketActionsDropdown({ market }: MarketActionsDropdownProps) {
         isOpen={isAssetsModalOpen}
         onOpenChange={setIsAssetsModalOpen}
         market={market}
-        onAssetAdded={(symbol) => toastSuccess('Asset blacklisted', `${symbol} markets are now hidden`)}
-        onAssetRemoved={(symbol) => toastSuccess('Asset removed from blacklist', `${symbol} markets are now visible`)}
       />
     </div>
   );

--- a/src/hooks/useProcessedMarkets.ts
+++ b/src/hooks/useProcessedMarkets.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useMorphoWhitelistStatusQuery } from '@/hooks/queries/useMorphoWhitelistStatusQuery';
 import { useMarketsQuery } from '@/hooks/queries/useMarketsQuery';
 import { useUsdEnrichedMarkets } from '@/hooks/useUsdEnrichedMarkets';
+import { getAssetBlacklistKey, useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
 import { useBlacklistedMarkets } from '@/stores/useBlacklistedMarkets';
 import { useAppSettings } from '@/stores/useAppSettings';
 import { getMarketIdentityKey } from '@/utils/market-identity';
@@ -83,10 +84,12 @@ export const useProcessedMarkets = (options?: UseProcessedMarketsOptions) => {
     enabled: enabled && enableMorphoMetadata,
   });
   const { getAllBlacklistedKeys, customBlacklistedMarkets } = useBlacklistedMarkets();
+  const { getAllBlacklistedAssetKeys, customBlacklistedAssets } = useBlacklistedAssets();
   const { showUnwhitelistedMarkets } = useAppSettings();
 
   // Get blacklisted keys (memoized to prevent infinite loops)
   const allBlacklistedMarketKeys = useMemo(() => getAllBlacklistedKeys(), [customBlacklistedMarkets, getAllBlacklistedKeys]);
+  const allBlacklistedAssetKeys = useMemo(() => getAllBlacklistedAssetKeys(), [customBlacklistedAssets, getAllBlacklistedAssetKeys]);
 
   // Process markets: blacklist filter + force-unwhitelisted overrides
   const processedData = useMemo(() => {
@@ -118,8 +121,16 @@ export const useProcessedMarkets = (options?: UseProcessedMarketsOptions) => {
     // rawMarketsUnfiltered: before blacklist (for blacklist management modal)
     const rawMarketsUnfiltered = withMergedMorphoMetadata;
 
-    // Apply blacklist filter
-    const blacklistFiltered = rawMarketsUnfiltered.filter((market) => !allBlacklistedMarketKeys.has(market.uniqueKey));
+    // Apply market and asset blacklist filters
+    const blacklistFiltered = rawMarketsUnfiltered.filter((market) => {
+      if (allBlacklistedMarketKeys.has(market.uniqueKey)) return false;
+
+      const chainId = market.morphoBlue.chain.id;
+      return !(
+        allBlacklistedAssetKeys.has(getAssetBlacklistKey(chainId, market.loanAsset.address)) ||
+        allBlacklistedAssetKeys.has(getAssetBlacklistKey(chainId, market.collateralAsset.address))
+      );
+    });
 
     // Apply force-unwhitelisted overrides after blacklist filtering
     const enriched = blacklistFiltered.map((market) => {
@@ -138,7 +149,7 @@ export const useProcessedMarkets = (options?: UseProcessedMarketsOptions) => {
       rawMarketsUnfiltered,
       allMarkets,
     };
-  }, [rawMarketsFromQuery, allBlacklistedMarketKeys, whitelistLookup, supplyingVaultsLookup]);
+  }, [rawMarketsFromQuery, allBlacklistedMarketKeys, allBlacklistedAssetKeys, whitelistLookup, supplyingVaultsLookup]);
 
   const { markets: allMarketsWithUsd, isLoading: isUsdEnrichmentLoading } = useUsdEnrichedMarkets(processedData.allMarkets, {
     enabled: enabled && enableUsdEnrichment,

--- a/src/hooks/useProcessedMarkets.ts
+++ b/src/hooks/useProcessedMarkets.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { useMorphoWhitelistStatusQuery } from '@/hooks/queries/useMorphoWhitelistStatusQuery';
 import { useMarketsQuery } from '@/hooks/queries/useMarketsQuery';
 import { useUsdEnrichedMarkets } from '@/hooks/useUsdEnrichedMarkets';
-import { getAssetBlacklistKey, useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
-import { useBlacklistedMarkets } from '@/stores/useBlacklistedMarkets';
+import { getAssetBlacklistKey, getBlacklistedAssetKeys, useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
+import { getBlacklistedMarketKeys, useBlacklistedMarkets } from '@/stores/useBlacklistedMarkets';
 import { useAppSettings } from '@/stores/useAppSettings';
 import { getMarketIdentityKey } from '@/utils/market-identity';
 import { isForceUnwhitelisted, isMarketVisibleWithWhitelistGuard } from '@/utils/markets';
@@ -83,13 +83,13 @@ export const useProcessedMarkets = (options?: UseProcessedMarketsOptions) => {
   const { whitelistLookup, supplyingVaultsLookup, availableWhitelistChainIds } = useMorphoWhitelistStatusQuery({
     enabled: enabled && enableMorphoMetadata,
   });
-  const { getAllBlacklistedKeys, customBlacklistedMarkets } = useBlacklistedMarkets();
-  const { getAllBlacklistedAssetKeys, customBlacklistedAssets } = useBlacklistedAssets();
+  const customBlacklistedMarkets = useBlacklistedMarkets((state) => state.customBlacklistedMarkets);
+  const customBlacklistedAssets = useBlacklistedAssets((state) => state.customBlacklistedAssets);
   const { showUnwhitelistedMarkets } = useAppSettings();
 
   // Get blacklisted keys (memoized to prevent infinite loops)
-  const allBlacklistedMarketKeys = useMemo(() => getAllBlacklistedKeys(), [customBlacklistedMarkets, getAllBlacklistedKeys]);
-  const allBlacklistedAssetKeys = useMemo(() => getAllBlacklistedAssetKeys(), [customBlacklistedAssets, getAllBlacklistedAssetKeys]);
+  const allBlacklistedMarketKeys = useMemo(() => getBlacklistedMarketKeys(customBlacklistedMarkets), [customBlacklistedMarkets]);
+  const allBlacklistedAssetKeys = useMemo(() => getBlacklistedAssetKeys(customBlacklistedAssets), [customBlacklistedAssets]);
 
   // Process markets: blacklist filter + force-unwhitelisted overrides
   const processedData = useMemo(() => {

--- a/src/modals/settings/monarch-settings/SettingsContent.tsx
+++ b/src/modals/settings/monarch-settings/SettingsContent.tsx
@@ -4,7 +4,14 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { slideVariants, slideTransition, type SlideDirection } from '@/components/common/settings-modal';
 import { SettingsHeader } from './SettingsHeader';
 import { TransactionPanel, DisplayPanel, FiltersPanel, PreferencesPanel, DeveloperPanel, ExperimentalPanel } from './panels';
-import { CustomTagDetail, TrustedVaultsDetail, BlacklistedMarketsDetail, RpcDetail, ThresholdsDetail } from './details';
+import {
+  CustomTagDetail,
+  TrustedVaultsDetail,
+  BlacklistedMarketsDetail,
+  BlacklistedAssetsDetail,
+  RpcDetail,
+  ThresholdsDetail,
+} from './details';
 import type { SettingsCategory, DetailView } from './constants';
 
 type PanelProps = {
@@ -24,6 +31,7 @@ const DETAIL_COMPONENTS: Record<Exclude<DetailView, null>, React.ComponentType> 
   'custom-tag-config': CustomTagDetail,
   'trusted-vaults': TrustedVaultsDetail,
   'blacklisted-markets': BlacklistedMarketsDetail,
+  'blacklisted-assets': BlacklistedAssetsDetail,
   'rpc-config': RpcDetail,
   'filter-thresholds': ThresholdsDetail,
 };

--- a/src/modals/settings/monarch-settings/constants.ts
+++ b/src/modals/settings/monarch-settings/constants.ts
@@ -5,7 +5,14 @@ import { RiCodeLine, RiFlaskLine } from 'react-icons/ri';
 
 export type SettingsCategory = 'transaction' | 'display' | 'filters' | 'preferences' | 'developer' | 'experimental';
 
-export type DetailView = 'custom-tag-config' | 'trusted-vaults' | 'blacklisted-markets' | 'rpc-config' | 'filter-thresholds' | null;
+export type DetailView =
+  | 'custom-tag-config'
+  | 'trusted-vaults'
+  | 'blacklisted-markets'
+  | 'blacklisted-assets'
+  | 'rpc-config'
+  | 'filter-thresholds'
+  | null;
 
 export type CategoryConfig = {
   id: SettingsCategory;
@@ -27,6 +34,7 @@ export const DETAIL_TITLES: Record<Exclude<DetailView, null>, string> = {
   'custom-tag-config': 'Configure Custom Tag',
   'trusted-vaults': 'Trusted Vaults',
   'blacklisted-markets': 'Blacklisted Markets',
+  'blacklisted-assets': 'Blacklisted Assets',
   'rpc-config': 'Custom RPC',
   'filter-thresholds': 'Filter Thresholds',
 };

--- a/src/modals/settings/monarch-settings/details/BlacklistedAssetsDetail.tsx
+++ b/src/modals/settings/monarch-settings/details/BlacklistedAssetsDetail.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { Cross2Icon } from '@radix-ui/react-icons';
+import { FiPlus } from 'react-icons/fi';
+import { Button } from '@/components/ui/button';
+import { TokenIcon } from '@/components/shared/token-icon';
+import { useProcessedMarkets } from '@/hooks/useProcessedMarkets';
+import { useStyledToast } from '@/hooks/useStyledToast';
+import { useBlacklistedAssets, getAssetBlacklistKey, type BlacklistedAsset } from '@/stores/useBlacklistedAssets';
+import type { TokenInfo } from '@/utils/types';
+
+type AssetOption = {
+  address: string;
+  chainId: number;
+  symbol: string;
+  name: string;
+  marketCount: number;
+};
+
+const ITEMS_PER_PAGE = 20;
+
+const toAssetOption = (asset: TokenInfo, chainId: number): AssetOption => ({
+  address: asset.address.toLowerCase(),
+  chainId,
+  symbol: asset.symbol,
+  name: asset.name,
+  marketCount: 0,
+});
+
+function AssetRow({ asset, action }: { asset: AssetOption | BlacklistedAsset; action: React.ReactNode }) {
+  const name = asset.name || asset.symbol || 'Unknown asset';
+  const symbol = asset.symbol || 'Unknown';
+  const marketCount = 'marketCount' in asset ? asset.marketCount : undefined;
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded bg-surface-soft p-2.5 transition-colors hover:bg-surface-dark">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <TokenIcon
+          address={asset.address}
+          chainId={asset.chainId}
+          width={22}
+          height={22}
+          symbol={symbol}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-primary">{symbol}</span>
+            <span className="text-[11px] text-secondary">Chain {asset.chainId}</span>
+          </div>
+          <div className="truncate text-xs text-secondary">
+            {name}
+            {marketCount ? ` · ${marketCount} market${marketCount === 1 ? '' : 's'}` : ''}
+          </div>
+        </div>
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export function BlacklistedAssetsDetail() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const { rawMarketsUnfiltered } = useProcessedMarkets();
+  const { customBlacklistedAssets, addBlacklistedAsset, removeBlacklistedAsset, isAssetBlacklisted } = useBlacklistedAssets();
+  const { success: toastSuccess } = useStyledToast();
+
+  const availableAssets = useMemo(() => {
+    const assets = new Map<string, AssetOption>();
+
+    for (const market of rawMarketsUnfiltered) {
+      const chainId = market.morphoBlue.chain.id;
+
+      for (const token of [market.loanAsset, market.collateralAsset]) {
+        const key = getAssetBlacklistKey(chainId, token.address);
+        const existing = assets.get(key) ?? toAssetOption(token, chainId);
+        existing.marketCount += 1;
+        assets.set(key, existing);
+      }
+    }
+
+    return Array.from(assets.values()).sort((a, b) => a.symbol.localeCompare(b.symbol));
+  }, [rawMarketsUnfiltered]);
+
+  const blacklistedAssets = useMemo(() => {
+    const metadataByKey = new Map(availableAssets.map((asset) => [getAssetBlacklistKey(asset.chainId, asset.address), asset]));
+
+    return customBlacklistedAssets
+      .map((asset) => ({ ...asset, ...metadataByKey.get(getAssetBlacklistKey(asset.chainId, asset.address)) }))
+      .sort((a, b) => (a.symbol ?? '').localeCompare(b.symbol ?? ''));
+  }, [availableAssets, customBlacklistedAssets]);
+
+  const filteredAvailableAssets = useMemo(() => {
+    const query = searchQuery.trim();
+
+    if (query.length < 2) return [];
+
+    const lowerQuery = query.toLowerCase();
+    return availableAssets.filter((asset) => {
+      if (isAssetBlacklisted(asset.chainId, asset.address)) return false;
+
+      return (
+        asset.symbol.toLowerCase().includes(lowerQuery) ||
+        asset.name.toLowerCase().includes(lowerQuery) ||
+        asset.address.toLowerCase().includes(lowerQuery)
+      );
+    });
+  }, [availableAssets, isAssetBlacklisted, searchQuery]);
+
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+    setCurrentPage(1);
+  }, []);
+
+  const totalPages = Math.ceil(filteredAvailableAssets.length / ITEMS_PER_PAGE);
+  const paginatedAssets = filteredAvailableAssets.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+  const trimmedQuery = searchQuery.trim();
+  const searchPlaceholder =
+    trimmedQuery.length === 0
+      ? 'Search by symbol, name, or address to hide every market using that asset.'
+      : trimmedQuery.length < 2
+        ? 'Type at least 2 characters to search.'
+        : filteredAvailableAssets.length === 0
+          ? `No assets found matching "${searchQuery}".`
+          : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded bg-surface p-4">
+        <p className="text-sm text-primary">Hide markets by token instead of by market ID.</p>
+        <p className="mt-1 text-xs text-secondary">
+          If an asset is blacklisted, markets using it as either loan or collateral are hidden from market lists.
+        </p>
+      </div>
+
+      {blacklistedAssets.length > 0 && (
+        <div className="flex flex-col gap-4 rounded bg-surface p-4">
+          <h3 className="text-xs uppercase text-secondary">Blacklisted Assets ({blacklistedAssets.length})</h3>
+          <div className="flex flex-col gap-1.5">
+            {blacklistedAssets.map((asset) => (
+              <AssetRow
+                key={getAssetBlacklistKey(asset.chainId, asset.address)}
+                asset={asset}
+                action={
+                  <Button
+                    size="xs"
+                    variant="default"
+                    onClick={() => {
+                      removeBlacklistedAsset(asset.chainId, asset.address);
+                      toastSuccess('Asset removed from blacklist', `${asset.symbol ?? 'Asset'} markets are now visible`);
+                    }}
+                    className="shrink-0"
+                  >
+                    <Cross2Icon className="h-3 w-3" />
+                  </Button>
+                }
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4 rounded bg-surface p-4">
+        <h3 className="text-xs uppercase text-secondary">Add Asset to Blacklist</h3>
+        <input
+          type="text"
+          placeholder="Search assets (min 2 characters)..."
+          value={searchQuery}
+          onChange={handleSearchChange}
+          className="bg-hovered h-9 w-full rounded p-2 font-zen text-xs focus:border-primary focus:outline-none"
+        />
+        {filteredAvailableAssets.length > 0 && (
+          <span className="text-[11px] text-secondary">
+            {filteredAvailableAssets.length} result{filteredAvailableAssets.length === 1 ? '' : 's'}
+          </span>
+        )}
+
+        <div className="flex flex-col gap-1.5">
+          {searchPlaceholder ? (
+            <div className="py-6 text-center text-xs text-secondary">{searchPlaceholder}</div>
+          ) : (
+            <>
+              {paginatedAssets.map((asset) => (
+                <AssetRow
+                  key={getAssetBlacklistKey(asset.chainId, asset.address)}
+                  asset={asset}
+                  action={
+                    <Button
+                      size="xs"
+                      variant="default"
+                      onClick={() => {
+                        const success = addBlacklistedAsset(asset);
+                        if (success) {
+                          toastSuccess('Asset blacklisted', `${asset.symbol} markets are now hidden`);
+                        }
+                      }}
+                      className="shrink-0"
+                    >
+                      <FiPlus className="h-3.5 w-3.5" />
+                    </Button>
+                  }
+                />
+              ))}
+
+              {totalPages > 1 && (
+                <div className="mt-3 flex items-center justify-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="default"
+                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                    disabled={currentPage === 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-[11px] text-secondary">
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="default"
+                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={currentPage === totalPages}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modals/settings/monarch-settings/details/BlacklistedAssetsDetail.tsx
+++ b/src/modals/settings/monarch-settings/details/BlacklistedAssetsDetail.tsx
@@ -1,235 +1,68 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
-import { FiPlus } from 'react-icons/fi';
-import { Button } from '@/components/ui/button';
 import { TokenIcon } from '@/components/shared/token-icon';
-import { useProcessedMarkets } from '@/hooks/useProcessedMarkets';
+import { Button } from '@/components/ui/button';
 import { useStyledToast } from '@/hooks/useStyledToast';
-import { useBlacklistedAssets, getAssetBlacklistKey, type BlacklistedAsset } from '@/stores/useBlacklistedAssets';
-import type { TokenInfo } from '@/utils/types';
+import { getAssetBlacklistKey, type BlacklistedAsset, useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
+import { getSlicedAddress } from '@/utils/address';
 
-type AssetOption = {
-  address: string;
-  chainId: number;
-  symbol: string;
-  name: string;
-  marketCount: number;
-};
-
-const ITEMS_PER_PAGE = 20;
-
-const toAssetOption = (asset: TokenInfo, chainId: number): AssetOption => ({
-  address: asset.address.toLowerCase(),
-  chainId,
-  symbol: asset.symbol,
-  name: asset.name,
-  marketCount: 0,
-});
-
-function AssetRow({ asset, action }: { asset: AssetOption | BlacklistedAsset; action: React.ReactNode }) {
-  const name = asset.name || asset.symbol || 'Unknown asset';
-  const symbol = asset.symbol || 'Unknown';
-  const marketCount = 'marketCount' in asset ? asset.marketCount : undefined;
-
-  return (
-    <div className="flex items-center justify-between gap-4 rounded bg-surface-soft p-2.5 transition-colors hover:bg-surface-dark">
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <TokenIcon
-          address={asset.address}
-          chainId={asset.chainId}
-          width={22}
-          height={22}
-          symbol={symbol}
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium text-primary">{symbol}</span>
-            <span className="text-[11px] text-secondary">Chain {asset.chainId}</span>
-          </div>
-          <div className="truncate text-xs text-secondary">
-            {name}
-            {marketCount ? ` · ${marketCount} market${marketCount === 1 ? '' : 's'}` : ''}
-          </div>
-        </div>
-      </div>
-      {action}
-    </div>
-  );
-}
+const getAssetLabel = (asset: Pick<BlacklistedAsset, 'address' | 'name' | 'symbol'>) =>
+  asset.symbol || asset.name || getSlicedAddress(asset.address) || 'Asset';
 
 export function BlacklistedAssetsDetail() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [currentPage, setCurrentPage] = useState(1);
-  const { rawMarketsUnfiltered } = useProcessedMarkets();
-  const { customBlacklistedAssets, addBlacklistedAsset, removeBlacklistedAsset, isAssetBlacklisted } = useBlacklistedAssets();
+  const customBlacklistedAssets = useBlacklistedAssets((state) => state.customBlacklistedAssets);
+  const removeBlacklistedAsset = useBlacklistedAssets((state) => state.removeBlacklistedAsset);
   const { success: toastSuccess } = useStyledToast();
 
-  const availableAssets = useMemo(() => {
-    const assets = new Map<string, AssetOption>();
+  const blacklistedAssets = [...customBlacklistedAssets].sort((a, b) => getAssetLabel(a).localeCompare(getAssetLabel(b)));
 
-    for (const market of rawMarketsUnfiltered) {
-      const chainId = market.morphoBlue.chain.id;
-
-      for (const token of [market.loanAsset, market.collateralAsset]) {
-        const key = getAssetBlacklistKey(chainId, token.address);
-        const existing = assets.get(key) ?? toAssetOption(token, chainId);
-        existing.marketCount += 1;
-        assets.set(key, existing);
-      }
-    }
-
-    return Array.from(assets.values()).sort((a, b) => a.symbol.localeCompare(b.symbol));
-  }, [rawMarketsUnfiltered]);
-
-  const blacklistedAssets = useMemo(() => {
-    const metadataByKey = new Map(availableAssets.map((asset) => [getAssetBlacklistKey(asset.chainId, asset.address), asset]));
-
-    return customBlacklistedAssets
-      .map((asset) => ({ ...asset, ...metadataByKey.get(getAssetBlacklistKey(asset.chainId, asset.address)) }))
-      .sort((a, b) => (a.symbol ?? '').localeCompare(b.symbol ?? ''));
-  }, [availableAssets, customBlacklistedAssets]);
-
-  const filteredAvailableAssets = useMemo(() => {
-    const query = searchQuery.trim();
-
-    if (query.length < 2) return [];
-
-    const lowerQuery = query.toLowerCase();
-    return availableAssets.filter((asset) => {
-      if (isAssetBlacklisted(asset.chainId, asset.address)) return false;
-
-      return (
-        asset.symbol.toLowerCase().includes(lowerQuery) ||
-        asset.name.toLowerCase().includes(lowerQuery) ||
-        asset.address.toLowerCase().includes(lowerQuery)
-      );
-    });
-  }, [availableAssets, isAssetBlacklisted, searchQuery]);
-
-  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
-    setCurrentPage(1);
-  }, []);
-
-  const totalPages = Math.ceil(filteredAvailableAssets.length / ITEMS_PER_PAGE);
-  const paginatedAssets = filteredAvailableAssets.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
-  const trimmedQuery = searchQuery.trim();
-  const searchPlaceholder =
-    trimmedQuery.length === 0
-      ? 'Search by symbol, name, or address to hide every market using that asset.'
-      : trimmedQuery.length < 2
-        ? 'Type at least 2 characters to search.'
-        : filteredAvailableAssets.length === 0
-          ? `No assets found matching "${searchQuery}".`
-          : null;
+  if (blacklistedAssets.length === 0) {
+    return (
+      <div className="rounded bg-surface p-4 text-xs text-secondary">
+        No assets are hidden. Use a market actions menu to hide every market involving one of its assets.
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="rounded bg-surface p-4">
-        <p className="text-sm text-primary">Hide markets by token instead of by market ID.</p>
-        <p className="mt-1 text-xs text-secondary">
-          If an asset is blacklisted, markets using it as either loan or collateral are hidden from market lists.
-        </p>
-      </div>
+    <div className="flex flex-col gap-1.5">
+      {blacklistedAssets.map((asset) => {
+        const label = getAssetLabel(asset);
 
-      {blacklistedAssets.length > 0 && (
-        <div className="flex flex-col gap-4 rounded bg-surface p-4">
-          <h3 className="text-xs uppercase text-secondary">Blacklisted Assets ({blacklistedAssets.length})</h3>
-          <div className="flex flex-col gap-1.5">
-            {blacklistedAssets.map((asset) => (
-              <AssetRow
-                key={getAssetBlacklistKey(asset.chainId, asset.address)}
-                asset={asset}
-                action={
-                  <Button
-                    size="xs"
-                    variant="default"
-                    onClick={() => {
-                      removeBlacklistedAsset(asset.chainId, asset.address);
-                      toastSuccess('Asset removed from blacklist', `${asset.symbol ?? 'Asset'} markets are now visible`);
-                    }}
-                    className="shrink-0"
-                  >
-                    <Cross2Icon className="h-3 w-3" />
-                  </Button>
-                }
+        return (
+          <div
+            key={getAssetBlacklistKey(asset.chainId, asset.address)}
+            className="flex items-center justify-between gap-3 rounded bg-surface p-2.5"
+          >
+            <div className="flex min-w-0 items-center gap-3">
+              <TokenIcon
+                address={asset.address}
+                chainId={asset.chainId}
+                width={22}
+                height={22}
+                symbol={asset.symbol || 'Unknown'}
               />
-            ))}
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-primary">{label}</div>
+                <div className="text-xs text-secondary">Chain {asset.chainId}</div>
+              </div>
+            </div>
+            <Button
+              size="xs"
+              variant="default"
+              aria-label={`Remove ${label} from blacklist`}
+              onClick={() => {
+                removeBlacklistedAsset(asset.chainId, asset.address);
+                toastSuccess('Asset removed from blacklist', `${label} markets are now visible`);
+              }}
+              className="shrink-0"
+            >
+              <Cross2Icon className="h-3 w-3" />
+            </Button>
           </div>
-        </div>
-      )}
-
-      <div className="flex flex-col gap-4 rounded bg-surface p-4">
-        <h3 className="text-xs uppercase text-secondary">Add Asset to Blacklist</h3>
-        <input
-          type="text"
-          placeholder="Search assets (min 2 characters)..."
-          value={searchQuery}
-          onChange={handleSearchChange}
-          className="bg-hovered h-9 w-full rounded p-2 font-zen text-xs focus:border-primary focus:outline-none"
-        />
-        {filteredAvailableAssets.length > 0 && (
-          <span className="text-[11px] text-secondary">
-            {filteredAvailableAssets.length} result{filteredAvailableAssets.length === 1 ? '' : 's'}
-          </span>
-        )}
-
-        <div className="flex flex-col gap-1.5">
-          {searchPlaceholder ? (
-            <div className="py-6 text-center text-xs text-secondary">{searchPlaceholder}</div>
-          ) : (
-            <>
-              {paginatedAssets.map((asset) => (
-                <AssetRow
-                  key={getAssetBlacklistKey(asset.chainId, asset.address)}
-                  asset={asset}
-                  action={
-                    <Button
-                      size="xs"
-                      variant="default"
-                      onClick={() => {
-                        const success = addBlacklistedAsset(asset);
-                        if (success) {
-                          toastSuccess('Asset blacklisted', `${asset.symbol} markets are now hidden`);
-                        }
-                      }}
-                      className="shrink-0"
-                    >
-                      <FiPlus className="h-3.5 w-3.5" />
-                    </Button>
-                  }
-                />
-              ))}
-
-              {totalPages > 1 && (
-                <div className="mt-3 flex items-center justify-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="default"
-                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                    disabled={currentPage === 1}
-                  >
-                    Previous
-                  </Button>
-                  <span className="text-[11px] text-secondary">
-                    Page {currentPage} of {totalPages}
-                  </span>
-                  <Button
-                    size="sm"
-                    variant="default"
-                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                    disabled={currentPage === totalPages}
-                  >
-                    Next
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/modals/settings/monarch-settings/details/index.ts
+++ b/src/modals/settings/monarch-settings/details/index.ts
@@ -1,5 +1,6 @@
 export { CustomTagDetail } from './CustomTagDetail';
 export { TrustedVaultsDetail } from './TrustedVaultsDetail';
 export { BlacklistedMarketsDetail } from './BlacklistedMarketsDetail';
+export { BlacklistedAssetsDetail } from './BlacklistedAssetsDetail';
 export { RpcDetail } from './RpcDetail';
 export { ThresholdsDetail } from './ThresholdsDetail';

--- a/src/modals/settings/monarch-settings/panels/PreferencesPanel.tsx
+++ b/src/modals/settings/monarch-settings/panels/PreferencesPanel.tsx
@@ -6,6 +6,7 @@ import { VaultIdentity } from '@/features/autovault/components/vault-identity';
 import { useEffectiveTrustedVaults } from '@/hooks/useEffectiveTrustedVaults';
 import { useTrustedVaultMetadata } from '@/hooks/useTrustedVaultMetadata';
 import { useAppSettings } from '@/stores/useAppSettings';
+import { useBlacklistedAssets } from '@/stores/useBlacklistedAssets';
 import { isTrustedVaultV2 } from '@/utils/vaults';
 import { SettingActionItem, SettingToggleItem } from '../SettingItem';
 import type { DetailView } from '../constants';
@@ -17,6 +18,7 @@ type PreferencesPanelProps = {
 export function PreferencesPanel({ onNavigateToDetail }: PreferencesPanelProps) {
   const effectiveTrustedVaults = useEffectiveTrustedVaults();
   const { rebalanceDefaultMode, setRebalanceDefaultMode } = useAppSettings();
+  const blacklistedAssetCount = useBlacklistedAssets((state) => state.customBlacklistedAssets.length);
   const [mounted, setMounted] = useState(false);
   const trustedVaultCount = effectiveTrustedVaults.length;
   const { trustedVaultMap } = useTrustedVaultMetadata({
@@ -106,6 +108,16 @@ export function PreferencesPanel({ onNavigateToDetail }: PreferencesPanelProps) 
           description="Block specific markets from appearing in your view. Blacklisted markets are completely hidden from all lists."
           buttonLabel="Edit"
           onClick={() => onNavigateToDetail?.('blacklisted-markets')}
+        />
+        <SettingActionItem
+          title="Manage Blacklisted Assets"
+          description={
+            blacklistedAssetCount === 0
+              ? 'Hide every market involving a specific loan or collateral asset.'
+              : `${blacklistedAssetCount} asset${blacklistedAssetCount === 1 ? '' : 's'} currently hidden from market lists.`
+          }
+          buttonLabel="Edit"
+          onClick={() => onNavigateToDetail?.('blacklisted-assets')}
         />
       </div>
     </div>

--- a/src/stores/useBlacklistedAssets.ts
+++ b/src/stores/useBlacklistedAssets.ts
@@ -1,0 +1,96 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type BlacklistedAsset = {
+  address: string;
+  chainId: number;
+  symbol?: string;
+  name?: string;
+  addedAt: number;
+};
+
+export const getAssetBlacklistKey = (chainId: number, address: string): string => `${chainId}:${address.toLowerCase()}`;
+
+export const getBlacklistedAssetKeys = (customBlacklistedAssets: readonly Pick<BlacklistedAsset, 'address' | 'chainId'>[]): Set<string> => {
+  return new Set(customBlacklistedAssets.map((asset) => getAssetBlacklistKey(asset.chainId, asset.address)));
+};
+
+type BlacklistedAssetsState = {
+  customBlacklistedAssets: BlacklistedAsset[];
+  _cachedBlacklistedAssetKeys: Set<string> | null;
+};
+
+type BlacklistedAssetsActions = {
+  addBlacklistedAsset: (asset: Omit<BlacklistedAsset, 'addedAt'>) => boolean;
+  removeBlacklistedAsset: (chainId: number, address: string) => void;
+  isAssetBlacklisted: (chainId: number, address: string) => boolean;
+  getAllBlacklistedAssetKeys: () => Set<string>;
+  setAll: (state: Partial<BlacklistedAssetsState>) => void;
+};
+
+type BlacklistedAssetsStore = BlacklistedAssetsState & BlacklistedAssetsActions;
+
+export const useBlacklistedAssets = create<BlacklistedAssetsStore>()(
+  persist(
+    (set, get) => ({
+      customBlacklistedAssets: [],
+      _cachedBlacklistedAssetKeys: null,
+
+      addBlacklistedAsset: (asset) => {
+        const key = getAssetBlacklistKey(asset.chainId, asset.address);
+        const state = get();
+
+        if (state.getAllBlacklistedAssetKeys().has(key)) {
+          return false;
+        }
+
+        set((prevState) => ({
+          customBlacklistedAssets: [
+            ...prevState.customBlacklistedAssets,
+            {
+              ...asset,
+              address: asset.address.toLowerCase(),
+              addedAt: Date.now(),
+            },
+          ],
+          _cachedBlacklistedAssetKeys: null,
+        }));
+
+        return true;
+      },
+
+      removeBlacklistedAsset: (chainId, address) => {
+        const key = getAssetBlacklistKey(chainId, address);
+
+        set((state) => ({
+          customBlacklistedAssets: state.customBlacklistedAssets.filter(
+            (asset) => getAssetBlacklistKey(asset.chainId, asset.address) !== key,
+          ),
+          _cachedBlacklistedAssetKeys: null,
+        }));
+      },
+
+      isAssetBlacklisted: (chainId, address) => get().getAllBlacklistedAssetKeys().has(getAssetBlacklistKey(chainId, address)),
+
+      getAllBlacklistedAssetKeys: () => {
+        const state = get();
+
+        if (state._cachedBlacklistedAssetKeys) {
+          return state._cachedBlacklistedAssetKeys;
+        }
+
+        const nextSet = getBlacklistedAssetKeys(state.customBlacklistedAssets);
+        set({ _cachedBlacklistedAssetKeys: nextSet });
+        return nextSet;
+      },
+
+      setAll: (newState) => set({ ...newState, _cachedBlacklistedAssetKeys: null }),
+    }),
+    {
+      name: 'monarch_store_blacklistedAssets',
+      partialize: (state) => ({
+        customBlacklistedAssets: state.customBlacklistedAssets,
+      }),
+    },
+  ),
+);

--- a/src/stores/useBlacklistedAssets.ts
+++ b/src/stores/useBlacklistedAssets.ts
@@ -17,15 +17,12 @@ export const getBlacklistedAssetKeys = (customBlacklistedAssets: readonly Pick<B
 
 type BlacklistedAssetsState = {
   customBlacklistedAssets: BlacklistedAsset[];
-  _cachedBlacklistedAssetKeys: Set<string> | null;
 };
 
 type BlacklistedAssetsActions = {
   addBlacklistedAsset: (asset: Omit<BlacklistedAsset, 'addedAt'>) => boolean;
   removeBlacklistedAsset: (chainId: number, address: string) => void;
   isAssetBlacklisted: (chainId: number, address: string) => boolean;
-  getAllBlacklistedAssetKeys: () => Set<string>;
-  setAll: (state: Partial<BlacklistedAssetsState>) => void;
 };
 
 type BlacklistedAssetsStore = BlacklistedAssetsState & BlacklistedAssetsActions;
@@ -34,13 +31,12 @@ export const useBlacklistedAssets = create<BlacklistedAssetsStore>()(
   persist(
     (set, get) => ({
       customBlacklistedAssets: [],
-      _cachedBlacklistedAssetKeys: null,
 
       addBlacklistedAsset: (asset) => {
         const key = getAssetBlacklistKey(asset.chainId, asset.address);
         const state = get();
 
-        if (state.getAllBlacklistedAssetKeys().has(key)) {
+        if (getBlacklistedAssetKeys(state.customBlacklistedAssets).has(key)) {
           return false;
         }
 
@@ -53,7 +49,6 @@ export const useBlacklistedAssets = create<BlacklistedAssetsStore>()(
               addedAt: Date.now(),
             },
           ],
-          _cachedBlacklistedAssetKeys: null,
         }));
 
         return true;
@@ -66,25 +61,11 @@ export const useBlacklistedAssets = create<BlacklistedAssetsStore>()(
           customBlacklistedAssets: state.customBlacklistedAssets.filter(
             (asset) => getAssetBlacklistKey(asset.chainId, asset.address) !== key,
           ),
-          _cachedBlacklistedAssetKeys: null,
         }));
       },
 
-      isAssetBlacklisted: (chainId, address) => get().getAllBlacklistedAssetKeys().has(getAssetBlacklistKey(chainId, address)),
-
-      getAllBlacklistedAssetKeys: () => {
-        const state = get();
-
-        if (state._cachedBlacklistedAssetKeys) {
-          return state._cachedBlacklistedAssetKeys;
-        }
-
-        const nextSet = getBlacklistedAssetKeys(state.customBlacklistedAssets);
-        set({ _cachedBlacklistedAssetKeys: nextSet });
-        return nextSet;
-      },
-
-      setAll: (newState) => set({ ...newState, _cachedBlacklistedAssetKeys: null }),
+      isAssetBlacklisted: (chainId, address) =>
+        getBlacklistedAssetKeys(get().customBlacklistedAssets).has(getAssetBlacklistKey(chainId, address)),
     }),
     {
       name: 'monarch_store_blacklistedAssets',

--- a/src/stores/useBlacklistedMarkets.ts
+++ b/src/stores/useBlacklistedMarkets.ts
@@ -18,8 +18,6 @@ export const getBlacklistedMarketKeys = (customBlacklistedMarkets: readonly Pick
 type BlacklistedMarketsState = {
   customBlacklistedMarkets: BlacklistedMarket[];
   showBlacklistedPositions: boolean;
-  /** Cached Set of all blacklisted keys (default + custom) */
-  _cachedBlacklistedKeys: Set<string> | null;
 };
 
 type BlacklistedMarketsActions = {
@@ -28,8 +26,6 @@ type BlacklistedMarketsActions = {
   setShowBlacklistedPositions: (show: boolean) => void;
   isBlacklisted: (uniqueKey: string) => boolean;
   isDefaultBlacklisted: (uniqueKey: string) => boolean;
-  getAllBlacklistedKeys: () => Set<string>;
-  setAll: (state: Partial<BlacklistedMarketsState>) => void;
 };
 
 type BlacklistedMarketsStore = BlacklistedMarketsState & BlacklistedMarketsActions;
@@ -43,11 +39,10 @@ export const useBlacklistedMarkets = create<BlacklistedMarketsStore>()(
     (set, get) => ({
       customBlacklistedMarkets: [],
       showBlacklistedPositions: true,
-      _cachedBlacklistedKeys: null,
 
       addBlacklistedMarket: (uniqueKey, chainId, reason) => {
         const state = get();
-        const allKeys = state.getAllBlacklistedKeys();
+        const allKeys = getBlacklistedMarketKeys(state.customBlacklistedMarkets);
 
         if (allKeys.has(uniqueKey.toLowerCase())) {
           return false;
@@ -62,7 +57,6 @@ export const useBlacklistedMarkets = create<BlacklistedMarketsStore>()(
 
         set((prevState) => ({
           customBlacklistedMarkets: [...prevState.customBlacklistedMarkets, newMarket],
-          _cachedBlacklistedKeys: null, // Invalidate cache
         }));
 
         return true;
@@ -71,7 +65,6 @@ export const useBlacklistedMarkets = create<BlacklistedMarketsStore>()(
       removeBlacklistedMarket: (uniqueKey) => {
         set((state) => ({
           customBlacklistedMarkets: state.customBlacklistedMarkets.filter((m) => m.uniqueKey !== uniqueKey),
-          _cachedBlacklistedKeys: null, // Invalidate cache
         }));
       },
 
@@ -79,27 +72,12 @@ export const useBlacklistedMarkets = create<BlacklistedMarketsStore>()(
 
       isBlacklisted: (uniqueKey) => {
         const state = get();
-        return state.getAllBlacklistedKeys().has(uniqueKey.toLowerCase());
+        return getBlacklistedMarketKeys(state.customBlacklistedMarkets).has(uniqueKey.toLowerCase());
       },
 
       isDefaultBlacklisted: (uniqueKey) => {
         return defaultBlacklistedMarkets.includes(uniqueKey);
       },
-
-      getAllBlacklistedKeys: () => {
-        const state = get();
-        // Return cached Set if available
-        if (state._cachedBlacklistedKeys) {
-          return state._cachedBlacklistedKeys;
-        }
-        // Compute and cache the Set
-        const newSet = getBlacklistedMarketKeys(state.customBlacklistedMarkets);
-        // Update cache (using set() to avoid mutation)
-        set({ _cachedBlacklistedKeys: newSet });
-        return newSet;
-      },
-
-      setAll: (newState) => set({ ...newState, _cachedBlacklistedKeys: null }),
     }),
     {
       name: 'monarch_store_blacklistedMarkets',

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'viem';
 import { create } from 'zustand';
-import type { SettingsCategory } from '@/modals/settings/monarch-settings/constants';
+import type { DetailView, SettingsCategory } from '@/modals/settings/monarch-settings/constants';
 import type { Market, MarketPosition, GroupedPosition } from '@/utils/types';
 import type { SwapToken } from '@/features/swap/types';
 import type { SupportedNetworks } from '@/utils/networks';
@@ -65,7 +65,7 @@ export type ModalProps = {
 
   monarchSettings: {
     initialCategory?: SettingsCategory;
-    initialDetailView?: 'custom-tag-config' | 'trusted-vaults' | 'blacklisted-markets' | 'rpc-config' | 'filter-thresholds';
+    initialDetailView?: Exclude<DetailView, null>;
     onCloseCallback?: () => void;
   };
 

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,7 +1,7 @@
 /**
  * getSlicedAddress returns the first 5 and last 4 characters of an address.
  */
-export const getSlicedAddress = (address: `0x${string}` | undefined) => {
+export const getSlicedAddress = (address: string | undefined) => {
   if (!address) {
     return '';
   }


### PR DESCRIPTION
## Summary
- add a persisted asset blacklist keyed by chain ID and token address
- filter market lists at the processed-markets chokepoint when loan or collateral assets are blacklisted
- add settings and market-action flows for managing blacklisted assets

## Validation
- pnpm exec ultracite fix
- pnpm exec ultracite check
- pnpm typecheck
- pnpm build

## Notes
- Impeccable context script is not present in this repo at .agents/skills/impeccable/scripts/context.mjs, so I applied the product UI register manually and ran the repo formatter/checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asset blacklisting to hide markets that involve specific loan or collateral assets.
  * Added a **“Blacklist Assets”** action in market menus to manage asset-level blacklists.
  * Added a dedicated **Blacklisted Assets** settings section to view and remove blacklisted assets.
* **Enhancements**
  * Markets are now automatically filtered out when either the market or its involved assets are blacklisted.
  * Added success feedback when assets are added to or removed from the blacklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->