### PR TITLE
Add existing position leverage update flow

### DIFF
--- a/src/features/positions/components/borrow-position-actions-dropdown.tsx
+++ b/src/features/positions/components/borrow-position-actions-dropdown.tsx
@@ -3,23 +3,27 @@
 import type React from 'react';
 import { IoEllipsisVertical } from 'react-icons/io5';
 import { BsArrowDownLeftCircle, BsArrowUpRightCircle } from 'react-icons/bs';
-import { TbTrendingDown } from 'react-icons/tb';
+import { TbTrendingDown, TbTrendingUp } from 'react-icons/tb';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
 type BorrowPositionActionsDropdownProps = {
   isOwner: boolean;
   isActiveDebt: boolean;
+  canAdjustLeverage: boolean;
   onBorrowMoreClick: () => void;
   onRepayClick: () => void;
+  onLeverageClick: () => void;
   onDeleverageClick: () => void;
 };
 
 export function BorrowPositionActionsDropdown({
   isOwner,
   isActiveDebt,
+  canAdjustLeverage,
   onBorrowMoreClick,
   onRepayClick,
+  onLeverageClick,
   onDeleverageClick,
 }: BorrowPositionActionsDropdownProps) {
   const handleClick = (event: React.MouseEvent) => {
@@ -64,6 +68,16 @@ export function BorrowPositionActionsDropdown({
           >
             {isActiveDebt ? 'Repay' : 'Manage'}
           </DropdownMenuItem>
+          {canAdjustLeverage && (
+            <DropdownMenuItem
+              onClick={onLeverageClick}
+              startContent={<TbTrendingUp className="h-4 w-4" />}
+              disabled={!isOwner}
+              className={isOwner ? '' : 'cursor-not-allowed opacity-50'}
+            >
+              Increase Leverage
+            </DropdownMenuItem>
+          )}
           {isActiveDebt && (
             <DropdownMenuItem
               onClick={onDeleverageClick}

--- a/src/features/positions/components/borrowed-morpho-blue-table.tsx
+++ b/src/features/positions/components/borrowed-morpho-blue-table.tsx
@@ -263,6 +263,7 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                         <BorrowPositionActionsDropdown
                           isOwner={isOwner}
                           isActiveDebt={row.isActiveDebt}
+                          canAdjustLeverage={row.collateralAmount > 0}
                           onBorrowMoreClick={() =>
                             open('borrow', {
                               market: row.market,
@@ -278,6 +279,17 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                               market: row.market,
                               defaultMode: 'repay',
                               toggleBorrowRepay: false,
+                              refetch: () => {
+                                void onRefetch();
+                              },
+                            })
+                          }
+                          onLeverageClick={() =>
+                            open('leverage', {
+                              market: row.market,
+                              defaultMode: 'leverage',
+                              defaultLeverageSource: 'position',
+                              toggleLeverageDeleverage: false,
                               refetch: () => {
                                 void onRefetch();
                               },

--- a/src/features/positions/components/borrowed-morpho-blue-table.tsx
+++ b/src/features/positions/components/borrowed-morpho-blue-table.tsx
@@ -175,10 +175,10 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                     </TableCell>
 
                     <TableCell data-label="Loan">
-                      <div className="flex items-center justify-center gap-2">
+                      <div className="flex items-center justify-center gap-2 whitespace-nowrap">
                         {row.isActiveDebt ? (
                           <>
-                            <span className="font-medium">{formatReadableTokenAmount(row.borrowAmount)}</span>
+                            <span className="font-medium tabular-nums">{formatReadableTokenAmount(row.borrowAmount)}</span>
                             <span>{row.market.loanAsset.symbol}</span>
                             <TokenIcon
                               address={row.market.loanAsset.address}
@@ -208,10 +208,10 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                     </TableCell>
 
                     <TableCell data-label="Collateral">
-                      <div className="flex items-center justify-center gap-2">
+                      <div className="flex items-center justify-center gap-2 whitespace-nowrap">
                         {row.collateralAmount > 0 ? (
                           <>
-                            <span className="font-medium">{formatReadableTokenAmount(row.collateralAmount)}</span>
+                            <span className="font-medium tabular-nums">{formatReadableTokenAmount(row.collateralAmount)}</span>
                             <span>{getTruncatedAssetName(row.market.collateralAsset.symbol)}</span>
                             <TokenIcon
                               address={row.market.collateralAsset.address}

--- a/src/hooks/leverage/leverageWithErc4626Deposit.ts
+++ b/src/hooks/leverage/leverageWithErc4626Deposit.ts
@@ -111,7 +111,7 @@ export const leverageWithErc4626Deposit = async ({
       }
     }
 
-    if (!isApproved) {
+    if (initialCapitalTransferAmount > 0n && !isApproved) {
       updateStep('approve_token');
       await approve();
       await sleep(900);
@@ -135,7 +135,7 @@ export const leverageWithErc4626Deposit = async ({
     );
   }
 
-  if (isLoanAssetInput) {
+  if (isLoanAssetInput && initialCapitalInputAmount > 0n) {
     // WHY: the user provided an exact amount of loan-token assets, so this leg should deposit that
     // exact asset amount into the vault with a share floor derived from the ERC4626 preview.
     txs.push(

--- a/src/hooks/leverage/leverageWithSwap.ts
+++ b/src/hooks/leverage/leverageWithSwap.ts
@@ -153,7 +153,7 @@ export const leverageWithSwap = async ({
       }
     }
 
-    if (!isApproved) {
+    if (initialCapitalTransferAmount > 0n && !isApproved) {
       updateStep('approve_token');
       await approve();
       await sleep(900);

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -446,7 +446,10 @@ export function useLeverageQuote({
 
   const flashLoanAssetAmount = useMemo(() => {
     if (!route) return 0n;
-    if (isPositionTargetSizing) return effectivePositionDebtInputAmount;
+    if (isPositionTargetSizing) {
+      if (route.kind === 'swap') return swapLoanSellQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
+      return effectivePositionDebtInputAmount;
+    }
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanSellQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -14,12 +14,15 @@ const shouldLogLeverageQuoteDebug = () => process.env.NODE_ENV !== 'production';
 type UseLeverageQuoteParams = {
   chainId: number;
   route: LeverageRoute | null;
+  sizingMode?: 'initial-capital' | 'position-target';
   /**
    * Exact user-entered starting capital, denominated by `inputMode`.
    * - `loan`: market loan asset amount
    * - `collateral`: market collateral token amount
    */
   initialCapitalInputAmount: bigint;
+  /** Exact additional loan-asset debt to loop from an existing position. */
+  positionDebtInputAmount?: bigint;
   inputMode: 'collateral' | 'loan';
   slippageBps: number;
   multiplierBps: bigint;
@@ -247,7 +250,9 @@ const quoteVeloraCollateralInputRoute = async ({
 export function useLeverageQuote({
   chainId,
   route,
+  sizingMode = 'initial-capital',
   initialCapitalInputAmount,
+  positionDebtInputAmount = 0n,
   inputMode,
   slippageBps,
   multiplierBps,
@@ -257,35 +262,51 @@ export function useLeverageQuote({
   collateralTokenDecimals,
   userAddress,
 }: UseLeverageQuoteParams): LeverageQuote {
+  const isPositionTargetSizing = sizingMode === 'position-target';
   const isLoanAssetInput = inputMode === 'loan';
-  const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput;
+  const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput && !isPositionTargetSizing;
   const swapExecutionAddress = route?.kind === 'swap' ? route.paraswapAdapterAddress : null;
+  const effectiveInitialCapitalInputAmount = isPositionTargetSizing ? 0n : initialCapitalInputAmount;
+  const effectivePositionDebtInputAmount = isPositionTargetSizing ? positionDebtInputAmount : 0n;
+  const erc4626LoanAssetDepositPreviewAmount = isPositionTargetSizing
+    ? effectivePositionDebtInputAmount
+    : isLoanAssetInput
+      ? effectiveInitialCapitalInputAmount
+      : 0n;
 
   const {
-    data: previewDepositCollateralSharesFromUserLoanAssets,
+    data: previewDepositCollateralSharesFromLoanAssets,
     isLoading: isLoadingErc4626Deposit,
     error: erc4626DepositError,
   } = useReadContract({
     address: route?.kind === 'erc4626' ? route.collateralVault : undefined,
     abi: erc4626Abi,
     functionName: 'previewDeposit',
-    // `previewDeposit(user loan assets)` -> ERC4626 collateral shares minted from that exact asset input.
-    args: [initialCapitalInputAmount],
+    // `previewDeposit(loan assets)` -> ERC4626 collateral shares minted from that exact asset input.
+    args: [erc4626LoanAssetDepositPreviewAmount],
     chainId,
     query: {
-      enabled: route?.kind === 'erc4626' && isLoanAssetInput && initialCapitalInputAmount > 0n,
+      enabled: route?.kind === 'erc4626' && erc4626LoanAssetDepositPreviewAmount > 0n,
     },
   });
 
   const quotedInitialCapitalCollateralTokenAmount = useMemo(() => {
+    if (isPositionTargetSizing) return 0n;
     if (!route) return 0n;
     if (isSwapLoanAssetInput) return 0n;
-    if (!isLoanAssetInput) return initialCapitalInputAmount;
+    if (!isLoanAssetInput) return effectiveInitialCapitalInputAmount;
     // `previewDeposit(initialCapitalInputAmount)` returns the ERC4626 collateral-share amount minted by
     // depositing the user's exact loan-token asset input into the vault.
-    if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromUserLoanAssets as bigint | undefined) ?? 0n;
+    if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n;
     return 0n;
-  }, [route, isSwapLoanAssetInput, isLoanAssetInput, initialCapitalInputAmount, previewDepositCollateralSharesFromUserLoanAssets]);
+  }, [
+    isPositionTargetSizing,
+    route,
+    isSwapLoanAssetInput,
+    isLoanAssetInput,
+    effectiveInitialCapitalInputAmount,
+    previewDepositCollateralSharesFromLoanAssets,
+  ]);
 
   const initialCapitalCollateralTokenAmount = useMemo(() => {
     if (route?.kind !== 'erc4626' || !isLoanAssetInput) return quotedInitialCapitalCollateralTokenAmount;
@@ -293,8 +314,11 @@ export function useLeverageQuote({
   }, [route, isLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, slippageBps]);
 
   const targetFlashCollateralTokenAmount = useMemo(
-    () => (isSwapLoanAssetInput ? 0n : computeFlashCollateralAmount(quotedInitialCapitalCollateralTokenAmount, multiplierBps)),
-    [isSwapLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, multiplierBps],
+    () =>
+      isPositionTargetSizing || isSwapLoanAssetInput
+        ? 0n
+        : computeFlashCollateralAmount(quotedInitialCapitalCollateralTokenAmount, multiplierBps),
+    [isPositionTargetSizing, isSwapLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, multiplierBps],
   );
 
   const {
@@ -353,14 +377,15 @@ export function useLeverageQuote({
       collateralTokenAddress,
       collateralTokenDecimals,
       swapExecutionAddress,
-      initialCapitalInputAmount.toString(),
+      effectiveInitialCapitalInputAmount.toString(),
       multiplierBps.toString(),
       slippageBps,
       userAddress ?? null,
     ],
-    enabled: route?.kind === 'swap' && isLoanAssetInput && initialCapitalInputAmount > 0n && !!userAddress,
+    enabled:
+      route?.kind === 'swap' && !isPositionTargetSizing && isLoanAssetInput && effectiveInitialCapitalInputAmount > 0n && !!userAddress,
     queryFn: async () => {
-      const flashLoanAssetAmount = computeLeveragedExtraAmount(initialCapitalInputAmount, multiplierBps);
+      const flashLoanAssetAmount = computeLeveragedExtraAmount(effectiveInitialCapitalInputAmount, multiplierBps);
       if (flashLoanAssetAmount <= 0n) {
         return {
           flashLoanAssetAmount: 0n,
@@ -370,7 +395,7 @@ export function useLeverageQuote({
         };
       }
 
-      const totalLoanSellAmount = initialCapitalInputAmount + flashLoanAssetAmount;
+      const totalLoanSellAmount = effectiveInitialCapitalInputAmount + flashLoanAssetAmount;
       const sellRoute = await fetchVeloraPriceRoute({
         srcToken: loanTokenAddress,
         srcDecimals: loanTokenDecimals,
@@ -393,8 +418,51 @@ export function useLeverageQuote({
     },
   });
 
+  const swapPositionDebtQuoteQuery = useQuery({
+    queryKey: [
+      'leverage-swap-position-debt-quote',
+      chainId,
+      route?.kind === 'swap' ? route.paraswapAdapterAddress : null,
+      route?.kind === 'swap' ? route.generalAdapterAddress : null,
+      loanTokenAddress,
+      loanTokenDecimals,
+      collateralTokenAddress,
+      collateralTokenDecimals,
+      swapExecutionAddress,
+      effectivePositionDebtInputAmount.toString(),
+      slippageBps,
+      userAddress ?? null,
+    ],
+    enabled: route?.kind === 'swap' && isPositionTargetSizing && effectivePositionDebtInputAmount > 0n && !!userAddress,
+    queryFn: async () => {
+      const sellRoute = await fetchVeloraPriceRoute({
+        srcToken: loanTokenAddress,
+        srcDecimals: loanTokenDecimals,
+        destToken: collateralTokenAddress,
+        destDecimals: collateralTokenDecimals,
+        amount: effectivePositionDebtInputAmount,
+        network: chainId,
+        userAddress: swapExecutionAddress as `0x${string}`,
+        side: 'SELL',
+      });
+
+      const totalCollateralTokenAmountAdded = withSlippageFloor(BigInt(sellRoute.destAmount), slippageBps);
+
+      return {
+        flashLoanAssetAmount: effectivePositionDebtInputAmount,
+        flashLegCollateralTokenAmount: totalCollateralTokenAmountAdded,
+        totalCollateralTokenAmountAdded,
+        priceRoute: sellRoute,
+      };
+    },
+  });
+
   const flashLegCollateralTokenAmount = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionTargetSizing) {
+      if (route.kind === 'swap') return swapPositionDebtQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
+      return withSlippageFloor((previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n, slippageBps);
+    }
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
@@ -402,6 +470,9 @@ export function useLeverageQuote({
     return withSlippageFloor(targetFlashCollateralTokenAmount, slippageBps);
   }, [
     route,
+    isPositionTargetSizing,
+    swapPositionDebtQuoteQuery.data?.flashLegCollateralTokenAmount,
+    previewDepositCollateralSharesFromLoanAssets,
     isLoanAssetInput,
     targetFlashCollateralTokenAmount,
     slippageBps,
@@ -411,6 +482,7 @@ export function useLeverageQuote({
 
   const flashLoanAssetAmount = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionTargetSizing) return effectivePositionDebtInputAmount;
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
@@ -420,6 +492,8 @@ export function useLeverageQuote({
     return previewMintableLoanAssets ?? 0n;
   }, [
     route,
+    isPositionTargetSizing,
+    effectivePositionDebtInputAmount,
     isLoanAssetInput,
     swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount,
     swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount,
@@ -428,6 +502,7 @@ export function useLeverageQuote({
 
   const totalCollateralTokenAmountAdded = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionTargetSizing) return flashLegCollateralTokenAmount;
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.totalCollateralTokenAmountAdded ?? 0n;
       return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
@@ -435,6 +510,7 @@ export function useLeverageQuote({
     return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
   }, [
     route,
+    isPositionTargetSizing,
     isLoanAssetInput,
     initialCapitalCollateralTokenAmount,
     flashLegCollateralTokenAmount,
@@ -443,15 +519,30 @@ export function useLeverageQuote({
 
   const swapPriceRoute = useMemo(() => {
     if (route?.kind !== 'swap') return null;
+    if (isPositionTargetSizing) return swapPositionDebtQuoteQuery.data?.priceRoute ?? null;
     if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.priceRoute ?? null;
     return swapCollateralInputQuoteQuery.data?.priceRoute ?? null;
-  }, [route, isLoanAssetInput, swapLoanInputCombinedQuoteQuery.data?.priceRoute, swapCollateralInputQuoteQuery.data?.priceRoute]);
+  }, [
+    route,
+    isPositionTargetSizing,
+    swapPositionDebtQuoteQuery.data?.priceRoute,
+    isLoanAssetInput,
+    swapLoanInputCombinedQuoteQuery.data?.priceRoute,
+    swapCollateralInputQuoteQuery.data?.priceRoute,
+  ]);
 
   const error = useMemo(() => {
     if (!route) return null;
     if (route.kind === 'swap') {
-      if (!userAddress && initialCapitalInputAmount > 0n) return 'Connect wallet to fetch swap-backed leverage route.';
-      const routeError = isLoanAssetInput ? swapLoanInputCombinedQuoteQuery.error : swapCollateralInputQuoteQuery.error;
+      const needsSwapQuote =
+        (isPositionTargetSizing && effectivePositionDebtInputAmount > 0n) ||
+        (!isPositionTargetSizing && effectiveInitialCapitalInputAmount > 0n);
+      if (!userAddress && needsSwapQuote) return 'Connect wallet to fetch swap-backed leverage route.';
+      const routeError = isPositionTargetSizing
+        ? swapPositionDebtQuoteQuery.error
+        : isLoanAssetInput
+          ? swapLoanInputCombinedQuoteQuery.error
+          : swapCollateralInputQuoteQuery.error;
       if (!routeError) return null;
       return toUserFacingVeloraQuoteError({ error: routeError, action: 'leverage' });
     }
@@ -462,8 +553,11 @@ export function useLeverageQuote({
     route,
     swapExecutionAddress,
     userAddress,
-    initialCapitalInputAmount,
+    isPositionTargetSizing,
+    effectivePositionDebtInputAmount,
+    effectiveInitialCapitalInputAmount,
     isLoanAssetInput,
+    swapPositionDebtQuoteQuery.error,
     swapLoanInputCombinedQuoteQuery.error,
     swapCollateralInputQuoteQuery.error,
     erc4626DepositError,
@@ -473,8 +567,13 @@ export function useLeverageQuote({
   const isLoading =
     !!route &&
     (route.kind === 'swap'
-      ? (isLoanAssetInput && (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
-        (!isLoanAssetInput && (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))
+      ? (isPositionTargetSizing && (swapPositionDebtQuoteQuery.isLoading || swapPositionDebtQuoteQuery.isFetching)) ||
+        (!isPositionTargetSizing &&
+          isLoanAssetInput &&
+          (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
+        (!isPositionTargetSizing &&
+          !isLoanAssetInput &&
+          (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))
       : isLoadingErc4626Deposit || isLoadingErc4626Mint);
 
   return {

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -14,7 +14,6 @@ const shouldLogLeverageQuoteDebug = () => process.env.NODE_ENV !== 'production';
 type UseLeverageQuoteParams = {
   chainId: number;
   route: LeverageRoute | null;
-  sizingMode?: 'initial-capital' | 'position-target';
   /**
    * Exact user-entered starting capital, denominated by `inputMode`.
    * - `loan`: market loan asset amount
@@ -250,9 +249,8 @@ const quoteVeloraCollateralInputRoute = async ({
 export function useLeverageQuote({
   chainId,
   route,
-  sizingMode = 'initial-capital',
   initialCapitalInputAmount,
-  positionDebtInputAmount = 0n,
+  positionDebtInputAmount,
   inputMode,
   slippageBps,
   multiplierBps,
@@ -262,12 +260,12 @@ export function useLeverageQuote({
   collateralTokenDecimals,
   userAddress,
 }: UseLeverageQuoteParams): LeverageQuote {
-  const isPositionTargetSizing = sizingMode === 'position-target';
+  const isPositionTargetSizing = positionDebtInputAmount !== undefined;
   const isLoanAssetInput = inputMode === 'loan';
   const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput && !isPositionTargetSizing;
   const swapExecutionAddress = route?.kind === 'swap' ? route.paraswapAdapterAddress : null;
   const effectiveInitialCapitalInputAmount = isPositionTargetSizing ? 0n : initialCapitalInputAmount;
-  const effectivePositionDebtInputAmount = isPositionTargetSizing ? positionDebtInputAmount : 0n;
+  const effectivePositionDebtInputAmount = positionDebtInputAmount ?? 0n;
   const erc4626LoanAssetDepositPreviewAmount = isPositionTargetSizing
     ? effectivePositionDebtInputAmount
     : isLoanAssetInput
@@ -366,9 +364,13 @@ export function useLeverageQuote({
       }),
   });
 
-  const swapLoanInputCombinedQuoteQuery = useQuery({
+  const needsSwapLoanSellQuote =
+    route?.kind === 'swap' &&
+    ((isPositionTargetSizing && effectivePositionDebtInputAmount > 0n) ||
+      (!isPositionTargetSizing && isLoanAssetInput && effectiveInitialCapitalInputAmount > 0n));
+  const swapLoanSellQuoteQuery = useQuery({
     queryKey: [
-      'leverage-swap-loan-input-combined-quote',
+      'leverage-swap-loan-sell-quote',
       chainId,
       route?.kind === 'swap' ? route.paraswapAdapterAddress : null,
       route?.kind === 'swap' ? route.generalAdapterAddress : null,
@@ -378,14 +380,16 @@ export function useLeverageQuote({
       collateralTokenDecimals,
       swapExecutionAddress,
       effectiveInitialCapitalInputAmount.toString(),
+      effectivePositionDebtInputAmount.toString(),
       multiplierBps.toString(),
       slippageBps,
       userAddress ?? null,
     ],
-    enabled:
-      route?.kind === 'swap' && !isPositionTargetSizing && isLoanAssetInput && effectiveInitialCapitalInputAmount > 0n && !!userAddress,
+    enabled: needsSwapLoanSellQuote && !!userAddress,
     queryFn: async () => {
-      const flashLoanAssetAmount = computeLeveragedExtraAmount(effectiveInitialCapitalInputAmount, multiplierBps);
+      const flashLoanAssetAmount = isPositionTargetSizing
+        ? effectivePositionDebtInputAmount
+        : computeLeveragedExtraAmount(effectiveInitialCapitalInputAmount, multiplierBps);
       if (flashLoanAssetAmount <= 0n) {
         return {
           flashLoanAssetAmount: 0n,
@@ -395,7 +399,7 @@ export function useLeverageQuote({
         };
       }
 
-      const totalLoanSellAmount = effectiveInitialCapitalInputAmount + flashLoanAssetAmount;
+      const totalLoanSellAmount = isPositionTargetSizing ? flashLoanAssetAmount : effectiveInitialCapitalInputAmount + flashLoanAssetAmount;
       const sellRoute = await fetchVeloraPriceRoute({
         srcToken: loanTokenAddress,
         srcDecimals: loanTokenDecimals,
@@ -411,46 +415,7 @@ export function useLeverageQuote({
 
       return {
         flashLoanAssetAmount,
-        flashLegCollateralTokenAmount: 0n,
-        totalCollateralTokenAmountAdded,
-        priceRoute: sellRoute,
-      };
-    },
-  });
-
-  const swapPositionDebtQuoteQuery = useQuery({
-    queryKey: [
-      'leverage-swap-position-debt-quote',
-      chainId,
-      route?.kind === 'swap' ? route.paraswapAdapterAddress : null,
-      route?.kind === 'swap' ? route.generalAdapterAddress : null,
-      loanTokenAddress,
-      loanTokenDecimals,
-      collateralTokenAddress,
-      collateralTokenDecimals,
-      swapExecutionAddress,
-      effectivePositionDebtInputAmount.toString(),
-      slippageBps,
-      userAddress ?? null,
-    ],
-    enabled: route?.kind === 'swap' && isPositionTargetSizing && effectivePositionDebtInputAmount > 0n && !!userAddress,
-    queryFn: async () => {
-      const sellRoute = await fetchVeloraPriceRoute({
-        srcToken: loanTokenAddress,
-        srcDecimals: loanTokenDecimals,
-        destToken: collateralTokenAddress,
-        destDecimals: collateralTokenDecimals,
-        amount: effectivePositionDebtInputAmount,
-        network: chainId,
-        userAddress: swapExecutionAddress as `0x${string}`,
-        side: 'SELL',
-      });
-
-      const totalCollateralTokenAmountAdded = withSlippageFloor(BigInt(sellRoute.destAmount), slippageBps);
-
-      return {
-        flashLoanAssetAmount: effectivePositionDebtInputAmount,
-        flashLegCollateralTokenAmount: totalCollateralTokenAmountAdded,
+        flashLegCollateralTokenAmount: isPositionTargetSizing ? totalCollateralTokenAmountAdded : 0n,
         totalCollateralTokenAmountAdded,
         priceRoute: sellRoute,
       };
@@ -460,23 +425,22 @@ export function useLeverageQuote({
   const flashLegCollateralTokenAmount = useMemo(() => {
     if (!route) return 0n;
     if (isPositionTargetSizing) {
-      if (route.kind === 'swap') return swapPositionDebtQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
+      if (route.kind === 'swap') return swapLoanSellQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
       return withSlippageFloor((previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n, slippageBps);
     }
     if (route.kind === 'swap') {
-      if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
+      if (isLoanAssetInput) return swapLoanSellQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
     }
     return withSlippageFloor(targetFlashCollateralTokenAmount, slippageBps);
   }, [
     route,
     isPositionTargetSizing,
-    swapPositionDebtQuoteQuery.data?.flashLegCollateralTokenAmount,
+    swapLoanSellQuoteQuery.data?.flashLegCollateralTokenAmount,
     previewDepositCollateralSharesFromLoanAssets,
     isLoanAssetInput,
     targetFlashCollateralTokenAmount,
     slippageBps,
-    swapLoanInputCombinedQuoteQuery.data?.flashLegCollateralTokenAmount,
     swapCollateralInputQuoteQuery.data?.flashLegCollateralTokenAmount,
   ]);
 
@@ -484,7 +448,7 @@ export function useLeverageQuote({
     if (!route) return 0n;
     if (isPositionTargetSizing) return effectivePositionDebtInputAmount;
     if (route.kind === 'swap') {
-      if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
+      if (isLoanAssetInput) return swapLoanSellQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
     }
     // `previewMint(targetFlashCollateralTokenAmount)` returns how many loan-token assets the flash leg
@@ -495,7 +459,7 @@ export function useLeverageQuote({
     isPositionTargetSizing,
     effectivePositionDebtInputAmount,
     isLoanAssetInput,
-    swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount,
+    swapLoanSellQuoteQuery.data?.flashLoanAssetAmount,
     swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount,
     previewMintableLoanAssets,
   ]);
@@ -504,7 +468,7 @@ export function useLeverageQuote({
     if (!route) return 0n;
     if (isPositionTargetSizing) return flashLegCollateralTokenAmount;
     if (route.kind === 'swap') {
-      if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.totalCollateralTokenAmountAdded ?? 0n;
+      if (isLoanAssetInput) return swapLoanSellQuoteQuery.data?.totalCollateralTokenAmountAdded ?? 0n;
       return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
     }
     return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
@@ -514,35 +478,27 @@ export function useLeverageQuote({
     isLoanAssetInput,
     initialCapitalCollateralTokenAmount,
     flashLegCollateralTokenAmount,
-    swapLoanInputCombinedQuoteQuery.data?.totalCollateralTokenAmountAdded,
+    swapLoanSellQuoteQuery.data?.totalCollateralTokenAmountAdded,
   ]);
 
   const swapPriceRoute = useMemo(() => {
     if (route?.kind !== 'swap') return null;
-    if (isPositionTargetSizing) return swapPositionDebtQuoteQuery.data?.priceRoute ?? null;
-    if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.priceRoute ?? null;
+    if (isPositionTargetSizing || isLoanAssetInput) return swapLoanSellQuoteQuery.data?.priceRoute ?? null;
     return swapCollateralInputQuoteQuery.data?.priceRoute ?? null;
   }, [
     route,
     isPositionTargetSizing,
-    swapPositionDebtQuoteQuery.data?.priceRoute,
     isLoanAssetInput,
-    swapLoanInputCombinedQuoteQuery.data?.priceRoute,
+    swapLoanSellQuoteQuery.data?.priceRoute,
     swapCollateralInputQuoteQuery.data?.priceRoute,
   ]);
 
   const error = useMemo(() => {
     if (!route) return null;
     if (route.kind === 'swap') {
-      const needsSwapQuote =
-        (isPositionTargetSizing && effectivePositionDebtInputAmount > 0n) ||
-        (!isPositionTargetSizing && effectiveInitialCapitalInputAmount > 0n);
+      const needsSwapQuote = needsSwapLoanSellQuote || (!isPositionTargetSizing && effectiveInitialCapitalInputAmount > 0n);
       if (!userAddress && needsSwapQuote) return 'Connect wallet to fetch swap-backed leverage route.';
-      const routeError = isPositionTargetSizing
-        ? swapPositionDebtQuoteQuery.error
-        : isLoanAssetInput
-          ? swapLoanInputCombinedQuoteQuery.error
-          : swapCollateralInputQuoteQuery.error;
+      const routeError = isPositionTargetSizing || isLoanAssetInput ? swapLoanSellQuoteQuery.error : swapCollateralInputQuoteQuery.error;
       if (!routeError) return null;
       return toUserFacingVeloraQuoteError({ error: routeError, action: 'leverage' });
     }
@@ -554,11 +510,10 @@ export function useLeverageQuote({
     swapExecutionAddress,
     userAddress,
     isPositionTargetSizing,
-    effectivePositionDebtInputAmount,
     effectiveInitialCapitalInputAmount,
     isLoanAssetInput,
-    swapPositionDebtQuoteQuery.error,
-    swapLoanInputCombinedQuoteQuery.error,
+    needsSwapLoanSellQuote,
+    swapLoanSellQuoteQuery.error,
     swapCollateralInputQuoteQuery.error,
     erc4626DepositError,
     erc4626MintError,
@@ -567,10 +522,7 @@ export function useLeverageQuote({
   const isLoading =
     !!route &&
     (route.kind === 'swap'
-      ? (isPositionTargetSizing && (swapPositionDebtQuoteQuery.isLoading || swapPositionDebtQuoteQuery.isFetching)) ||
-        (!isPositionTargetSizing &&
-          isLoanAssetInput &&
-          (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
+      ? (needsSwapLoanSellQuote && (swapLoanSellQuoteQuery.isLoading || swapLoanSellQuoteQuery.isFetching)) ||
         (!isPositionTargetSizing &&
           !isLoanAssetInput &&
           (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))

--- a/src/hooks/useLeverageTransaction.ts
+++ b/src/hooks/useLeverageTransaction.ts
@@ -80,7 +80,6 @@ export function useLeverageTransaction({
   const { address: account, chainId } = useConnection();
   const toast = useStyledToast();
   const isSwapRoute = route?.kind === 'swap';
-  const usePermit2ForRoute = usePermit2Setting;
 
   const bundlerAddress = useMemo<Address>(() => {
     if (route?.kind === 'swap') {
@@ -105,6 +104,8 @@ export function useLeverageTransaction({
   const initialCapitalInputTokenSymbol = initialCapitalUsesLoanAsset ? market.loanAsset.symbol : market.collateralAsset.symbol;
   const initialCapitalInputTokenDecimals = initialCapitalUsesLoanAsset ? market.loanAsset.decimals : market.collateralAsset.decimals;
   const initialCapitalTransferAmount = initialCapitalUsesLoanAsset ? initialCapitalInputAmount : initialCapitalCollateralTokenAmount;
+  const requiresInitialCapitalTransfer = initialCapitalTransferAmount > 0n;
+  const usePermit2ForRoute = usePermit2Setting && requiresInitialCapitalTransfer;
   const approvalSpender = route?.kind === 'swap' ? route.generalAdapterAddress : bundlerAddress;
 
   const {
@@ -145,7 +146,9 @@ export function useLeverageTransaction({
 
   const { isConfirming: leveragePending, sendTransactionAsync } = useTransactionWithToast({
     toastId: 'leverage',
-    pendingText: `Leveraging ${formatBalance(initialCapitalInputAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`,
+    pendingText: requiresInitialCapitalTransfer
+      ? `Leveraging ${formatBalance(initialCapitalInputAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`
+      : `Increasing leverage on ${market.collateralAsset.symbol}`,
     successText: 'Leverage Executed',
     errorText: 'Failed to execute leverage',
     chainId,
@@ -161,14 +164,32 @@ export function useLeverageTransaction({
       title: 'Leverage',
       description: `${market.collateralAsset.symbol} leveraged using ${market.loanAsset.symbol} debt`,
       tokenSymbol: initialCapitalInputTokenSymbol,
-      amount: initialCapitalInputAmount,
+      amount: requiresInitialCapitalTransfer ? initialCapitalInputAmount : flashLoanAssetAmount,
       marketId: market.uniqueKey,
     }),
-    [market.collateralAsset.symbol, market.loanAsset.symbol, initialCapitalInputTokenSymbol, initialCapitalInputAmount, market.uniqueKey],
+    [
+      market.collateralAsset.symbol,
+      market.loanAsset.symbol,
+      initialCapitalInputTokenSymbol,
+      requiresInitialCapitalTransfer,
+      initialCapitalInputAmount,
+      flashLoanAssetAmount,
+      market.uniqueKey,
+    ],
   );
 
   const getStepsForFlow = useCallback(
     (isPermit2: boolean, isSwap: boolean) => {
+      const approvalStep = requiresInitialCapitalTransfer
+        ? [
+            {
+              id: 'approve_token' as const,
+              title: `Approve ${initialCapitalInputTokenSymbol}`,
+              description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
+            },
+          ]
+        : [];
+
       if (isSwap && isPermit2) {
         return [
           {
@@ -201,11 +222,7 @@ export function useLeverageTransaction({
             title: 'Authorize Morpho Adapter',
             description: 'Submit one transaction authorizing Morpho adapter actions on your position.',
           },
-          {
-            id: 'approve_token',
-            title: `Approve ${initialCapitalInputTokenSymbol}`,
-            description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
-          },
+          ...approvalStep,
           {
             id: 'execute',
             title: 'Confirm Leverage',
@@ -245,11 +262,7 @@ export function useLeverageTransaction({
           title: 'Authorize Morpho Bundler',
           description: 'Submit one transaction authorizing bundler actions on your Morpho position.',
         },
-        {
-          id: 'approve_token',
-          title: `Approve ${initialCapitalInputTokenSymbol}`,
-          description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
-        },
+        ...approvalStep,
         {
           id: 'execute',
           title: 'Confirm Leverage',
@@ -257,7 +270,7 @@ export function useLeverageTransaction({
         },
       ];
     },
-    [initialCapitalInputTokenSymbol],
+    [initialCapitalInputTokenSymbol, requiresInitialCapitalTransfer],
   );
 
   const getLeverageExecutionPreflight = useCallback((): LeverageExecutionPreflight | null => {
@@ -273,8 +286,8 @@ export function useLeverageTransaction({
 
     const hasCollateralOutput =
       route.kind === 'swap' && initialCapitalUsesLoanAsset ? totalCollateralTokenAmountAdded > 0n : flashLegCollateralTokenAmount > 0n;
-    if (initialCapitalInputAmount <= 0n || flashLoanAssetAmount <= 0n || !hasCollateralOutput) {
-      toast.info('Invalid leverage inputs', 'Set initial capital and multiplier above 1x before submitting.');
+    if (flashLoanAssetAmount <= 0n || !hasCollateralOutput) {
+      toast.info('Invalid leverage inputs', 'Set leverage inputs above zero before submitting.');
       return null;
     }
     if (collateralAssetPriceUsd == null || !Number.isFinite(collateralAssetPriceUsd) || collateralAssetPriceUsd <= 0) {
@@ -318,7 +331,6 @@ export function useLeverageTransaction({
     initialCapitalUsesLoanAsset,
     totalCollateralTokenAmountAdded,
     flashLegCollateralTokenAmount,
-    initialCapitalInputAmount,
     flashLoanAssetAmount,
     collateralAssetPriceUsd,
     market.collateralAsset.decimals,
@@ -492,7 +504,7 @@ export function useLeverageTransaction({
           : 'authorize_bundler_sig'
         : 'approve_permit2'
       : isBundlerAuthorized
-        ? isApproved
+        ? !requiresInitialCapitalTransfer || isApproved
           ? 'execute'
           : 'approve_token'
         : 'authorize_bundler_tx';
@@ -503,7 +515,7 @@ export function useLeverageTransaction({
       errorTitle: 'Error',
       logLabel: 'approveAndLeverage',
     });
-  }, [usePermit2ForRoute, permit2Authorized, isBundlerAuthorized, isApproved, runLeverageFlow]);
+  }, [usePermit2ForRoute, permit2Authorized, isBundlerAuthorized, requiresInitialCapitalTransfer, isApproved, runLeverageFlow]);
 
   const signAndLeverage = useCallback(async () => {
     if (!usePermit2ForRoute) {

--- a/src/hooks/useLeverageTransaction.ts
+++ b/src/hooks/useLeverageTransaction.ts
@@ -163,7 +163,7 @@ export function useLeverageTransaction({
     () => ({
       title: 'Leverage',
       description: `${market.collateralAsset.symbol} leveraged using ${market.loanAsset.symbol} debt`,
-      tokenSymbol: initialCapitalInputTokenSymbol,
+      tokenSymbol: requiresInitialCapitalTransfer ? initialCapitalInputTokenSymbol : market.loanAsset.symbol,
       amount: requiresInitialCapitalTransfer ? initialCapitalInputAmount : flashLoanAssetAmount,
       marketId: market.uniqueKey,
     }),

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -169,7 +169,7 @@ export function AddCollateralAndLeverage({
 
   useEffect(() => {
     setHasInitializedPositionTarget(false);
-  }, [useExistingPositionSource, currentCollateralAssets, currentBorrowAssets]);
+  }, [useExistingPositionSource, market.uniqueKey, account]);
 
   useEffect(() => {
     if (

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -3,7 +3,7 @@ import { erc20Abi, formatUnits } from 'viem';
 import { useConnection, useReadContract } from 'wagmi';
 import { BorrowPositionRiskCard } from '@/modals/borrow/components/borrow-position-risk-card';
 import { PreviewSectionHeader } from '@/modals/borrow/components/preview-section-header';
-import { LTV_WAD, computeLtv } from '@/modals/borrow/components/helpers';
+import { LTV_WAD, computeLtv, getCollateralValueInLoan } from '@/modals/borrow/components/helpers';
 import { HelpTooltipIcon } from '@/components/shared/help-tooltip-icon';
 import { RateFormatted } from '@/components/shared/rate-formatted';
 import { TooltipContent as SharedTooltipContent } from '@/components/shared/tooltip-content';
@@ -25,6 +25,7 @@ import {
   parseUnsignedBigInt,
   toScaledRatio,
   targetLtvBpsFromMultiplier,
+  WAD_TO_BPS_SCALE,
 } from '@/hooks/leverage/math';
 import { LEVERAGE_DEFAULT_MULTIPLIER_BPS } from '@/hooks/leverage/types';
 import { useMerklHoldIncentivesQuery } from '@/hooks/queries/useMerklHoldIncentivesQuery';
@@ -49,6 +50,7 @@ type AddCollateralAndLeverageProps = {
   currentPosition: MarketPosition | null;
   collateralTokenBalance: bigint | undefined;
   oraclePrice: bigint;
+  defaultLeverageSource?: 'wallet' | 'position';
   onSuccess?: () => void;
   isRefreshing?: boolean;
 };
@@ -63,6 +65,7 @@ export function AddCollateralAndLeverage({
   currentPosition,
   collateralTokenBalance,
   oraclePrice,
+  defaultLeverageSource = 'wallet',
   onSuccess,
   isRefreshing = false,
 }: AddCollateralAndLeverageProps): JSX.Element {
@@ -83,6 +86,25 @@ export function AddCollateralAndLeverage({
     () => clampTargetLtvBps(targetLtvBpsFromMultiplier(defaultMultiplierBps), maxTargetLtvBps),
     [defaultMultiplierBps, maxTargetLtvBps],
   );
+  const currentCollateralAssets = useMemo(
+    () => parseUnsignedBigInt(currentPosition?.state.collateral) ?? 0n,
+    [currentPosition?.state.collateral],
+  );
+  const currentBorrowAssets = useMemo(
+    () => parseUnsignedBigInt(currentPosition?.state.borrowAssets) ?? 0n,
+    [currentPosition?.state.borrowAssets],
+  );
+  const currentLTV = useMemo(
+    () =>
+      computeLtv({
+        borrowAssets: currentBorrowAssets,
+        collateralAssets: currentCollateralAssets,
+        oraclePrice,
+      }),
+    [currentBorrowAssets, currentCollateralAssets, oraclePrice],
+  );
+  const currentLtvBps = useMemo(() => ltvWadToBps(currentLTV), [currentLTV]);
+  const canLeverageExistingPosition = currentCollateralAssets > 0n;
 
   const [initialCapitalInputAmount, setInitialCapitalInputAmount] = useState<bigint>(0n);
   const [initialCapitalInputError, setInitialCapitalInputError] = useState<string | null>(null);
@@ -100,6 +122,9 @@ export function AddCollateralAndLeverage({
   const isErc4626Route = route?.kind === 'erc4626';
   const isSwapRoute = route?.kind === 'swap';
   const canUseLoanAssetInput = isErc4626Route || isSwapRoute;
+  const useExistingPositionSource = defaultLeverageSource === 'position';
+  const leverageSizingMode = useExistingPositionSource ? 'position-target' : 'initial-capital';
+  const useLoanAssetInputForTransaction = !useExistingPositionSource && useLoanAssetInput;
 
   const { data: loanTokenBalance, refetch: refetchLoanTokenBalance } = useReadContract({
     address: market.loanAsset.address as `0x${string}`,
@@ -108,7 +133,7 @@ export function AddCollateralAndLeverage({
     abi: erc20Abi,
     chainId: market.morphoBlue.chain.id,
     query: {
-      enabled: !!account && useLoanAssetInput,
+      enabled: !!account && useLoanAssetInputForTransaction,
     },
   });
 
@@ -136,11 +161,44 @@ export function AddCollateralAndLeverage({
     }
   }, [targetMultiplierBps, maxMultiplierBps, maxTargetLtvBps, useTargetLtvInput, targetLtvIntentBps]);
 
+  const suggestedPositionTargetLtvBps = useMemo(() => {
+    if (currentLtvBps >= maxTargetLtvBps) return maxTargetLtvBps;
+    return clampTargetLtvBps(currentLtvBps + 500n, maxTargetLtvBps);
+  }, [currentLtvBps, maxTargetLtvBps]);
+
+  useEffect(() => {
+    if (!useExistingPositionSource || suggestedPositionTargetLtvBps <= currentLtvBps || targetLtvBps > currentLtvBps) return;
+
+    setTargetLtvIntentBps(suggestedPositionTargetLtvBps);
+    setTargetMultiplierBps(multiplierBpsFromTargetLtv(suggestedPositionTargetLtvBps, maxMultiplierBps));
+  }, [useExistingPositionSource, suggestedPositionTargetLtvBps, currentLtvBps, targetLtvBps, maxMultiplierBps]);
+
+  const positionDebtInputAmount = useMemo(() => {
+    if (!useExistingPositionSource || currentCollateralAssets <= 0n || oraclePrice <= 0n) return 0n;
+
+    const targetLtvWad = targetLtvBps * WAD_TO_BPS_SCALE;
+    if (targetLtvWad <= 0n || targetLtvWad >= LTV_WAD || targetLtvWad <= currentLTV) return 0n;
+
+    const currentCollateralValueInLoan = getCollateralValueInLoan(currentCollateralAssets, oraclePrice);
+    if (currentCollateralValueInLoan <= 0n) return 0n;
+
+    // Solve targetLTV = (currentDebt + addedDebt) / (currentCollateralValue + addedDebt)
+    // so the input targets the whole position instead of only the new loop leg.
+    const targetBorrowNumerator = targetLtvWad * currentCollateralValueInLoan;
+    const currentBorrowNumerator = currentBorrowAssets * LTV_WAD;
+    if (targetBorrowNumerator <= currentBorrowNumerator) return 0n;
+
+    const denominator = LTV_WAD - targetLtvWad;
+    return (targetBorrowNumerator - currentBorrowNumerator + denominator - 1n) / denominator;
+  }, [useExistingPositionSource, currentCollateralAssets, oraclePrice, targetLtvBps, currentLTV, currentBorrowAssets]);
+
   const quote = useLeverageQuote({
     chainId: market.morphoBlue.chain.id,
     route,
+    sizingMode: leverageSizingMode,
     initialCapitalInputAmount,
-    inputMode: useLoanAssetInput ? 'loan' : 'collateral',
+    positionDebtInputAmount,
+    inputMode: useLoanAssetInputForTransaction ? 'loan' : 'collateral',
     multiplierBps,
     loanTokenAddress: market.loanAsset.address,
     loanTokenDecimals: market.loanAsset.decimals,
@@ -150,8 +208,6 @@ export function AddCollateralAndLeverage({
     slippageBps: swapSlippageBps,
   });
 
-  const currentCollateralAssets = BigInt(currentPosition?.state.collateral ?? 0);
-  const currentBorrowAssets = BigInt(currentPosition?.state.borrowAssets ?? 0);
   const hasQuoteChanges = quote.totalCollateralTokenAmountAdded > 0n && quote.flashLoanAssetAmount > 0n;
   const collateralAssetPriceUsd = useMemo(() => {
     const totalCollateralAssets = BigInt(market.state.collateralAssets);
@@ -239,16 +295,6 @@ export function AddCollateralAndLeverage({
     [projectedBorrowAssets, projectedCollateralAssets, oraclePrice],
   );
 
-  const currentLTV = useMemo(
-    () =>
-      computeLtv({
-        borrowAssets: currentBorrowAssets,
-        collateralAssets: currentCollateralAssets,
-        oraclePrice,
-      }),
-    [currentBorrowAssets, currentCollateralAssets, oraclePrice],
-  );
-
   const syncInputFieldsFromMultiplier = useCallback(
     (nextMultiplierBps: bigint) => {
       const clampedMultiplier = clampMultiplierBps(nextMultiplierBps, maxMultiplierBps);
@@ -264,11 +310,11 @@ export function AddCollateralAndLeverage({
     setInitialCapitalInputAmount(0n);
     setInitialCapitalInputError(null);
     syncInputFieldsFromMultiplier(defaultMultiplierBps);
-    if (useLoanAssetInput) {
+    if (useLoanAssetInputForTransaction) {
       void refetchLoanTokenBalance();
     }
     if (onSuccess) onSuccess();
-  }, [defaultMultiplierBps, onSuccess, refetchLoanTokenBalance, syncInputFieldsFromMultiplier, useLoanAssetInput]);
+  }, [defaultMultiplierBps, onSuccess, refetchLoanTokenBalance, syncInputFieldsFromMultiplier, useLoanAssetInputForTransaction]);
 
   const {
     transaction,
@@ -288,7 +334,7 @@ export function AddCollateralAndLeverage({
     totalCollateralTokenAmountAdded: quote.totalCollateralTokenAmountAdded,
     collateralAssetPriceUsd,
     swapPriceRoute: quote.swapPriceRoute,
-    useLoanAssetInput,
+    useLoanAssetInput: useLoanAssetInputForTransaction,
     slippageBps: swapSlippageBps,
     onSuccess: handleTransactionSuccess,
   });
@@ -306,7 +352,7 @@ export function AddCollateralAndLeverage({
 
   const handleLeverage = useCallback(() => {
     if (!isLeverageFeeReady) return;
-    const usePermit2Flow = usePermit2Setting;
+    const usePermit2Flow = usePermit2Setting && !useExistingPositionSource;
 
     if (usePermit2Flow && permit2Authorized) {
       void signAndLeverage();
@@ -314,18 +360,19 @@ export function AddCollateralAndLeverage({
     }
 
     void approveAndLeverage();
-  }, [isLeverageFeeReady, usePermit2Setting, permit2Authorized, signAndLeverage, approveAndLeverage]);
+  }, [isLeverageFeeReady, usePermit2Setting, useExistingPositionSource, permit2Authorized, signAndLeverage, approveAndLeverage]);
 
   const projectedOverLimit = projectedLTV >= lltv;
   const insufficientLiquidity = quote.flashLoanAssetAmount > marketLiquidity;
-  const inputAssetSymbol = useLoanAssetInput ? market.loanAsset.symbol : market.collateralAsset.symbol;
-  const inputAssetDecimals = useLoanAssetInput ? market.loanAsset.decimals : market.collateralAsset.decimals;
-  const inputAssetBalance = useLoanAssetInput ? (loanTokenBalance as bigint | undefined) : collateralTokenBalance;
-  const inputTokenIconAddress = useLoanAssetInput ? market.loanAsset.address : market.collateralAsset.address;
+  const inputAssetSymbol = useLoanAssetInputForTransaction ? market.loanAsset.symbol : market.collateralAsset.symbol;
+  const inputAssetDecimals = useLoanAssetInputForTransaction ? market.loanAsset.decimals : market.collateralAsset.decimals;
+  const inputAssetBalance = useLoanAssetInputForTransaction ? (loanTokenBalance as bigint | undefined) : collateralTokenBalance;
+  const inputTokenIconAddress = useLoanAssetInputForTransaction ? market.loanAsset.address : market.collateralAsset.address;
   const flashBorrowPreview = useMemo(
     () => formatTokenAmountPreview(quote.flashLoanAssetAmount, market.loanAsset.decimals),
     [quote.flashLoanAssetAmount, market.loanAsset.decimals],
   );
+  const flashBorrowLabel = useExistingPositionSource ? 'Additional Debt' : isSwapRoute ? 'Flash Borrow Required' : 'Flash Borrow';
   const totalCollateralAddedPreview = useMemo(
     () => formatTokenAmountPreview(quote.totalCollateralTokenAmountAdded, market.collateralAsset.decimals),
     [quote.totalCollateralTokenAmountAdded, market.collateralAsset.decimals],
@@ -346,20 +393,49 @@ export function AddCollateralAndLeverage({
     () => formatTokenAmountPreview(quote.flashLegCollateralTokenAmount, market.collateralAsset.decimals),
     [quote.flashLegCollateralTokenAmount, market.collateralAsset.decimals],
   );
-  const collateralPreviewForDisplay = isSwapRoute && !useLoanAssetInput ? swapCollateralOutPreview : totalCollateralAddedPreview;
-  const collateralPreviewLabel = isSwapRoute
-    ? useLoanAssetInput
-      ? 'Total Collateral Added (Min.)'
-      : 'Collateral From Swap (Min.)'
-    : isErc4626Route
-      ? 'Total Collateral Added (Min.)'
-      : 'Total Collateral Added';
+  const collateralPreviewForDisplay =
+    isSwapRoute && !useLoanAssetInputForTransaction ? swapCollateralOutPreview : totalCollateralAddedPreview;
+  const collateralPreviewLabel = useExistingPositionSource
+    ? isSwapRoute
+      ? 'Collateral From Loop (Min.)'
+      : 'Collateral Added (Min.)'
+    : isSwapRoute
+      ? useLoanAssetInputForTransaction
+        ? 'Total Collateral Added (Min.)'
+        : 'Collateral From Swap (Min.)'
+      : isErc4626Route
+        ? 'Total Collateral Added (Min.)'
+        : 'Total Collateral Added';
   const hasExecutableInitialCapitalConversion = useMemo(() => {
-    if (!useLoanAssetInput) return true;
+    if (useExistingPositionSource) return quote.totalCollateralTokenAmountAdded > 0n;
+    if (!useLoanAssetInputForTransaction) return true;
     if (isSwapRoute) return quote.totalCollateralTokenAmountAdded > 0n;
     if (isErc4626Route) return quote.initialCapitalCollateralTokenAmount > 0n;
     return false;
-  }, [useLoanAssetInput, isSwapRoute, isErc4626Route, quote.totalCollateralTokenAmountAdded, quote.initialCapitalCollateralTokenAmount]);
+  }, [
+    useExistingPositionSource,
+    useLoanAssetInputForTransaction,
+    isSwapRoute,
+    isErc4626Route,
+    quote.totalCollateralTokenAmountAdded,
+    quote.initialCapitalCollateralTokenAmount,
+  ]);
+  const positionTargetError = useMemo(() => {
+    if (!useExistingPositionSource) return null;
+    if (!canLeverageExistingPosition) return 'Existing collateral is required to increase leverage without new capital.';
+    if (currentLtvBps >= maxTargetLtvBps) return 'Current LTV is already at or above the safe leverage target.';
+    if (targetLtvBps <= currentLtvBps) return 'Set a target above current LTV to increase leverage.';
+    if (positionDebtInputAmount <= 0n) return 'Target does not require additional debt.';
+    return null;
+  }, [useExistingPositionSource, canLeverageExistingPosition, currentLtvBps, maxTargetLtvBps, targetLtvBps, positionDebtInputAmount]);
+  const hasLeverageInput = useExistingPositionSource ? positionDebtInputAmount > 0n : initialCapitalInputAmount > 0n;
+  const targetInputLabel = useExistingPositionSource
+    ? useTargetLtvInput
+      ? 'Target Position LTV'
+      : 'Target Position Multiplier'
+    : useTargetLtvInput
+      ? 'Target LTV'
+      : 'Target Multiplier';
   const swapRatePreviewText = useMemo(() => {
     if (!isSwapRoute || !quote.swapPriceRoute) return null;
 
@@ -537,6 +613,7 @@ export function AddCollateralAndLeverage({
   const hasConfiguredHoldRewards = merklHoldIncentives.incentiveLabel != null;
   const shouldShowHoldRewardsRow = hasConfiguredHoldRewards;
   const shouldShowNetRate = isErc4626Route || (showFullRewardAPY && shouldShowHoldRewardsRow);
+  const shouldShowLeveredCarry = !useExistingPositionSource;
   const isNetRateLoading =
     (isErc4626Route && (vaultRateInsight.isLoading || vaultRateInsight.vaultApy3d == null || projectedLtvRatio == null)) ||
     (showFullRewardAPY && shouldShowHoldRewardsRow && merklHoldIncentives.loading);
@@ -583,6 +660,7 @@ export function AddCollateralAndLeverage({
     return Number.isFinite(leveredCarryRate) ? leveredCarryRate : null;
   }, [addedCollateralAssets, addedDebtToCollateralRatio, collateralYieldRate, borrowRateForCarry, contributedCapitalAssets]);
   const isLeveredCarryLoading =
+    shouldShowLeveredCarry &&
     isLeverageFeeReady &&
     ((isErc4626Route && (vaultRateInsight.isLoading || vaultRateInsight.vaultApy3d == null || vaultRateInsight.sharePriceNow == null)) ||
       (showFullRewardAPY && shouldShowHoldRewardsRow && merklHoldIncentives.loading));
@@ -600,7 +678,7 @@ export function AddCollateralAndLeverage({
       {!transaction?.isModalVisible && (
         <div className="flex flex-col">
           <PreviewSectionHeader
-            title="Leverage Preview"
+            title={useExistingPositionSource ? 'Update Position Preview' : 'Leverage Preview'}
             onRefresh={onSuccess}
             isRefreshing={isRefreshing}
           />
@@ -619,56 +697,63 @@ export function AddCollateralAndLeverage({
           />
 
           <div className="mt-2 space-y-3">
-            <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Initial Capital</p>
-                {canUseLoanAssetInput && (
-                  <div className="flex items-center gap-2">
-                    <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
-                    <IconSwitch
-                      size="sm"
-                      selected={useLoanAssetInput}
-                      onChange={setUseLoanAssetInput}
-                      thumbIcon={null}
-                      classNames={{
-                        wrapper: 'mr-0 h-4 w-9',
-                        thumb: 'h-3 w-3',
-                      }}
+            {useExistingPositionSource && (
+              <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Current Position</p>
+                <p className="mt-1 text-xs text-secondary">Set a higher target LTV. No wallet capital is added.</p>
+              </div>
+            )}
+
+            {!useExistingPositionSource && (
+              <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Initial Capital</p>
+                  {canUseLoanAssetInput && (
+                    <div className="flex items-center gap-2">
+                      <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
+                      <IconSwitch
+                        size="sm"
+                        selected={useLoanAssetInput}
+                        onChange={setUseLoanAssetInput}
+                        thumbIcon={null}
+                        classNames={{
+                          wrapper: 'mr-0 h-4 w-9',
+                          thumb: 'h-3 w-3',
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+                <Input
+                  decimals={inputAssetDecimals}
+                  max={inputAssetBalance}
+                  setValue={setInitialCapitalInputAmount}
+                  setError={setInitialCapitalInputError}
+                  exceedMaxErrMessage="Insufficient Balance"
+                  value={initialCapitalInputAmount}
+                  inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
+                  endAdornment={
+                    <TokenIcon
+                      address={inputTokenIconAddress}
+                      chainId={market.morphoBlue.chain.id}
+                      symbol={inputAssetSymbol}
+                      width={16}
+                      height={16}
                     />
-                  </div>
-                )}
+                  }
+                />
+                <div className="mt-1 flex items-start gap-3 text-xs">
+                  {initialCapitalInputError && <p className="text-red-500">{initialCapitalInputError}</p>}
+                  <span className="ml-auto text-right text-secondary">
+                    Balance: {formatBalance(inputAssetBalance ?? 0n, inputAssetDecimals)} {inputAssetSymbol}
+                  </span>
+                </div>
               </div>
-              <Input
-                decimals={inputAssetDecimals}
-                max={inputAssetBalance}
-                setValue={setInitialCapitalInputAmount}
-                setError={setInitialCapitalInputError}
-                exceedMaxErrMessage="Insufficient Balance"
-                value={initialCapitalInputAmount}
-                inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
-                endAdornment={
-                  <TokenIcon
-                    address={inputTokenIconAddress}
-                    chainId={market.morphoBlue.chain.id}
-                    symbol={inputAssetSymbol}
-                    width={16}
-                    height={16}
-                  />
-                }
-              />
-              <div className="mt-1 flex items-start gap-3 text-xs">
-                {initialCapitalInputError && <p className="text-red-500">{initialCapitalInputError}</p>}
-                <span className="ml-auto text-right text-secondary">
-                  Balance: {formatBalance(inputAssetBalance ?? 0n, inputAssetDecimals)} {inputAssetSymbol}
-                </span>
-              </div>
-            </div>
+            )}
 
             <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
               <div className="mb-1 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">
-                  {useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}
-                </p>
+                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">{targetInputLabel}</p>
                 <div className="flex items-center gap-2">
                   <div className="text-xs text-secondary">Use LTV</div>
                   <IconSwitch
@@ -714,7 +799,7 @@ export function AddCollateralAndLeverage({
               <p className="mb-2 text-[11px] uppercase tracking-[0.12em] text-secondary">Transaction Preview</p>
               <div className="space-y-1 text-xs">
                 <div className="flex items-center justify-between">
-                  <span className="text-secondary">{isSwapRoute ? 'Flash Borrow Required' : 'Flash Borrow'}</span>
+                  <span className="text-secondary">{flashBorrowLabel}</span>
                   <span className="tabular-nums inline-flex items-center gap-1.5">
                     <Tooltip content={<span className="text-xs">{flashBorrowPreview.full}</span>}>
                       <span className="cursor-help border-b border-dotted border-white/40">{flashBorrowPreview.compact}</span>
@@ -846,30 +931,33 @@ export function AddCollateralAndLeverage({
                             {isNetRateLoading ? '...' : renderRateFromDisplayMode(previewExpectedNetRate)}
                           </span>
                         </div>
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-0.5">
-                            <span className="text-secondary">{leveredCarryLabel}</span>
-                            <HelpTooltipIcon
-                              content={
-                                <SharedTooltipContent
-                                  title={leveredCarryLabel}
-                                  detail={leveredCarryDetail}
-                                  secondaryDetail={leveredCarrySecondaryDetail}
-                                />
-                              }
-                              ariaLabel={`Explain ${leveredCarryLabel}`}
-                              className="h-auto w-auto"
-                            />
+                        {shouldShowLeveredCarry && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-0.5">
+                              <span className="text-secondary">{leveredCarryLabel}</span>
+                              <HelpTooltipIcon
+                                content={
+                                  <SharedTooltipContent
+                                    title={leveredCarryLabel}
+                                    detail={leveredCarryDetail}
+                                    secondaryDetail={leveredCarrySecondaryDetail}
+                                  />
+                                }
+                                ariaLabel={`Explain ${leveredCarryLabel}`}
+                                className="h-auto w-auto"
+                              />
+                            </div>
+                            <span className={`tabular-nums ${leveredCarryRateClass}`}>
+                              {isLeveredCarryLoading ? '...' : renderRateFromDisplayMode(previewLeveredCarryOnCapitalRate)}
+                            </span>
                           </div>
-                          <span className={`tabular-nums ${leveredCarryRateClass}`}>
-                            {isLeveredCarryLoading ? '...' : renderRateFromDisplayMode(previewLeveredCarryOnCapitalRate)}
-                          </span>
-                        </div>
+                        )}
                       </>
                     )}
                   </>
                 )}
               </div>
+              {positionTargetError && <p className="mt-2 text-xs text-red-500">{positionTargetError}</p>}
               {quote.error && <p className="mt-2 text-xs text-red-500">{quote.error}</p>}
               {!quote.error && leverageFeeReadinessError && <p className="mt-2 text-xs text-red-500">{leverageFeeReadinessError}</p>}
               {isErc4626Route && vaultRateInsight.error && (
@@ -895,9 +983,10 @@ export function AddCollateralAndLeverage({
                 isLoading={isLoadingPermit2 || leveragePending || quote.isLoading}
                 disabled={
                   route == null ||
-                  initialCapitalInputError !== null ||
+                  (!useExistingPositionSource && initialCapitalInputError !== null) ||
+                  positionTargetError !== null ||
                   quote.error !== null ||
-                  initialCapitalInputAmount <= 0n ||
+                  !hasLeverageInput ||
                   !isBundlerAuthorizationReady ||
                   !hasExecutableInitialCapitalConversion ||
                   !isLeverageFeeReady ||
@@ -908,7 +997,7 @@ export function AddCollateralAndLeverage({
                 variant="primary"
                 className="min-w-32"
               >
-                Leverage
+                {useExistingPositionSource ? 'Update Position' : 'Leverage'}
               </ExecuteTransactionButton>
             </div>
 

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -112,6 +112,7 @@ export function AddCollateralAndLeverage({
   const [targetMultiplierBps, setTargetMultiplierBps] = useState<bigint>(defaultMultiplierBps);
   const [targetLtvIntentBps, setTargetLtvIntentBps] = useState<bigint>(defaultTargetLtvIntentBps);
   const [swapSlippagePercent, setSwapSlippagePercent] = useState<number>(DEFAULT_SLIPPAGE_PERCENT);
+  const [hasInitializedPositionTarget, setHasInitializedPositionTarget] = useState(false);
 
   const multiplierBps = useMemo(() => clampMultiplierBps(targetMultiplierBps, maxMultiplierBps), [targetMultiplierBps, maxMultiplierBps]);
   const targetLtvBps = useMemo(
@@ -167,11 +168,30 @@ export function AddCollateralAndLeverage({
   }, [currentLtvBps, maxTargetLtvBps]);
 
   useEffect(() => {
-    if (!useExistingPositionSource || suggestedPositionTargetLtvBps <= currentLtvBps || targetLtvBps > currentLtvBps) return;
+    setHasInitializedPositionTarget(false);
+  }, [useExistingPositionSource, currentCollateralAssets, currentBorrowAssets]);
+
+  useEffect(() => {
+    if (
+      !useExistingPositionSource ||
+      !canLeverageExistingPosition ||
+      hasInitializedPositionTarget ||
+      suggestedPositionTargetLtvBps <= currentLtvBps
+    ) {
+      return;
+    }
 
     setTargetLtvIntentBps(suggestedPositionTargetLtvBps);
     setTargetMultiplierBps(multiplierBpsFromTargetLtv(suggestedPositionTargetLtvBps, maxMultiplierBps));
-  }, [useExistingPositionSource, suggestedPositionTargetLtvBps, currentLtvBps, targetLtvBps, maxMultiplierBps]);
+    setHasInitializedPositionTarget(true);
+  }, [
+    useExistingPositionSource,
+    canLeverageExistingPosition,
+    hasInitializedPositionTarget,
+    suggestedPositionTargetLtvBps,
+    currentLtvBps,
+    maxMultiplierBps,
+  ]);
 
   const positionDebtInputAmount = useMemo(() => {
     if (!useExistingPositionSource || currentCollateralAssets <= 0n || oraclePrice <= 0n) return 0n;

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -78,7 +78,7 @@ export function AddCollateralAndLeverage({
     setLeverageUseTargetLtvInput,
   } = useAppSettings();
   const lltv = useMemo(() => parseUnsignedBigInt(market.lltv) ?? 0n, [market.lltv]);
-  const lltvBps = useMemo(() => ltvWadToBps(lltv), [lltv]);
+  const lltvBps = ltvWadToBps(lltv);
   const maxTargetLtvBps = useMemo(() => (lltvBps > LEVERAGE_SAFE_LTV_BUFFER_BPS ? lltvBps - LEVERAGE_SAFE_LTV_BUFFER_BPS : 0n), [lltvBps]);
   const maxMultiplierBps = useMemo(() => computeMaxMultiplierBpsForTargetLtv(maxTargetLtvBps), [maxTargetLtvBps]);
   const defaultMultiplierBps = useMemo(() => clampMultiplierBps(LEVERAGE_DEFAULT_MULTIPLIER_BPS, maxMultiplierBps), [maxMultiplierBps]);
@@ -86,14 +86,8 @@ export function AddCollateralAndLeverage({
     () => clampTargetLtvBps(targetLtvBpsFromMultiplier(defaultMultiplierBps), maxTargetLtvBps),
     [defaultMultiplierBps, maxTargetLtvBps],
   );
-  const currentCollateralAssets = useMemo(
-    () => parseUnsignedBigInt(currentPosition?.state.collateral) ?? 0n,
-    [currentPosition?.state.collateral],
-  );
-  const currentBorrowAssets = useMemo(
-    () => parseUnsignedBigInt(currentPosition?.state.borrowAssets) ?? 0n,
-    [currentPosition?.state.borrowAssets],
-  );
+  const currentCollateralAssets = parseUnsignedBigInt(currentPosition?.state.collateral) ?? 0n;
+  const currentBorrowAssets = parseUnsignedBigInt(currentPosition?.state.borrowAssets) ?? 0n;
   const currentLTV = useMemo(
     () =>
       computeLtv({
@@ -103,7 +97,7 @@ export function AddCollateralAndLeverage({
       }),
     [currentBorrowAssets, currentCollateralAssets, oraclePrice],
   );
-  const currentLtvBps = useMemo(() => ltvWadToBps(currentLTV), [currentLTV]);
+  const currentLtvBps = ltvWadToBps(currentLTV);
   const canLeverageExistingPosition = currentCollateralAssets > 0n;
 
   const [initialCapitalInputAmount, setInitialCapitalInputAmount] = useState<bigint>(0n);
@@ -112,7 +106,7 @@ export function AddCollateralAndLeverage({
   const [targetMultiplierBps, setTargetMultiplierBps] = useState<bigint>(defaultMultiplierBps);
   const [targetLtvIntentBps, setTargetLtvIntentBps] = useState<bigint>(defaultTargetLtvIntentBps);
   const [swapSlippagePercent, setSwapSlippagePercent] = useState<number>(DEFAULT_SLIPPAGE_PERCENT);
-  const [hasInitializedPositionTarget, setHasInitializedPositionTarget] = useState(false);
+  const [initializedPositionTargetKey, setInitializedPositionTargetKey] = useState<string | null>(null);
 
   const multiplierBps = useMemo(() => clampMultiplierBps(targetMultiplierBps, maxMultiplierBps), [targetMultiplierBps, maxMultiplierBps]);
   const targetLtvBps = useMemo(
@@ -124,7 +118,7 @@ export function AddCollateralAndLeverage({
   const isSwapRoute = route?.kind === 'swap';
   const canUseLoanAssetInput = isErc4626Route || isSwapRoute;
   const useExistingPositionSource = defaultLeverageSource === 'position';
-  const leverageSizingMode = useExistingPositionSource ? 'position-target' : 'initial-capital';
+  const positionTargetInitKey = useExistingPositionSource && account ? `${market.uniqueKey}:${account}` : null;
   const useLoanAssetInputForTransaction = !useExistingPositionSource && useLoanAssetInput;
 
   const { data: loanTokenBalance, refetch: refetchLoanTokenBalance } = useReadContract({
@@ -168,14 +162,10 @@ export function AddCollateralAndLeverage({
   }, [currentLtvBps, maxTargetLtvBps]);
 
   useEffect(() => {
-    setHasInitializedPositionTarget(false);
-  }, [useExistingPositionSource, market.uniqueKey, account]);
-
-  useEffect(() => {
     if (
-      !useExistingPositionSource ||
+      !positionTargetInitKey ||
       !canLeverageExistingPosition ||
-      hasInitializedPositionTarget ||
+      initializedPositionTargetKey === positionTargetInitKey ||
       suggestedPositionTargetLtvBps <= currentLtvBps
     ) {
       return;
@@ -183,11 +173,11 @@ export function AddCollateralAndLeverage({
 
     setTargetLtvIntentBps(suggestedPositionTargetLtvBps);
     setTargetMultiplierBps(multiplierBpsFromTargetLtv(suggestedPositionTargetLtvBps, maxMultiplierBps));
-    setHasInitializedPositionTarget(true);
+    setInitializedPositionTargetKey(positionTargetInitKey);
   }, [
-    useExistingPositionSource,
+    positionTargetInitKey,
     canLeverageExistingPosition,
-    hasInitializedPositionTarget,
+    initializedPositionTargetKey,
     suggestedPositionTargetLtvBps,
     currentLtvBps,
     maxMultiplierBps,
@@ -215,9 +205,8 @@ export function AddCollateralAndLeverage({
   const quote = useLeverageQuote({
     chainId: market.morphoBlue.chain.id,
     route,
-    sizingMode: leverageSizingMode,
     initialCapitalInputAmount,
-    positionDebtInputAmount,
+    positionDebtInputAmount: useExistingPositionSource ? positionDebtInputAmount : undefined,
     inputMode: useLoanAssetInputForTransaction ? 'loan' : 'collateral',
     multiplierBps,
     loanTokenAddress: market.loanAsset.address,
@@ -426,20 +415,10 @@ export function AddCollateralAndLeverage({
       : isErc4626Route
         ? 'Total Collateral Added (Min.)'
         : 'Total Collateral Added';
-  const hasExecutableInitialCapitalConversion = useMemo(() => {
-    if (useExistingPositionSource) return quote.totalCollateralTokenAmountAdded > 0n;
-    if (!useLoanAssetInputForTransaction) return true;
-    if (isSwapRoute) return quote.totalCollateralTokenAmountAdded > 0n;
-    if (isErc4626Route) return quote.initialCapitalCollateralTokenAmount > 0n;
-    return false;
-  }, [
-    useExistingPositionSource,
-    useLoanAssetInputForTransaction,
-    isSwapRoute,
-    isErc4626Route,
-    quote.totalCollateralTokenAmountAdded,
-    quote.initialCapitalCollateralTokenAmount,
-  ]);
+  const hasExecutableInitialCapitalConversion = useExistingPositionSource
+    ? quote.totalCollateralTokenAmountAdded > 0n
+    : !useLoanAssetInputForTransaction ||
+      (isSwapRoute ? quote.totalCollateralTokenAmountAdded > 0n : isErc4626Route && quote.initialCapitalCollateralTokenAmount > 0n);
   const positionTargetError = useMemo(() => {
     if (!useExistingPositionSource) return null;
     if (!canLeverageExistingPosition) return 'Existing collateral is required to increase leverage without new capital.';

--- a/src/modals/leverage/leverage-modal-global.tsx
+++ b/src/modals/leverage/leverage-modal-global.tsx
@@ -11,6 +11,7 @@ type LeverageModalGlobalProps = {
   market: Market;
   defaultMode?: 'leverage' | 'deleverage';
   toggleLeverageDeleverage?: boolean;
+  defaultLeverageSource?: 'wallet' | 'position';
   refetch?: () => void;
   onOpenChange: (open: boolean) => void;
 };
@@ -23,6 +24,7 @@ export function LeverageModalGlobal({
   market,
   defaultMode,
   toggleLeverageDeleverage,
+  defaultLeverageSource,
   refetch: externalRefetch,
   onOpenChange,
 }: LeverageModalGlobalProps): JSX.Element {
@@ -50,6 +52,7 @@ export function LeverageModalGlobal({
       position={position}
       defaultMode={defaultMode}
       toggleLeverageDeleverage={toggleLeverageDeleverage}
+      defaultLeverageSource={defaultLeverageSource}
     />
   );
 }

--- a/src/modals/leverage/leverage-modal.tsx
+++ b/src/modals/leverage/leverage-modal.tsx
@@ -27,6 +27,7 @@ type LeverageModalProps = {
   position: MarketPosition | null;
   defaultMode?: 'leverage' | 'deleverage';
   toggleLeverageDeleverage?: boolean;
+  defaultLeverageSource?: 'wallet' | 'position';
 };
 
 const ROUTE_MODE_LABELS = {
@@ -102,6 +103,7 @@ export function LeverageModal({
   position,
   defaultMode = 'leverage',
   toggleLeverageDeleverage = true,
+  defaultLeverageSource = 'wallet',
 }: LeverageModalProps): JSX.Element {
   const [mode, setMode] = useState<'leverage' | 'deleverage'>(defaultMode);
   const [routeMode, setRouteMode] = useState<RouteMode>('erc4626');
@@ -173,17 +175,33 @@ export function LeverageModal({
   }, [route, availableRouteModes, routeMode]);
 
   const effectiveMode = mode;
+  const isPositionUpdateIntent = defaultLeverageSource === 'position';
+  const leverageModeLabel = isPositionUpdateIntent ? 'Update Position' : `Leverage ${market.collateralAsset.symbol}`;
   const modeOptions: { value: string; label: string }[] = toggleLeverageDeleverage
     ? [
-        { value: 'leverage', label: `Leverage ${market.collateralAsset.symbol}` },
+        { value: 'leverage', label: leverageModeLabel },
         { value: 'deleverage', label: `Deleverage ${market.collateralAsset.symbol}` },
       ]
     : [
         {
           value: effectiveMode,
-          label: effectiveMode === 'leverage' ? `Leverage ${market.collateralAsset.symbol}` : `Deleverage ${market.collateralAsset.symbol}`,
+          label: effectiveMode === 'leverage' ? leverageModeLabel : `Deleverage ${market.collateralAsset.symbol}`,
         },
       ];
+  const description =
+    effectiveMode === 'leverage'
+      ? isPositionUpdateIntent
+        ? 'Increase leverage on this position without adding wallet capital.'
+        : isErc4626Route
+          ? `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
+          : isSwapRoute
+            ? `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
+            : `Leverage your ${market.collateralAsset.symbol} exposure by looping.`
+      : isErc4626Route
+        ? `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`
+        : isSwapRoute
+          ? `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`
+          : `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`;
 
   const {
     data: collateralTokenBalance,
@@ -220,6 +238,7 @@ export function LeverageModal({
           currentPosition={position}
           collateralTokenBalance={collateralTokenBalance}
           oraclePrice={oraclePrice}
+          defaultLeverageSource={defaultLeverageSource}
           onSuccess={handleRefreshAll}
           isRefreshing={isRefreshingAnyData}
         />
@@ -236,7 +255,17 @@ export function LeverageModal({
         isRefreshing={isRefreshingAnyData}
       />
     );
-  }, [route, effectiveMode, market, position, collateralTokenBalance, oraclePrice, handleRefreshAll, isRefreshingAnyData]);
+  }, [
+    route,
+    effectiveMode,
+    market,
+    position,
+    collateralTokenBalance,
+    oraclePrice,
+    defaultLeverageSource,
+    handleRefreshAll,
+    isRefreshingAnyData,
+  ]);
 
   const mainIcon = (
     <div className="flex -space-x-2">
@@ -276,13 +305,15 @@ export function LeverageModal({
               options={modeOptions}
               onValueChange={(nextMode) => setMode(nextMode as 'leverage' | 'deleverage')}
             />
-            <Badge
-              variant="default"
-              className="inline-flex items-center gap-1"
-            >
-              <RiSparklingFill className="h-3 w-3 text-yellow-400" />
-              New
-            </Badge>
+            {!isPositionUpdateIntent && (
+              <Badge
+                variant="default"
+                className="inline-flex items-center gap-1"
+              >
+                <RiSparklingFill className="h-3 w-3 text-yellow-400" />
+                New
+              </Badge>
+            )}
             {(route || availableRouteModes.length > 0) && (
               <RouteModeBadge
                 value={displayedRouteMode}
@@ -292,19 +323,7 @@ export function LeverageModal({
             )}
           </div>
         }
-        description={
-          effectiveMode === 'leverage'
-            ? isErc4626Route
-              ? `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-              : isSwapRoute
-                ? `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-                : `Leverage your ${market.collateralAsset.symbol} exposure by looping.`
-            : isErc4626Route
-              ? `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`
-              : isSwapRoute
-                ? `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`
-                : `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`
-        }
+        description={description}
       />
       <ModalBody>
         {routeContent ? (

--- a/src/modals/leverage/leverage-modal.tsx
+++ b/src/modals/leverage/leverage-modal.tsx
@@ -188,20 +188,24 @@ export function LeverageModal({
           label: effectiveMode === 'leverage' ? leverageModeLabel : `Deleverage ${market.collateralAsset.symbol}`,
         },
       ];
-  const description =
-    effectiveMode === 'leverage'
-      ? isPositionUpdateIntent
-        ? 'Increase leverage on this position without adding wallet capital.'
-        : isErc4626Route
-          ? `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-          : isSwapRoute
-            ? `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-            : `Leverage your ${market.collateralAsset.symbol} exposure by looping.`
-      : isErc4626Route
-        ? `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`
-        : isSwapRoute
-          ? `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`
-          : `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`;
+  let description: string;
+  if (effectiveMode === 'leverage') {
+    if (isPositionUpdateIntent) {
+      description = 'Increase leverage on this position without adding wallet capital.';
+    } else if (isErc4626Route) {
+      description = `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`;
+    } else if (isSwapRoute) {
+      description = `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`;
+    } else {
+      description = `Leverage your ${market.collateralAsset.symbol} exposure by looping.`;
+    }
+  } else if (isErc4626Route) {
+    description = `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`;
+  } else if (isSwapRoute) {
+    description = `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`;
+  } else {
+    description = `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`;
+  }
 
   const {
     data: collateralTokenBalance,

--- a/src/modals/leverage/leverage-modal.tsx
+++ b/src/modals/leverage/leverage-modal.tsx
@@ -188,24 +188,20 @@ export function LeverageModal({
           label: effectiveMode === 'leverage' ? leverageModeLabel : `Deleverage ${market.collateralAsset.symbol}`,
         },
       ];
-  let description: string;
-  if (effectiveMode === 'leverage') {
-    if (isPositionUpdateIntent) {
-      description = 'Increase leverage on this position without adding wallet capital.';
-    } else if (isErc4626Route) {
-      description = `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`;
-    } else if (isSwapRoute) {
-      description = `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`;
-    } else {
-      description = `Leverage your ${market.collateralAsset.symbol} exposure by looping.`;
-    }
-  } else if (isErc4626Route) {
-    description = `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`;
-  } else if (isSwapRoute) {
-    description = `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`;
-  } else {
-    description = `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`;
-  }
+  const description =
+    effectiveMode === 'leverage'
+      ? isPositionUpdateIntent
+        ? 'Increase leverage on this position without adding wallet capital.'
+        : isErc4626Route
+          ? `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
+          : isSwapRoute
+            ? `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
+            : `Leverage your ${market.collateralAsset.symbol} exposure by looping.`
+      : isErc4626Route
+        ? `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`
+        : isSwapRoute
+          ? `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`
+          : `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`;
 
   const {
     data: collateralTokenBalance,

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -31,6 +31,7 @@ export type ModalProps = {
     market: Market;
     defaultMode?: 'leverage' | 'deleverage';
     toggleLeverageDeleverage?: boolean;
+    defaultLeverageSource?: 'wallet' | 'position';
     refetch?: () => void;
   };
 


### PR DESCRIPTION
## Summary
- add an Increase Leverage shortcut to existing borrow-position actions
- open the existing leverage modal in a Current Position / Update Position mode without showing initial-capital input
- size the added debt against the whole current position and reuse existing leverage quote/transaction hooks
- skip token approvals when the update requires no wallet capital transfer

## Validation
- git diff --check
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- pnpm build passed before the final parseUnsignedBigInt cleanup; the final retry stayed active in Next compile for about 10 minutes and was stopped, so final production-build coverage is inconclusive

Fixes #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Increase Leverage** action in the positions actions dropdown when leverage can be adjusted.
  * Enabled leveraging to open in **position-update** mode (with “Update Position” intent) and propagate sensible defaults through the modal.
* **Bug Fixes**
  * Reduced unnecessary token approval steps by skipping approval when no initial transfer is needed.
  * Improved leverage quoting, previews, and transaction step/validation logic for position-target vs wallet-based flows.
* **UI Updates**
  * Updated modal labels, headers/badges, preview wording (e.g., “Additional Debt”), and disabled/submit behavior; tightened amount number formatting in the table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->