### PR TITLE
Add existing-position leverage shortcut

### DIFF
--- a/src/features/positions/components/borrow-position-actions-dropdown.tsx
+++ b/src/features/positions/components/borrow-position-actions-dropdown.tsx
@@ -3,23 +3,27 @@
 import type React from 'react';
 import { IoEllipsisVertical } from 'react-icons/io5';
 import { BsArrowDownLeftCircle, BsArrowUpRightCircle } from 'react-icons/bs';
-import { TbTrendingDown } from 'react-icons/tb';
+import { TbTrendingDown, TbTrendingUp } from 'react-icons/tb';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
 type BorrowPositionActionsDropdownProps = {
   isOwner: boolean;
   isActiveDebt: boolean;
+  canIncreaseLeverage: boolean;
   onBorrowMoreClick: () => void;
   onRepayClick: () => void;
+  onIncreaseLeverageClick: () => void;
   onDeleverageClick: () => void;
 };
 
 export function BorrowPositionActionsDropdown({
   isOwner,
   isActiveDebt,
+  canIncreaseLeverage,
   onBorrowMoreClick,
   onRepayClick,
+  onIncreaseLeverageClick,
   onDeleverageClick,
 }: BorrowPositionActionsDropdownProps) {
   const handleClick = (event: React.MouseEvent) => {
@@ -64,6 +68,16 @@ export function BorrowPositionActionsDropdown({
           >
             {isActiveDebt ? 'Repay' : 'Manage'}
           </DropdownMenuItem>
+          {canIncreaseLeverage && (
+            <DropdownMenuItem
+              onClick={onIncreaseLeverageClick}
+              startContent={<TbTrendingUp className="h-4 w-4" />}
+              disabled={!isOwner}
+              className={isOwner ? '' : 'cursor-not-allowed opacity-50'}
+            >
+              Increase Leverage
+            </DropdownMenuItem>
+          )}
           {isActiveDebt && (
             <DropdownMenuItem
               onClick={onDeleverageClick}

--- a/src/features/positions/components/borrowed-morpho-blue-table.tsx
+++ b/src/features/positions/components/borrowed-morpho-blue-table.tsx
@@ -175,10 +175,10 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                     </TableCell>
 
                     <TableCell data-label="Loan">
-                      <div className="flex items-center justify-center gap-2">
+                      <div className="flex items-center justify-center gap-2 whitespace-nowrap">
                         {row.isActiveDebt ? (
                           <>
-                            <span className="font-medium">{formatReadableTokenAmount(row.borrowAmount)}</span>
+                            <span className="font-medium tabular-nums">{formatReadableTokenAmount(row.borrowAmount)}</span>
                             <span>{row.market.loanAsset.symbol}</span>
                             <TokenIcon
                               address={row.market.loanAsset.address}
@@ -208,10 +208,10 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                     </TableCell>
 
                     <TableCell data-label="Collateral">
-                      <div className="flex items-center justify-center gap-2">
+                      <div className="flex items-center justify-center gap-2 whitespace-nowrap">
                         {row.collateralAmount > 0 ? (
                           <>
-                            <span className="font-medium">{formatReadableTokenAmount(row.collateralAmount)}</span>
+                            <span className="font-medium tabular-nums">{formatReadableTokenAmount(row.collateralAmount)}</span>
                             <span>{getTruncatedAssetName(row.market.collateralAsset.symbol)}</span>
                             <TokenIcon
                               address={row.market.collateralAsset.address}
@@ -263,6 +263,7 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                         <BorrowPositionActionsDropdown
                           isOwner={isOwner}
                           isActiveDebt={row.isActiveDebt}
+                          canIncreaseLeverage={row.collateralAmount > 0}
                           onBorrowMoreClick={() =>
                             open('borrow', {
                               market: row.market,
@@ -283,9 +284,22 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                               },
                             })
                           }
+                          onIncreaseLeverageClick={() =>
+                            open('leverage', {
+                              market: row.market,
+                              position: row.position,
+                              defaultMode: 'leverage',
+                              defaultLeverageSource: 'position',
+                              toggleLeverageDeleverage: false,
+                              refetch: () => {
+                                void onRefetch();
+                              },
+                            })
+                          }
                           onDeleverageClick={() =>
                             open('leverage', {
                               market: row.market,
+                              position: row.position,
                               defaultMode: 'deleverage',
                               toggleLeverageDeleverage: false,
                               refetch: () => {

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -562,14 +562,35 @@ export function useLeverageQuote({
     erc4626MintError,
   ]);
 
-  const isLoading =
-    !!route &&
-    (route.kind === 'swap'
-      ? (isPositionDebtInput && (swapPositionDebtQuoteQuery.isLoading || swapPositionDebtQuoteQuery.isFetching)) ||
-        (!isPositionDebtInput &&
-          ((isLoanAssetInput && (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
-            (!isLoanAssetInput && (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))))
-      : isLoadingErc4626Deposit || isLoadingErc4626Mint);
+  const isLoading = useMemo(() => {
+    if (!route) return false;
+
+    if (route.kind !== 'swap') {
+      return isLoadingErc4626Deposit || isLoadingErc4626Mint;
+    }
+
+    if (isPositionDebtInput) {
+      return swapPositionDebtQuoteQuery.isLoading || swapPositionDebtQuoteQuery.isFetching;
+    }
+
+    if (isLoanAssetInput) {
+      return swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching;
+    }
+
+    return swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching;
+  }, [
+    route,
+    isLoadingErc4626Deposit,
+    isLoadingErc4626Mint,
+    isPositionDebtInput,
+    isLoanAssetInput,
+    swapPositionDebtQuoteQuery.isLoading,
+    swapPositionDebtQuoteQuery.isFetching,
+    swapLoanInputCombinedQuoteQuery.isLoading,
+    swapLoanInputCombinedQuoteQuery.isFetching,
+    swapCollateralInputQuoteQuery.isLoading,
+    swapCollateralInputQuoteQuery.isFetching,
+  ]);
 
   return {
     initialCapitalCollateralTokenAmount,

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -20,6 +20,11 @@ type UseLeverageQuoteParams = {
    * - `collateral`: market collateral token amount
    */
   initialCapitalInputAmount: bigint;
+  /**
+   * Exact extra debt to loop from an existing position. When set, the quote has no wallet-funded
+   * initial leg: the flash-loaned debt is converted into collateral and supplied back to the same market.
+   */
+  positionDebtInputAmount?: bigint;
   inputMode: 'collateral' | 'loan';
   slippageBps: number;
   multiplierBps: bigint;
@@ -248,6 +253,7 @@ export function useLeverageQuote({
   chainId,
   route,
   initialCapitalInputAmount,
+  positionDebtInputAmount,
   inputMode,
   slippageBps,
   multiplierBps,
@@ -257,35 +263,46 @@ export function useLeverageQuote({
   collateralTokenDecimals,
   userAddress,
 }: UseLeverageQuoteParams): LeverageQuote {
+  const isPositionDebtInput = positionDebtInputAmount !== undefined;
+  const safePositionDebtInputAmount = positionDebtInputAmount ?? 0n;
   const isLoanAssetInput = inputMode === 'loan';
-  const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput;
+  const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput && !isPositionDebtInput;
   const swapExecutionAddress = route?.kind === 'swap' ? route.paraswapAdapterAddress : null;
+  const erc4626PreviewDepositAmount = isPositionDebtInput ? safePositionDebtInputAmount : isLoanAssetInput ? initialCapitalInputAmount : 0n;
 
   const {
-    data: previewDepositCollateralSharesFromUserLoanAssets,
+    data: previewDepositCollateralSharesFromLoanAssets,
     isLoading: isLoadingErc4626Deposit,
     error: erc4626DepositError,
   } = useReadContract({
     address: route?.kind === 'erc4626' ? route.collateralVault : undefined,
     abi: erc4626Abi,
     functionName: 'previewDeposit',
-    // `previewDeposit(user loan assets)` -> ERC4626 collateral shares minted from that exact asset input.
-    args: [initialCapitalInputAmount],
+    // `previewDeposit(loan assets)` -> ERC4626 collateral shares minted from that exact asset input.
+    args: [erc4626PreviewDepositAmount],
     chainId,
     query: {
-      enabled: route?.kind === 'erc4626' && isLoanAssetInput && initialCapitalInputAmount > 0n,
+      enabled: route?.kind === 'erc4626' && erc4626PreviewDepositAmount > 0n,
     },
   });
 
   const quotedInitialCapitalCollateralTokenAmount = useMemo(() => {
+    if (isPositionDebtInput) return 0n;
     if (!route) return 0n;
     if (isSwapLoanAssetInput) return 0n;
     if (!isLoanAssetInput) return initialCapitalInputAmount;
     // `previewDeposit(initialCapitalInputAmount)` returns the ERC4626 collateral-share amount minted by
     // depositing the user's exact loan-token asset input into the vault.
-    if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromUserLoanAssets as bigint | undefined) ?? 0n;
+    if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n;
     return 0n;
-  }, [route, isSwapLoanAssetInput, isLoanAssetInput, initialCapitalInputAmount, previewDepositCollateralSharesFromUserLoanAssets]);
+  }, [
+    isPositionDebtInput,
+    route,
+    isSwapLoanAssetInput,
+    isLoanAssetInput,
+    initialCapitalInputAmount,
+    previewDepositCollateralSharesFromLoanAssets,
+  ]);
 
   const initialCapitalCollateralTokenAmount = useMemo(() => {
     if (route?.kind !== 'erc4626' || !isLoanAssetInput) return quotedInitialCapitalCollateralTokenAmount;
@@ -293,8 +310,11 @@ export function useLeverageQuote({
   }, [route, isLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, slippageBps]);
 
   const targetFlashCollateralTokenAmount = useMemo(
-    () => (isSwapLoanAssetInput ? 0n : computeFlashCollateralAmount(quotedInitialCapitalCollateralTokenAmount, multiplierBps)),
-    [isSwapLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, multiplierBps],
+    () =>
+      isPositionDebtInput || isSwapLoanAssetInput
+        ? 0n
+        : computeFlashCollateralAmount(quotedInitialCapitalCollateralTokenAmount, multiplierBps),
+    [isPositionDebtInput, isSwapLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, multiplierBps],
   );
 
   const {
@@ -393,8 +413,51 @@ export function useLeverageQuote({
     },
   });
 
+  const swapPositionDebtQuoteQuery = useQuery({
+    queryKey: [
+      'leverage-swap-position-debt-quote',
+      chainId,
+      route?.kind === 'swap' ? route.paraswapAdapterAddress : null,
+      route?.kind === 'swap' ? route.generalAdapterAddress : null,
+      loanTokenAddress,
+      loanTokenDecimals,
+      collateralTokenAddress,
+      collateralTokenDecimals,
+      swapExecutionAddress,
+      safePositionDebtInputAmount.toString(),
+      slippageBps,
+      userAddress ?? null,
+    ],
+    enabled: route?.kind === 'swap' && isPositionDebtInput && safePositionDebtInputAmount > 0n && !!userAddress,
+    queryFn: async () => {
+      const sellRoute = await fetchVeloraPriceRoute({
+        srcToken: loanTokenAddress,
+        srcDecimals: loanTokenDecimals,
+        destToken: collateralTokenAddress,
+        destDecimals: collateralTokenDecimals,
+        amount: safePositionDebtInputAmount,
+        network: chainId,
+        userAddress: swapExecutionAddress as `0x${string}`,
+        side: 'SELL',
+      });
+
+      const collateralTokenAmount = withSlippageFloor(BigInt(sellRoute.destAmount), slippageBps);
+
+      return {
+        flashLoanAssetAmount: safePositionDebtInputAmount,
+        flashLegCollateralTokenAmount: collateralTokenAmount,
+        totalCollateralTokenAmountAdded: collateralTokenAmount,
+        priceRoute: sellRoute,
+      };
+    },
+  });
+
   const flashLegCollateralTokenAmount = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionDebtInput) {
+      if (route.kind === 'swap') return swapPositionDebtQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
+      return withSlippageFloor((previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n, slippageBps);
+    }
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
@@ -402,6 +465,9 @@ export function useLeverageQuote({
     return withSlippageFloor(targetFlashCollateralTokenAmount, slippageBps);
   }, [
     route,
+    isPositionDebtInput,
+    swapPositionDebtQuoteQuery.data?.flashLegCollateralTokenAmount,
+    previewDepositCollateralSharesFromLoanAssets,
     isLoanAssetInput,
     targetFlashCollateralTokenAmount,
     slippageBps,
@@ -411,6 +477,10 @@ export function useLeverageQuote({
 
   const flashLoanAssetAmount = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionDebtInput) {
+      if (route.kind === 'swap') return swapPositionDebtQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
+      return safePositionDebtInputAmount;
+    }
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
@@ -420,6 +490,9 @@ export function useLeverageQuote({
     return previewMintableLoanAssets ?? 0n;
   }, [
     route,
+    isPositionDebtInput,
+    safePositionDebtInputAmount,
+    swapPositionDebtQuoteQuery.data?.flashLoanAssetAmount,
     isLoanAssetInput,
     swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount,
     swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount,
@@ -428,6 +501,7 @@ export function useLeverageQuote({
 
   const totalCollateralTokenAmountAdded = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionDebtInput) return flashLegCollateralTokenAmount;
     if (route.kind === 'swap') {
       if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.totalCollateralTokenAmountAdded ?? 0n;
       return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
@@ -435,6 +509,7 @@ export function useLeverageQuote({
     return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
   }, [
     route,
+    isPositionDebtInput,
     isLoanAssetInput,
     initialCapitalCollateralTokenAmount,
     flashLegCollateralTokenAmount,
@@ -443,15 +518,29 @@ export function useLeverageQuote({
 
   const swapPriceRoute = useMemo(() => {
     if (route?.kind !== 'swap') return null;
+    if (isPositionDebtInput) return swapPositionDebtQuoteQuery.data?.priceRoute ?? null;
     if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.priceRoute ?? null;
     return swapCollateralInputQuoteQuery.data?.priceRoute ?? null;
-  }, [route, isLoanAssetInput, swapLoanInputCombinedQuoteQuery.data?.priceRoute, swapCollateralInputQuoteQuery.data?.priceRoute]);
+  }, [
+    route,
+    isPositionDebtInput,
+    swapPositionDebtQuoteQuery.data?.priceRoute,
+    isLoanAssetInput,
+    swapLoanInputCombinedQuoteQuery.data?.priceRoute,
+    swapCollateralInputQuoteQuery.data?.priceRoute,
+  ]);
 
   const error = useMemo(() => {
     if (!route) return null;
     if (route.kind === 'swap') {
-      if (!userAddress && initialCapitalInputAmount > 0n) return 'Connect wallet to fetch swap-backed leverage route.';
-      const routeError = isLoanAssetInput ? swapLoanInputCombinedQuoteQuery.error : swapCollateralInputQuoteQuery.error;
+      if (!userAddress && (initialCapitalInputAmount > 0n || safePositionDebtInputAmount > 0n)) {
+        return 'Connect wallet to fetch swap-backed leverage route.';
+      }
+      const routeError = isPositionDebtInput
+        ? swapPositionDebtQuoteQuery.error
+        : isLoanAssetInput
+          ? swapLoanInputCombinedQuoteQuery.error
+          : swapCollateralInputQuoteQuery.error;
       if (!routeError) return null;
       return toUserFacingVeloraQuoteError({ error: routeError, action: 'leverage' });
     }
@@ -463,7 +552,10 @@ export function useLeverageQuote({
     swapExecutionAddress,
     userAddress,
     initialCapitalInputAmount,
+    safePositionDebtInputAmount,
+    isPositionDebtInput,
     isLoanAssetInput,
+    swapPositionDebtQuoteQuery.error,
     swapLoanInputCombinedQuoteQuery.error,
     swapCollateralInputQuoteQuery.error,
     erc4626DepositError,
@@ -473,8 +565,10 @@ export function useLeverageQuote({
   const isLoading =
     !!route &&
     (route.kind === 'swap'
-      ? (isLoanAssetInput && (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
-        (!isLoanAssetInput && (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))
+      ? (isPositionDebtInput && (swapPositionDebtQuoteQuery.isLoading || swapPositionDebtQuoteQuery.isFetching)) ||
+        (!isPositionDebtInput &&
+          ((isLoanAssetInput && (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
+            (!isLoanAssetInput && (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))))
       : isLoadingErc4626Deposit || isLoadingErc4626Mint);
 
   return {

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -18,6 +18,7 @@ type UseLeverageQuoteParams = {
    * Exact user-entered starting capital, denominated by `inputMode`.
    * - `loan`: market loan asset amount
    * - `collateral`: market collateral token amount
+   * Ignored when `positionDebtInputAmount` is set.
    */
   initialCapitalInputAmount: bigint;
   /**
@@ -264,11 +265,16 @@ export function useLeverageQuote({
   userAddress,
 }: UseLeverageQuoteParams): LeverageQuote {
   const isPositionDebtInput = positionDebtInputAmount !== undefined;
+  const safeInitialCapitalInputAmount = isPositionDebtInput ? 0n : initialCapitalInputAmount;
   const safePositionDebtInputAmount = positionDebtInputAmount ?? 0n;
   const isLoanAssetInput = inputMode === 'loan';
   const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput && !isPositionDebtInput;
   const swapExecutionAddress = route?.kind === 'swap' ? route.paraswapAdapterAddress : null;
-  const erc4626PreviewDepositAmount = isPositionDebtInput ? safePositionDebtInputAmount : isLoanAssetInput ? initialCapitalInputAmount : 0n;
+  const erc4626PreviewDepositAmount = isPositionDebtInput
+    ? safePositionDebtInputAmount
+    : isLoanAssetInput
+      ? safeInitialCapitalInputAmount
+      : 0n;
 
   const {
     data: previewDepositCollateralSharesFromLoanAssets,
@@ -290,7 +296,7 @@ export function useLeverageQuote({
     if (isPositionDebtInput) return 0n;
     if (!route) return 0n;
     if (isSwapLoanAssetInput) return 0n;
-    if (!isLoanAssetInput) return initialCapitalInputAmount;
+    if (!isLoanAssetInput) return safeInitialCapitalInputAmount;
     // `previewDeposit(initialCapitalInputAmount)` returns the ERC4626 collateral-share amount minted by
     // depositing the user's exact loan-token asset input into the vault.
     if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n;
@@ -300,7 +306,7 @@ export function useLeverageQuote({
     route,
     isSwapLoanAssetInput,
     isLoanAssetInput,
-    initialCapitalInputAmount,
+    safeInitialCapitalInputAmount,
     previewDepositCollateralSharesFromLoanAssets,
   ]);
 
@@ -373,14 +379,14 @@ export function useLeverageQuote({
       collateralTokenAddress,
       collateralTokenDecimals,
       swapExecutionAddress,
-      initialCapitalInputAmount.toString(),
+      safeInitialCapitalInputAmount.toString(),
       multiplierBps.toString(),
       slippageBps,
       userAddress ?? null,
     ],
-    enabled: route?.kind === 'swap' && isLoanAssetInput && initialCapitalInputAmount > 0n && !!userAddress,
+    enabled: route?.kind === 'swap' && isLoanAssetInput && safeInitialCapitalInputAmount > 0n && !!userAddress,
     queryFn: async () => {
-      const flashLoanAssetAmount = computeLeveragedExtraAmount(initialCapitalInputAmount, multiplierBps);
+      const flashLoanAssetAmount = computeLeveragedExtraAmount(safeInitialCapitalInputAmount, multiplierBps);
       if (flashLoanAssetAmount <= 0n) {
         return {
           flashLoanAssetAmount: 0n,
@@ -390,7 +396,7 @@ export function useLeverageQuote({
         };
       }
 
-      const totalLoanSellAmount = initialCapitalInputAmount + flashLoanAssetAmount;
+      const totalLoanSellAmount = safeInitialCapitalInputAmount + flashLoanAssetAmount;
       const sellRoute = await fetchVeloraPriceRoute({
         srcToken: loanTokenAddress,
         srcDecimals: loanTokenDecimals,
@@ -533,7 +539,7 @@ export function useLeverageQuote({
   const error = useMemo(() => {
     if (!route) return null;
     if (route.kind === 'swap') {
-      if (!userAddress && (initialCapitalInputAmount > 0n || safePositionDebtInputAmount > 0n)) {
+      if (!userAddress && (safeInitialCapitalInputAmount > 0n || safePositionDebtInputAmount > 0n)) {
         return 'Connect wallet to fetch swap-backed leverage route.';
       }
       const routeError = isPositionDebtInput
@@ -551,7 +557,7 @@ export function useLeverageQuote({
     route,
     swapExecutionAddress,
     userAddress,
-    initialCapitalInputAmount,
+    safeInitialCapitalInputAmount,
     safePositionDebtInputAmount,
     isPositionDebtInput,
     isLoanAssetInput,

--- a/src/hooks/useLeverageTransaction.ts
+++ b/src/hooks/useLeverageTransaction.ts
@@ -80,7 +80,6 @@ export function useLeverageTransaction({
   const { address: account, chainId } = useConnection();
   const toast = useStyledToast();
   const isSwapRoute = route?.kind === 'swap';
-  const usePermit2ForRoute = usePermit2Setting;
 
   const bundlerAddress = useMemo<Address>(() => {
     if (route?.kind === 'swap') {
@@ -105,6 +104,8 @@ export function useLeverageTransaction({
   const initialCapitalInputTokenSymbol = initialCapitalUsesLoanAsset ? market.loanAsset.symbol : market.collateralAsset.symbol;
   const initialCapitalInputTokenDecimals = initialCapitalUsesLoanAsset ? market.loanAsset.decimals : market.collateralAsset.decimals;
   const initialCapitalTransferAmount = initialCapitalUsesLoanAsset ? initialCapitalInputAmount : initialCapitalCollateralTokenAmount;
+  const requiresInitialCapitalTransfer = initialCapitalTransferAmount > 0n;
+  const usePermit2ForRoute = usePermit2Setting && requiresInitialCapitalTransfer;
   const approvalSpender = route?.kind === 'swap' ? route.generalAdapterAddress : bundlerAddress;
 
   const {
@@ -145,7 +146,9 @@ export function useLeverageTransaction({
 
   const { isConfirming: leveragePending, sendTransactionAsync } = useTransactionWithToast({
     toastId: 'leverage',
-    pendingText: `Leveraging ${formatBalance(initialCapitalInputAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`,
+    pendingText: requiresInitialCapitalTransfer
+      ? `Leveraging ${formatBalance(initialCapitalInputAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`
+      : `Increasing leverage on ${market.collateralAsset.symbol}`,
     successText: 'Leverage Executed',
     errorText: 'Failed to execute leverage',
     chainId,
@@ -160,15 +163,33 @@ export function useLeverageTransaction({
     () => ({
       title: 'Leverage',
       description: `${market.collateralAsset.symbol} leveraged using ${market.loanAsset.symbol} debt`,
-      tokenSymbol: initialCapitalInputTokenSymbol,
-      amount: initialCapitalInputAmount,
+      tokenSymbol: requiresInitialCapitalTransfer ? initialCapitalInputTokenSymbol : market.loanAsset.symbol,
+      amount: requiresInitialCapitalTransfer ? initialCapitalInputAmount : flashLoanAssetAmount,
       marketId: market.uniqueKey,
     }),
-    [market.collateralAsset.symbol, market.loanAsset.symbol, initialCapitalInputTokenSymbol, initialCapitalInputAmount, market.uniqueKey],
+    [
+      market.collateralAsset.symbol,
+      market.loanAsset.symbol,
+      initialCapitalInputTokenSymbol,
+      requiresInitialCapitalTransfer,
+      initialCapitalInputAmount,
+      flashLoanAssetAmount,
+      market.uniqueKey,
+    ],
   );
 
   const getStepsForFlow = useCallback(
     (isPermit2: boolean, isSwap: boolean) => {
+      const approvalStep = requiresInitialCapitalTransfer
+        ? [
+            {
+              id: 'approve_token' as const,
+              title: `Approve ${initialCapitalInputTokenSymbol}`,
+              description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
+            },
+          ]
+        : [];
+
       if (isSwap && isPermit2) {
         return [
           {
@@ -201,11 +222,7 @@ export function useLeverageTransaction({
             title: 'Authorize Morpho Adapter',
             description: 'Submit one transaction authorizing Morpho adapter actions on your position.',
           },
-          {
-            id: 'approve_token',
-            title: `Approve ${initialCapitalInputTokenSymbol}`,
-            description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
-          },
+          ...approvalStep,
           {
             id: 'execute',
             title: 'Confirm Leverage',
@@ -245,11 +262,7 @@ export function useLeverageTransaction({
           title: 'Authorize Morpho Bundler',
           description: 'Submit one transaction authorizing bundler actions on your Morpho position.',
         },
-        {
-          id: 'approve_token',
-          title: `Approve ${initialCapitalInputTokenSymbol}`,
-          description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
-        },
+        ...approvalStep,
         {
           id: 'execute',
           title: 'Confirm Leverage',
@@ -257,7 +270,7 @@ export function useLeverageTransaction({
         },
       ];
     },
-    [initialCapitalInputTokenSymbol],
+    [initialCapitalInputTokenSymbol, requiresInitialCapitalTransfer],
   );
 
   const getLeverageExecutionPreflight = useCallback((): LeverageExecutionPreflight | null => {
@@ -273,8 +286,10 @@ export function useLeverageTransaction({
 
     const hasCollateralOutput =
       route.kind === 'swap' && initialCapitalUsesLoanAsset ? totalCollateralTokenAmountAdded > 0n : flashLegCollateralTokenAmount > 0n;
-    if (initialCapitalInputAmount <= 0n || flashLoanAssetAmount <= 0n || !hasCollateralOutput) {
-      toast.info('Invalid leverage inputs', 'Set initial capital and multiplier above 1x before submitting.');
+    // WHY: existing-position leverage has no wallet-funded transfer. The executable invariant is the
+    // same flash-loan loop as add-capital leverage: positive debt input plus positive collateral output.
+    if (flashLoanAssetAmount <= 0n || !hasCollateralOutput) {
+      toast.info('Invalid leverage inputs', 'Set leverage inputs above zero before submitting.');
       return null;
     }
     if (collateralAssetPriceUsd == null || !Number.isFinite(collateralAssetPriceUsd) || collateralAssetPriceUsd <= 0) {
@@ -318,7 +333,6 @@ export function useLeverageTransaction({
     initialCapitalUsesLoanAsset,
     totalCollateralTokenAmountAdded,
     flashLegCollateralTokenAmount,
-    initialCapitalInputAmount,
     flashLoanAssetAmount,
     collateralAssetPriceUsd,
     market.collateralAsset.decimals,
@@ -492,7 +506,7 @@ export function useLeverageTransaction({
           : 'authorize_bundler_sig'
         : 'approve_permit2'
       : isBundlerAuthorized
-        ? isApproved
+        ? !requiresInitialCapitalTransfer || isApproved
           ? 'execute'
           : 'approve_token'
         : 'authorize_bundler_tx';
@@ -503,7 +517,7 @@ export function useLeverageTransaction({
       errorTitle: 'Error',
       logLabel: 'approveAndLeverage',
     });
-  }, [usePermit2ForRoute, permit2Authorized, isBundlerAuthorized, isApproved, runLeverageFlow]);
+  }, [usePermit2ForRoute, permit2Authorized, isBundlerAuthorized, requiresInitialCapitalTransfer, isApproved, runLeverageFlow]);
 
   const signAndLeverage = useCallback(async () => {
     if (!usePermit2ForRoute) {

--- a/src/hooks/useLeverageTransaction.ts
+++ b/src/hooks/useLeverageTransaction.ts
@@ -147,7 +147,7 @@ export function useLeverageTransaction({
   const { isConfirming: leveragePending, sendTransactionAsync } = useTransactionWithToast({
     toastId: 'leverage',
     pendingText: requiresInitialCapitalTransfer
-      ? `Leveraging ${formatBalance(initialCapitalInputAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`
+      ? `Leveraging ${formatBalance(initialCapitalTransferAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`
       : `Increasing leverage on ${market.collateralAsset.symbol}`,
     successText: 'Leverage Executed',
     errorText: 'Failed to execute leverage',
@@ -164,7 +164,7 @@ export function useLeverageTransaction({
       title: 'Leverage',
       description: `${market.collateralAsset.symbol} leveraged using ${market.loanAsset.symbol} debt`,
       tokenSymbol: requiresInitialCapitalTransfer ? initialCapitalInputTokenSymbol : market.loanAsset.symbol,
-      amount: requiresInitialCapitalTransfer ? initialCapitalInputAmount : flashLoanAssetAmount,
+      amount: requiresInitialCapitalTransfer ? initialCapitalTransferAmount : flashLoanAssetAmount,
       marketId: market.uniqueKey,
     }),
     [
@@ -172,7 +172,7 @@ export function useLeverageTransaction({
       market.loanAsset.symbol,
       initialCapitalInputTokenSymbol,
       requiresInitialCapitalTransfer,
-      initialCapitalInputAmount,
+      initialCapitalTransferAmount,
       flashLoanAssetAmount,
       market.uniqueKey,
     ],

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -4,14 +4,13 @@ import { useConnection, useReadContract } from 'wagmi';
 import { BorrowPositionRiskCard } from '@/modals/borrow/components/borrow-position-risk-card';
 import { PreviewSectionHeader } from '@/modals/borrow/components/preview-section-header';
 import { LTV_WAD, computeLtv } from '@/modals/borrow/components/helpers';
+import { PositionLeverageSummary } from './position-leverage-summary';
 import { HelpTooltipIcon } from '@/components/shared/help-tooltip-icon';
 import { RateFormatted } from '@/components/shared/rate-formatted';
 import { TooltipContent as SharedTooltipContent } from '@/components/shared/tooltip-content';
-import Input from '@/components/Input/Input';
 import { LTVWarning } from '@/components/shared/ltv-warning';
 import { TokenIcon } from '@/components/shared/token-icon';
 import { ExecuteTransactionButton } from '@/components/ui/ExecuteTransactionButton';
-import { IconSwitch } from '@/components/ui/icon-switch';
 import { Tooltip } from '@/components/ui/tooltip';
 import {
   clampTargetLtvBps,
@@ -21,7 +20,6 @@ import {
   computeLeverageProjectedPosition,
   formatTokenAmountPreview,
   ltvWadToBps,
-  multiplierBpsFromTargetLtv,
   parseUnsignedBigInt,
   toScaledRatio,
   targetLtvBpsFromMultiplier,
@@ -42,6 +40,7 @@ import { previewMarketState } from '@/utils/morpho';
 import { convertAprToApy, toApyFromDisplayRate, toDisplayRateFromApy } from '@/utils/rateMath';
 import type { LeverageRoute } from '@/hooks/leverage/types';
 import type { Market, MarketPosition } from '@/utils/types';
+import { PositionDebtLoopInput, TargetLeverageInput, WalletCapitalInput } from './leverage-input-panels';
 
 type AddCollateralAndLeverageProps = {
   market: Market;
@@ -49,12 +48,12 @@ type AddCollateralAndLeverageProps = {
   currentPosition: MarketPosition | null;
   collateralTokenBalance: bigint | undefined;
   oraclePrice: bigint;
+  defaultLeverageSource?: 'wallet' | 'position';
   onSuccess?: () => void;
   isRefreshing?: boolean;
 };
 
 const LEVERAGE_SAFE_LTV_BUFFER_BPS = 100n; // keep a 1% buffer below liquidation LTV
-const TARGET_INPUT_DEBOUNCE_MS = 300;
 const INLINE_VALUE_TOOLTIP_CLASS_NAME = 'px-4 py-3 text-xs';
 
 export function AddCollateralAndLeverage({
@@ -63,6 +62,7 @@ export function AddCollateralAndLeverage({
   currentPosition,
   collateralTokenBalance,
   oraclePrice,
+  defaultLeverageSource = 'wallet',
   onSuccess,
   isRefreshing = false,
 }: AddCollateralAndLeverageProps): JSX.Element {
@@ -86,6 +86,8 @@ export function AddCollateralAndLeverage({
 
   const [initialCapitalInputAmount, setInitialCapitalInputAmount] = useState<bigint>(0n);
   const [initialCapitalInputError, setInitialCapitalInputError] = useState<string | null>(null);
+  const [positionDebtInputAmount, setPositionDebtInputAmount] = useState<bigint>(0n);
+  const [positionDebtInputError, setPositionDebtInputError] = useState<string | null>(null);
   const [useLoanAssetInput, setUseLoanAssetInput] = useState(false);
   const [targetMultiplierBps, setTargetMultiplierBps] = useState<bigint>(defaultMultiplierBps);
   const [targetLtvIntentBps, setTargetLtvIntentBps] = useState<bigint>(defaultTargetLtvIntentBps);
@@ -100,6 +102,8 @@ export function AddCollateralAndLeverage({
   const isErc4626Route = route?.kind === 'erc4626';
   const isSwapRoute = route?.kind === 'swap';
   const canUseLoanAssetInput = isErc4626Route || isSwapRoute;
+  const useExistingPositionSource = defaultLeverageSource === 'position';
+  const useLoanAssetInputForTransaction = !useExistingPositionSource && useLoanAssetInput;
 
   const { data: loanTokenBalance, refetch: refetchLoanTokenBalance } = useReadContract({
     address: market.loanAsset.address as `0x${string}`,
@@ -108,7 +112,7 @@ export function AddCollateralAndLeverage({
     abi: erc20Abi,
     chainId: market.morphoBlue.chain.id,
     query: {
-      enabled: !!account && useLoanAssetInput,
+      enabled: !!account && useLoanAssetInputForTransaction,
     },
   });
 
@@ -122,6 +126,13 @@ export function AddCollateralAndLeverage({
     if (canUseLoanAssetInput) return;
     setUseLoanAssetInput(false);
   }, [canUseLoanAssetInput]);
+
+  useEffect(() => {
+    if (!useExistingPositionSource) return;
+    setUseLoanAssetInput(false);
+    setInitialCapitalInputAmount(0n);
+    setInitialCapitalInputError(null);
+  }, [useExistingPositionSource]);
 
   useEffect(() => {
     const clampedMultiplier = clampMultiplierBps(targetMultiplierBps, maxMultiplierBps);
@@ -140,7 +151,8 @@ export function AddCollateralAndLeverage({
     chainId: market.morphoBlue.chain.id,
     route,
     initialCapitalInputAmount,
-    inputMode: useLoanAssetInput ? 'loan' : 'collateral',
+    positionDebtInputAmount: useExistingPositionSource ? positionDebtInputAmount : undefined,
+    inputMode: useLoanAssetInputForTransaction ? 'loan' : 'collateral',
     multiplierBps,
     loanTokenAddress: market.loanAsset.address,
     loanTokenDecimals: market.loanAsset.decimals,
@@ -150,8 +162,8 @@ export function AddCollateralAndLeverage({
     slippageBps: swapSlippageBps,
   });
 
-  const currentCollateralAssets = BigInt(currentPosition?.state.collateral ?? 0);
-  const currentBorrowAssets = BigInt(currentPosition?.state.borrowAssets ?? 0);
+  const currentCollateralAssets = parseUnsignedBigInt(currentPosition?.state.collateral) ?? 0n;
+  const currentBorrowAssets = parseUnsignedBigInt(currentPosition?.state.borrowAssets) ?? 0n;
   const hasQuoteChanges = quote.totalCollateralTokenAmountAdded > 0n && quote.flashLoanAssetAmount > 0n;
   const collateralAssetPriceUsd = useMemo(() => {
     const totalCollateralAssets = BigInt(market.state.collateralAssets);
@@ -263,12 +275,14 @@ export function AddCollateralAndLeverage({
     // WHY: after a confirmed leverage tx, reset drafts so the panel reflects refreshed onchain position state.
     setInitialCapitalInputAmount(0n);
     setInitialCapitalInputError(null);
+    setPositionDebtInputAmount(0n);
+    setPositionDebtInputError(null);
     syncInputFieldsFromMultiplier(defaultMultiplierBps);
-    if (useLoanAssetInput) {
+    if (useLoanAssetInputForTransaction) {
       void refetchLoanTokenBalance();
     }
     if (onSuccess) onSuccess();
-  }, [defaultMultiplierBps, onSuccess, refetchLoanTokenBalance, syncInputFieldsFromMultiplier, useLoanAssetInput]);
+  }, [defaultMultiplierBps, onSuccess, refetchLoanTokenBalance, syncInputFieldsFromMultiplier, useLoanAssetInputForTransaction]);
 
   const {
     transaction,
@@ -288,7 +302,7 @@ export function AddCollateralAndLeverage({
     totalCollateralTokenAmountAdded: quote.totalCollateralTokenAmountAdded,
     collateralAssetPriceUsd,
     swapPriceRoute: quote.swapPriceRoute,
-    useLoanAssetInput,
+    useLoanAssetInput: useLoanAssetInputForTransaction,
     slippageBps: swapSlippageBps,
     onSuccess: handleTransactionSuccess,
   });
@@ -306,7 +320,7 @@ export function AddCollateralAndLeverage({
 
   const handleLeverage = useCallback(() => {
     if (!isLeverageFeeReady) return;
-    const usePermit2Flow = usePermit2Setting;
+    const usePermit2Flow = usePermit2Setting && !useExistingPositionSource;
 
     if (usePermit2Flow && permit2Authorized) {
       void signAndLeverage();
@@ -314,14 +328,14 @@ export function AddCollateralAndLeverage({
     }
 
     void approveAndLeverage();
-  }, [isLeverageFeeReady, usePermit2Setting, permit2Authorized, signAndLeverage, approveAndLeverage]);
+  }, [isLeverageFeeReady, usePermit2Setting, useExistingPositionSource, permit2Authorized, signAndLeverage, approveAndLeverage]);
 
   const projectedOverLimit = projectedLTV >= lltv;
   const insufficientLiquidity = quote.flashLoanAssetAmount > marketLiquidity;
-  const inputAssetSymbol = useLoanAssetInput ? market.loanAsset.symbol : market.collateralAsset.symbol;
-  const inputAssetDecimals = useLoanAssetInput ? market.loanAsset.decimals : market.collateralAsset.decimals;
-  const inputAssetBalance = useLoanAssetInput ? (loanTokenBalance as bigint | undefined) : collateralTokenBalance;
-  const inputTokenIconAddress = useLoanAssetInput ? market.loanAsset.address : market.collateralAsset.address;
+  const inputAssetSymbol = useLoanAssetInputForTransaction ? market.loanAsset.symbol : market.collateralAsset.symbol;
+  const inputAssetDecimals = useLoanAssetInputForTransaction ? market.loanAsset.decimals : market.collateralAsset.decimals;
+  const inputAssetBalance = useLoanAssetInputForTransaction ? (loanTokenBalance as bigint | undefined) : collateralTokenBalance;
+  const inputTokenIconAddress = useLoanAssetInputForTransaction ? market.loanAsset.address : market.collateralAsset.address;
   const flashBorrowPreview = useMemo(
     () => formatTokenAmountPreview(quote.flashLoanAssetAmount, market.loanAsset.decimals),
     [quote.flashLoanAssetAmount, market.loanAsset.decimals],
@@ -346,20 +360,28 @@ export function AddCollateralAndLeverage({
     () => formatTokenAmountPreview(quote.flashLegCollateralTokenAmount, market.collateralAsset.decimals),
     [quote.flashLegCollateralTokenAmount, market.collateralAsset.decimals],
   );
-  const collateralPreviewForDisplay = isSwapRoute && !useLoanAssetInput ? swapCollateralOutPreview : totalCollateralAddedPreview;
+  const collateralPreviewForDisplay =
+    isSwapRoute && !useLoanAssetInputForTransaction ? swapCollateralOutPreview : totalCollateralAddedPreview;
   const collateralPreviewLabel = isSwapRoute
-    ? useLoanAssetInput
+    ? useLoanAssetInputForTransaction
       ? 'Total Collateral Added (Min.)'
       : 'Collateral From Swap (Min.)'
     : isErc4626Route
       ? 'Total Collateral Added (Min.)'
       : 'Total Collateral Added';
   const hasExecutableInitialCapitalConversion = useMemo(() => {
-    if (!useLoanAssetInput) return true;
+    if (useExistingPositionSource || !useLoanAssetInputForTransaction) return true;
     if (isSwapRoute) return quote.totalCollateralTokenAmountAdded > 0n;
     if (isErc4626Route) return quote.initialCapitalCollateralTokenAmount > 0n;
     return false;
-  }, [useLoanAssetInput, isSwapRoute, isErc4626Route, quote.totalCollateralTokenAmountAdded, quote.initialCapitalCollateralTokenAmount]);
+  }, [
+    useExistingPositionSource,
+    useLoanAssetInputForTransaction,
+    isSwapRoute,
+    isErc4626Route,
+    quote.totalCollateralTokenAmountAdded,
+    quote.initialCapitalCollateralTokenAmount,
+  ]);
   const swapRatePreviewText = useMemo(() => {
     if (!isSwapRoute || !quote.swapPriceRoute) return null;
 
@@ -493,9 +515,10 @@ export function AddCollateralAndLeverage({
     vaultRateInsight.sharePriceNow,
   ]);
   const contributedCapitalAssets = useMemo(() => {
+    if (useExistingPositionSource) return null;
     if (addedCollateralAssets <= 0n) return null;
 
-    if (isSwapRoute && useLoanAssetInput) {
+    if (isSwapRoute && useLoanAssetInputForTransaction) {
       const totalLoanInput = initialCapitalInputAmount + addedBorrowAssets;
       if (totalLoanInput <= 0n) return null;
 
@@ -515,7 +538,8 @@ export function AddCollateralAndLeverage({
     isSwapRoute,
     quote.initialCapitalCollateralTokenAmount,
     quote.totalCollateralTokenAmountAdded,
-    useLoanAssetInput,
+    useExistingPositionSource,
+    useLoanAssetInputForTransaction,
   ]);
   const holdRewardsApy = useMemo(() => {
     const holdRewardAprDecimal = merklHoldIncentives.holdRewardAprDecimal;
@@ -537,6 +561,7 @@ export function AddCollateralAndLeverage({
   const hasConfiguredHoldRewards = merklHoldIncentives.incentiveLabel != null;
   const shouldShowHoldRewardsRow = hasConfiguredHoldRewards;
   const shouldShowNetRate = isErc4626Route || (showFullRewardAPY && shouldShowHoldRewardsRow);
+  const shouldShowLeveredCarryRow = !useExistingPositionSource;
   const isNetRateLoading =
     (isErc4626Route && (vaultRateInsight.isLoading || vaultRateInsight.vaultApy3d == null || projectedLtvRatio == null)) ||
     (showFullRewardAPY && shouldShowHoldRewardsRow && merklHoldIncentives.loading);
@@ -594,15 +619,25 @@ export function AddCollateralAndLeverage({
     if (previewLeveredCarryOnCapitalRate == null) return 'text-secondary';
     return previewLeveredCarryOnCapitalRate >= 0 ? 'text-emerald-500' : 'text-red-500';
   }, [previewLeveredCarryOnCapitalRate]);
+  const hasRequiredInput = useExistingPositionSource
+    ? currentCollateralAssets > 0n && positionDebtInputAmount > 0n && positionDebtInputError === null
+    : initialCapitalInputAmount > 0n && initialCapitalInputError === null;
+  const leverageButtonLabel = useExistingPositionSource ? 'Increase Leverage' : 'Leverage';
 
   return (
     <div className="bg-surface relative w-full max-w-lg rounded-lg">
       {!transaction?.isModalVisible && (
         <div className="flex flex-col">
           <PreviewSectionHeader
-            title="Leverage Preview"
+            title={useExistingPositionSource ? 'Increase Leverage' : 'Leverage Preview'}
             onRefresh={onSuccess}
             isRefreshing={isRefreshing}
+          />
+          <PositionLeverageSummary
+            currentLtv={currentLTV}
+            projectedLtv={projectedLTV}
+            lltv={lltv}
+            hasChanges={hasChanges}
           />
           <BorrowPositionRiskCard
             market={market}
@@ -619,102 +654,52 @@ export function AddCollateralAndLeverage({
           />
 
           <div className="mt-2 space-y-3">
-            <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Initial Capital</p>
-                {canUseLoanAssetInput && (
-                  <div className="flex items-center gap-2">
-                    <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
-                    <IconSwitch
-                      size="sm"
-                      selected={useLoanAssetInput}
-                      onChange={setUseLoanAssetInput}
-                      thumbIcon={null}
-                      classNames={{
-                        wrapper: 'mr-0 h-4 w-9',
-                        thumb: 'h-3 w-3',
-                      }}
-                    />
-                  </div>
-                )}
-              </div>
-              <Input
-                decimals={inputAssetDecimals}
-                max={inputAssetBalance}
-                setValue={setInitialCapitalInputAmount}
-                setError={setInitialCapitalInputError}
-                exceedMaxErrMessage="Insufficient Balance"
-                value={initialCapitalInputAmount}
-                inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
-                endAdornment={
-                  <TokenIcon
-                    address={inputTokenIconAddress}
-                    chainId={market.morphoBlue.chain.id}
-                    symbol={inputAssetSymbol}
-                    width={16}
-                    height={16}
-                  />
-                }
+            {useExistingPositionSource ? (
+              <PositionDebtLoopInput
+                market={market}
+                marketLiquidity={marketLiquidity}
+                value={positionDebtInputAmount}
+                setValue={setPositionDebtInputAmount}
+                error={positionDebtInputError}
+                setError={setPositionDebtInputError}
               />
-              <div className="mt-1 flex items-start gap-3 text-xs">
-                {initialCapitalInputError && <p className="text-red-500">{initialCapitalInputError}</p>}
-                <span className="ml-auto text-right text-secondary">
-                  Balance: {formatBalance(inputAssetBalance ?? 0n, inputAssetDecimals)} {inputAssetSymbol}
-                </span>
-              </div>
-            </div>
-
-            <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">
-                  {useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}
-                </p>
-                <div className="flex items-center gap-2">
-                  <div className="text-xs text-secondary">Use LTV</div>
-                  <IconSwitch
-                    size="sm"
-                    selected={useTargetLtvInput}
-                    onChange={handleTargetInputModeChange}
-                    thumbIcon={null}
-                    classNames={{
-                      wrapper: 'mr-0 h-4 w-9',
-                      thumb: 'h-3 w-3',
-                    }}
-                  />
-                </div>
-              </div>
-              <div className="relative min-w-0">
-                {useTargetLtvInput ? (
-                  <Input
-                    decimals={2}
-                    setValue={(nextTargetLtvBps) => {
-                      const clampedTargetLtvBps = clampTargetLtvBps(nextTargetLtvBps, maxTargetLtvBps);
-                      setTargetLtvIntentBps(clampedTargetLtvBps);
-                      setTargetMultiplierBps(multiplierBpsFromTargetLtv(clampedTargetLtvBps, maxMultiplierBps));
-                    }}
-                    value={targetLtvIntentBps}
-                    inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
-                    endAdornment={<span className="text-xs text-secondary">%</span>}
-                    debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
-                  />
-                ) : (
-                  <Input
-                    decimals={4}
-                    setValue={syncInputFieldsFromMultiplier}
-                    value={multiplierBps}
-                    inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
-                    endAdornment={<span className="text-xs text-secondary">x</span>}
-                    debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
-                  />
-                )}
-              </div>
-            </div>
+            ) : (
+              <>
+                <WalletCapitalInput
+                  market={market}
+                  canUseLoanAssetInput={canUseLoanAssetInput}
+                  useLoanAssetInput={useLoanAssetInput}
+                  setUseLoanAssetInput={setUseLoanAssetInput}
+                  inputAssetSymbol={inputAssetSymbol}
+                  inputAssetDecimals={inputAssetDecimals}
+                  inputAssetBalance={inputAssetBalance}
+                  inputTokenIconAddress={inputTokenIconAddress}
+                  value={initialCapitalInputAmount}
+                  setValue={setInitialCapitalInputAmount}
+                  error={initialCapitalInputError}
+                  setError={setInitialCapitalInputError}
+                />
+                <TargetLeverageInput
+                  useTargetLtvInput={useTargetLtvInput}
+                  onTargetInputModeChange={handleTargetInputModeChange}
+                  targetLtvIntentBps={targetLtvIntentBps}
+                  setTargetLtvIntentBps={setTargetLtvIntentBps}
+                  setTargetMultiplierBps={setTargetMultiplierBps}
+                  maxTargetLtvBps={maxTargetLtvBps}
+                  maxMultiplierBps={maxMultiplierBps}
+                  multiplierBps={multiplierBps}
+                  syncInputFieldsFromMultiplier={syncInputFieldsFromMultiplier}
+                />
+              </>
+            )}
 
             <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
               <p className="mb-2 text-[11px] uppercase tracking-[0.12em] text-secondary">Transaction Preview</p>
               <div className="space-y-1 text-xs">
                 <div className="flex items-center justify-between">
-                  <span className="text-secondary">{isSwapRoute ? 'Flash Borrow Required' : 'Flash Borrow'}</span>
+                  <span className="text-secondary">
+                    {useExistingPositionSource ? 'Additional Debt' : isSwapRoute ? 'Flash Borrow Required' : 'Flash Borrow'}
+                  </span>
                   <span className="tabular-nums inline-flex items-center gap-1.5">
                     <Tooltip content={<span className="text-xs">{flashBorrowPreview.full}</span>}>
                       <span className="cursor-help border-b border-dotted border-white/40">{flashBorrowPreview.compact}</span>
@@ -846,31 +831,36 @@ export function AddCollateralAndLeverage({
                             {isNetRateLoading ? '...' : renderRateFromDisplayMode(previewExpectedNetRate)}
                           </span>
                         </div>
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-0.5">
-                            <span className="text-secondary">{leveredCarryLabel}</span>
-                            <HelpTooltipIcon
-                              content={
-                                <SharedTooltipContent
-                                  title={leveredCarryLabel}
-                                  detail={leveredCarryDetail}
-                                  secondaryDetail={leveredCarrySecondaryDetail}
-                                />
-                              }
-                              ariaLabel={`Explain ${leveredCarryLabel}`}
-                              className="h-auto w-auto"
-                            />
+                        {shouldShowLeveredCarryRow && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-0.5">
+                              <span className="text-secondary">{leveredCarryLabel}</span>
+                              <HelpTooltipIcon
+                                content={
+                                  <SharedTooltipContent
+                                    title={leveredCarryLabel}
+                                    detail={leveredCarryDetail}
+                                    secondaryDetail={leveredCarrySecondaryDetail}
+                                  />
+                                }
+                                ariaLabel={`Explain ${leveredCarryLabel}`}
+                                className="h-auto w-auto"
+                              />
+                            </div>
+                            <span className={`tabular-nums ${leveredCarryRateClass}`}>
+                              {isLeveredCarryLoading ? '...' : renderRateFromDisplayMode(previewLeveredCarryOnCapitalRate)}
+                            </span>
                           </div>
-                          <span className={`tabular-nums ${leveredCarryRateClass}`}>
-                            {isLeveredCarryLoading ? '...' : renderRateFromDisplayMode(previewLeveredCarryOnCapitalRate)}
-                          </span>
-                        </div>
+                        )}
                       </>
                     )}
                   </>
                 )}
               </div>
               {quote.error && <p className="mt-2 text-xs text-red-500">{quote.error}</p>}
+              {useExistingPositionSource && currentCollateralAssets <= 0n && (
+                <p className="mt-2 text-xs text-red-500">Existing collateral is required to increase leverage without wallet capital.</p>
+              )}
               {!quote.error && leverageFeeReadinessError && <p className="mt-2 text-xs text-red-500">{leverageFeeReadinessError}</p>}
               {isErc4626Route && vaultRateInsight.error && (
                 <p className="mt-2 text-xs text-red-500">Failed to fetch 3-day vault/borrow rates: {vaultRateInsight.error}</p>
@@ -895,9 +885,8 @@ export function AddCollateralAndLeverage({
                 isLoading={isLoadingPermit2 || leveragePending || quote.isLoading}
                 disabled={
                   route == null ||
-                  initialCapitalInputError !== null ||
+                  !hasRequiredInput ||
                   quote.error !== null ||
-                  initialCapitalInputAmount <= 0n ||
                   !isBundlerAuthorizationReady ||
                   !hasExecutableInitialCapitalConversion ||
                   !isLeverageFeeReady ||
@@ -908,7 +897,7 @@ export function AddCollateralAndLeverage({
                 variant="primary"
                 className="min-w-32"
               >
-                Leverage
+                {leverageButtonLabel}
               </ExecuteTransactionButton>
             </div>
 

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -147,11 +147,18 @@ export function AddCollateralAndLeverage({
     }
   }, [targetMultiplierBps, maxMultiplierBps, maxTargetLtvBps, useTargetLtvInput, targetLtvIntentBps]);
 
+  const currentCollateralAssetsRaw = parseUnsignedBigInt(currentPosition?.state.collateral);
+  const currentBorrowAssetsRaw = parseUnsignedBigInt(currentPosition?.state.borrowAssets);
+  const hasInvalidExistingPositionData =
+    useExistingPositionSource && (currentCollateralAssetsRaw == null || currentBorrowAssetsRaw == null);
+  const currentCollateralAssets = currentCollateralAssetsRaw ?? 0n;
+  const currentBorrowAssets = currentBorrowAssetsRaw ?? 0n;
+
   const quote = useLeverageQuote({
     chainId: market.morphoBlue.chain.id,
     route,
     initialCapitalInputAmount,
-    positionDebtInputAmount: useExistingPositionSource ? positionDebtInputAmount : undefined,
+    positionDebtInputAmount: useExistingPositionSource ? (hasInvalidExistingPositionData ? 0n : positionDebtInputAmount) : undefined,
     inputMode: useLoanAssetInputForTransaction ? 'loan' : 'collateral',
     multiplierBps,
     loanTokenAddress: market.loanAsset.address,
@@ -162,8 +169,6 @@ export function AddCollateralAndLeverage({
     slippageBps: swapSlippageBps,
   });
 
-  const currentCollateralAssets = parseUnsignedBigInt(currentPosition?.state.collateral) ?? 0n;
-  const currentBorrowAssets = parseUnsignedBigInt(currentPosition?.state.borrowAssets) ?? 0n;
   const hasQuoteChanges = quote.totalCollateralTokenAmountAdded > 0n && quote.flashLoanAssetAmount > 0n;
   const collateralAssetPriceUsd = useMemo(() => {
     const totalCollateralAssets = BigInt(market.state.collateralAssets);
@@ -620,7 +625,7 @@ export function AddCollateralAndLeverage({
     return previewLeveredCarryOnCapitalRate >= 0 ? 'text-emerald-500' : 'text-red-500';
   }, [previewLeveredCarryOnCapitalRate]);
   const hasRequiredInput = useExistingPositionSource
-    ? currentCollateralAssets > 0n && positionDebtInputAmount > 0n && positionDebtInputError === null
+    ? !hasInvalidExistingPositionData && currentCollateralAssets > 0n && positionDebtInputAmount > 0n && positionDebtInputError === null
     : initialCapitalInputAmount > 0n && initialCapitalInputError === null;
   const leverageButtonLabel = useExistingPositionSource ? 'Increase Leverage' : 'Leverage';
 
@@ -857,7 +862,10 @@ export function AddCollateralAndLeverage({
                 )}
               </div>
               {quote.error && <p className="mt-2 text-xs text-red-500">{quote.error}</p>}
-              {useExistingPositionSource && currentCollateralAssets <= 0n && (
+              {hasInvalidExistingPositionData && (
+                <p className="mt-2 text-xs text-red-500">Unable to read valid position data. Refresh balances and try again.</p>
+              )}
+              {useExistingPositionSource && !hasInvalidExistingPositionData && currentCollateralAssets <= 0n && (
                 <p className="mt-2 text-xs text-red-500">Existing collateral is required to increase leverage without wallet capital.</p>
               )}
               {!quote.error && leverageFeeReadinessError && <p className="mt-2 text-xs text-red-500">{leverageFeeReadinessError}</p>}
@@ -885,6 +893,7 @@ export function AddCollateralAndLeverage({
                 disabled={
                   route == null ||
                   !hasRequiredInput ||
+                  hasInvalidExistingPositionData ||
                   quote.error !== null ||
                   !isBundlerAuthorizationReady ||
                   !hasExecutableInitialCapitalConversion ||

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -636,7 +636,6 @@ export function AddCollateralAndLeverage({
           <PositionLeverageSummary
             currentLtv={currentLTV}
             projectedLtv={projectedLTV}
-            lltv={lltv}
             hasChanges={hasChanges}
           />
           <BorrowPositionRiskCard

--- a/src/modals/leverage/components/leverage-input-panels.tsx
+++ b/src/modals/leverage/components/leverage-input-panels.tsx
@@ -1,0 +1,205 @@
+import { TokenIcon } from '@/components/shared/token-icon';
+import Input from '@/components/Input/Input';
+import { IconSwitch } from '@/components/ui/icon-switch';
+import { clampTargetLtvBps, multiplierBpsFromTargetLtv } from '@/hooks/leverage/math';
+import { formatBalance } from '@/utils/balance';
+import type { Market } from '@/utils/types';
+
+const TARGET_INPUT_DEBOUNCE_MS = 300;
+
+type InputErrorSetter = (error: string | null) => void;
+
+type PositionDebtLoopInputProps = {
+  market: Market;
+  marketLiquidity: bigint;
+  value: bigint;
+  setValue: (value: bigint) => void;
+  error: string | null;
+  setError: InputErrorSetter;
+};
+
+type WalletCapitalInputProps = {
+  market: Market;
+  canUseLoanAssetInput: boolean;
+  useLoanAssetInput: boolean;
+  setUseLoanAssetInput: (selected: boolean) => void;
+  inputAssetSymbol: string;
+  inputAssetDecimals: number;
+  inputAssetBalance: bigint | undefined;
+  inputTokenIconAddress: string;
+  value: bigint;
+  setValue: (value: bigint) => void;
+  error: string | null;
+  setError: InputErrorSetter;
+};
+
+type TargetLeverageInputProps = {
+  useTargetLtvInput: boolean;
+  onTargetInputModeChange: (useTargetLtvInput: boolean) => void;
+  targetLtvIntentBps: bigint;
+  setTargetLtvIntentBps: (value: bigint) => void;
+  setTargetMultiplierBps: (value: bigint) => void;
+  maxTargetLtvBps: bigint;
+  maxMultiplierBps: bigint;
+  multiplierBps: bigint;
+  syncInputFieldsFromMultiplier: (value: bigint) => void;
+};
+
+export function PositionDebtLoopInput({
+  market,
+  marketLiquidity,
+  value,
+  setValue,
+  error,
+  setError,
+}: PositionDebtLoopInputProps): JSX.Element {
+  return (
+    <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+      <p className="mb-1 text-[11px] uppercase tracking-[0.12em] text-secondary">Additional Debt To Loop</p>
+      <Input
+        decimals={market.loanAsset.decimals}
+        max={marketLiquidity}
+        setValue={setValue}
+        setError={setError}
+        exceedMaxErrMessage="Exceeds available liquidity"
+        value={value}
+        inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
+        endAdornment={
+          <TokenIcon
+            address={market.loanAsset.address}
+            chainId={market.morphoBlue.chain.id}
+            symbol={market.loanAsset.symbol}
+            width={16}
+            height={16}
+          />
+        }
+      />
+      <div className="mt-1 flex items-start gap-3 text-xs">
+        {error && <p className="text-red-500">{error}</p>}
+        <span className="ml-auto text-right text-secondary">
+          Available: {formatBalance(marketLiquidity, market.loanAsset.decimals)} {market.loanAsset.symbol}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function WalletCapitalInput({
+  market,
+  canUseLoanAssetInput,
+  useLoanAssetInput,
+  setUseLoanAssetInput,
+  inputAssetSymbol,
+  inputAssetDecimals,
+  inputAssetBalance,
+  inputTokenIconAddress,
+  value,
+  setValue,
+  error,
+  setError,
+}: WalletCapitalInputProps): JSX.Element {
+  return (
+    <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Initial Capital</p>
+        {canUseLoanAssetInput && (
+          <div className="flex items-center gap-2">
+            <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
+            <IconSwitch
+              size="sm"
+              selected={useLoanAssetInput}
+              onChange={setUseLoanAssetInput}
+              thumbIcon={null}
+              classNames={{
+                wrapper: 'mr-0 h-4 w-9',
+                thumb: 'h-3 w-3',
+              }}
+            />
+          </div>
+        )}
+      </div>
+      <Input
+        decimals={inputAssetDecimals}
+        max={inputAssetBalance}
+        setValue={setValue}
+        setError={setError}
+        exceedMaxErrMessage="Insufficient Balance"
+        value={value}
+        inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
+        endAdornment={
+          <TokenIcon
+            address={inputTokenIconAddress}
+            chainId={market.morphoBlue.chain.id}
+            symbol={inputAssetSymbol}
+            width={16}
+            height={16}
+          />
+        }
+      />
+      <div className="mt-1 flex items-start gap-3 text-xs">
+        {error && <p className="text-red-500">{error}</p>}
+        <span className="ml-auto text-right text-secondary">
+          Balance: {formatBalance(inputAssetBalance ?? 0n, inputAssetDecimals)} {inputAssetSymbol}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function TargetLeverageInput({
+  useTargetLtvInput,
+  onTargetInputModeChange,
+  targetLtvIntentBps,
+  setTargetLtvIntentBps,
+  setTargetMultiplierBps,
+  maxTargetLtvBps,
+  maxMultiplierBps,
+  multiplierBps,
+  syncInputFieldsFromMultiplier,
+}: TargetLeverageInputProps): JSX.Element {
+  return (
+    <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">{useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}</p>
+        <div className="flex items-center gap-2">
+          <div className="text-xs text-secondary">Use LTV</div>
+          <IconSwitch
+            size="sm"
+            selected={useTargetLtvInput}
+            onChange={onTargetInputModeChange}
+            thumbIcon={null}
+            classNames={{
+              wrapper: 'mr-0 h-4 w-9',
+              thumb: 'h-3 w-3',
+            }}
+          />
+        </div>
+      </div>
+      <div className="relative min-w-0">
+        {useTargetLtvInput ? (
+          <Input
+            decimals={2}
+            setValue={(nextTargetLtvBps) => {
+              const clampedTargetLtvBps = clampTargetLtvBps(nextTargetLtvBps, maxTargetLtvBps);
+              setTargetLtvIntentBps(clampedTargetLtvBps);
+              setTargetMultiplierBps(multiplierBpsFromTargetLtv(clampedTargetLtvBps, maxMultiplierBps));
+            }}
+            value={targetLtvIntentBps}
+            inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
+            endAdornment={<span className="text-xs text-secondary">%</span>}
+            debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
+          />
+        ) : (
+          <Input
+            decimals={4}
+            setValue={syncInputFieldsFromMultiplier}
+            value={multiplierBps}
+            inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
+            endAdornment={<span className="text-xs text-secondary">x</span>}
+            debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modals/leverage/components/leverage-input-panels.tsx
+++ b/src/modals/leverage/components/leverage-input-panels.tsx
@@ -55,7 +55,7 @@ export function PositionDebtLoopInput({
 }: PositionDebtLoopInputProps): JSX.Element {
   return (
     <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-      <p className="mb-1 text-[11px] uppercase tracking-[0.12em] text-secondary">Additional Debt To Loop</p>
+      <p className="mb-1 font-monospace text-[11px] uppercase tracking-[0.12em] text-secondary">Additional Debt</p>
       <Input
         decimals={market.loanAsset.decimals}
         max={marketLiquidity}
@@ -101,7 +101,7 @@ export function WalletCapitalInput({
   return (
     <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
       <div className="mb-1 flex items-center justify-between gap-2">
-        <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Initial Capital</p>
+        <p className="font-monospace text-[11px] uppercase tracking-[0.12em] text-secondary">Wallet Capital</p>
         {canUseLoanAssetInput && (
           <div className="flex items-center gap-2">
             <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
@@ -160,7 +160,9 @@ export function TargetLeverageInput({
   return (
     <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
       <div className="mb-1 flex items-center justify-between gap-2">
-        <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">{useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}</p>
+        <p className="font-monospace text-[11px] uppercase tracking-[0.12em] text-secondary">
+          {useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}
+        </p>
         <div className="flex items-center gap-2">
           <div className="text-xs text-secondary">Use LTV</div>
           <IconSwitch

--- a/src/modals/leverage/components/position-leverage-summary.tsx
+++ b/src/modals/leverage/components/position-leverage-summary.tsx
@@ -1,0 +1,42 @@
+import { formatMultiplierBps, ltvWadToBps, multiplierBpsFromTargetLtv } from '@/hooks/leverage/math';
+import { LTV_WAD, formatLtvPercent, getLTVColor } from '@/modals/borrow/components/helpers';
+
+type PositionLeverageSummaryProps = {
+  currentLtv: bigint;
+  projectedLtv: bigint;
+  lltv: bigint;
+  hasChanges: boolean;
+};
+
+const formatLeverageFromLtv = (ltv: bigint): string => {
+  if (ltv >= LTV_WAD) return '∞';
+  if (ltv <= 0n) return '1.00x';
+  return `${formatMultiplierBps(multiplierBpsFromTargetLtv(ltvWadToBps(ltv)))}x`;
+};
+
+export function PositionLeverageSummary({ currentLtv, projectedLtv, lltv, hasChanges }: PositionLeverageSummaryProps): JSX.Element {
+  const currentLeverage = formatLeverageFromLtv(currentLtv);
+  const projectedLeverage = hasChanges ? formatLeverageFromLtv(projectedLtv) : currentLeverage;
+  const projectedLtvForDisplay = hasChanges ? projectedLtv : currentLtv;
+
+  return (
+    <div className="mb-3 grid grid-cols-2 gap-2">
+      <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+        <p className="mb-1 text-[11px] uppercase tracking-[0.12em] text-secondary">Current</p>
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-lg font-medium tabular-nums">{currentLeverage}</span>
+          <span className={`text-xs tabular-nums ${getLTVColor(currentLtv, lltv)}`}>{formatLtvPercent(currentLtv)}% LTV</span>
+        </div>
+      </div>
+      <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+        <p className="mb-1 text-[11px] uppercase tracking-[0.12em] text-secondary">Updated</p>
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-lg font-medium tabular-nums">{projectedLeverage}</span>
+          <span className={`text-xs tabular-nums ${getLTVColor(projectedLtvForDisplay, lltv)}`}>
+            {formatLtvPercent(projectedLtvForDisplay)}% LTV
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modals/leverage/components/position-leverage-summary.tsx
+++ b/src/modals/leverage/components/position-leverage-summary.tsx
@@ -1,10 +1,10 @@
 import { formatMultiplierBps, ltvWadToBps, multiplierBpsFromTargetLtv } from '@/hooks/leverage/math';
-import { LTV_WAD, formatLtvPercent, getLTVColor } from '@/modals/borrow/components/helpers';
+import { LTV_WAD } from '@/modals/borrow/components/helpers';
+import { cn } from '@/utils/components';
 
 type PositionLeverageSummaryProps = {
   currentLtv: bigint;
   projectedLtv: bigint;
-  lltv: bigint;
   hasChanges: boolean;
 };
 
@@ -14,28 +14,21 @@ const formatLeverageFromLtv = (ltv: bigint): string => {
   return `${formatMultiplierBps(multiplierBpsFromTargetLtv(ltvWadToBps(ltv)))}x`;
 };
 
-export function PositionLeverageSummary({ currentLtv, projectedLtv, lltv, hasChanges }: PositionLeverageSummaryProps): JSX.Element {
+export function PositionLeverageSummary({ currentLtv, projectedLtv, hasChanges }: PositionLeverageSummaryProps): JSX.Element {
   const currentLeverage = formatLeverageFromLtv(currentLtv);
   const projectedLeverage = hasChanges ? formatLeverageFromLtv(projectedLtv) : currentLeverage;
-  const projectedLtvForDisplay = hasChanges ? projectedLtv : currentLtv;
+  const cardClassName = 'rounded border px-3 py-2.5';
+  const valueClassName = 'text-lg font-medium tabular-nums';
 
   return (
     <div className="mb-3 grid grid-cols-2 gap-2">
-      <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+      <div className={cn(cardClassName, 'border-white/10 bg-hovered')}>
         <p className="mb-1 text-[11px] uppercase tracking-[0.12em] text-secondary">Current</p>
-        <div className="flex items-baseline justify-between gap-3">
-          <span className="text-lg font-medium tabular-nums">{currentLeverage}</span>
-          <span className={`text-xs tabular-nums ${getLTVColor(currentLtv, lltv)}`}>{formatLtvPercent(currentLtv)}% LTV</span>
-        </div>
+        <span className={valueClassName}>{currentLeverage}</span>
       </div>
-      <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+      <div className={cn(cardClassName, hasChanges ? 'border-white/10 bg-hovered' : 'border-white/5 bg-hovered/40 text-secondary')}>
         <p className="mb-1 text-[11px] uppercase tracking-[0.12em] text-secondary">Updated</p>
-        <div className="flex items-baseline justify-between gap-3">
-          <span className="text-lg font-medium tabular-nums">{projectedLeverage}</span>
-          <span className={`text-xs tabular-nums ${getLTVColor(projectedLtvForDisplay, lltv)}`}>
-            {formatLtvPercent(projectedLtvForDisplay)}% LTV
-          </span>
-        </div>
+        <span className={cn(valueClassName, !hasChanges && 'text-secondary')}>{projectedLeverage}</span>
       </div>
     </div>
   );

--- a/src/modals/leverage/components/remove-collateral-and-deleverage.tsx
+++ b/src/modals/leverage/components/remove-collateral-and-deleverage.tsx
@@ -16,6 +16,7 @@ import type { LeverageRoute } from '@/hooks/leverage/types';
 import { computeLtv, formatLtvPercent, getLTVColor } from '@/modals/borrow/components/helpers';
 import { BorrowPositionRiskCard } from '@/modals/borrow/components/borrow-position-risk-card';
 import { PreviewSectionHeader } from '@/modals/borrow/components/preview-section-header';
+import { PositionLeverageSummary } from './position-leverage-summary';
 
 type RemoveCollateralAndDeleverageProps = {
   market: Market;
@@ -245,6 +246,12 @@ export function RemoveCollateralAndDeleverage({
             onRefresh={onSuccess}
             isRefreshing={isRefreshing}
           />
+          <PositionLeverageSummary
+            currentLtv={currentLTV}
+            projectedLtv={displayProjectedLTV}
+            lltv={lltv}
+            hasChanges={hasChanges}
+          />
           <BorrowPositionRiskCard
             market={market}
             oraclePrice={oraclePrice}
@@ -388,7 +395,7 @@ export function RemoveCollateralAndDeleverage({
                 variant="primary"
                 className="min-w-32"
               >
-                Deleverage
+                Decrease Leverage
               </ExecuteTransactionButton>
             </div>
 

--- a/src/modals/leverage/components/remove-collateral-and-deleverage.tsx
+++ b/src/modals/leverage/components/remove-collateral-and-deleverage.tsx
@@ -249,7 +249,6 @@ export function RemoveCollateralAndDeleverage({
           <PositionLeverageSummary
             currentLtv={currentLTV}
             projectedLtv={displayProjectedLTV}
-            lltv={lltv}
             hasChanges={hasChanges}
           />
           <BorrowPositionRiskCard

--- a/src/modals/leverage/leverage-modal-global.tsx
+++ b/src/modals/leverage/leverage-modal-global.tsx
@@ -38,8 +38,8 @@ export function LeverageModalGlobal({
     chainId,
   });
 
-  const { position, refetch: refetchPosition } = useUserPosition(address, chainId, market.uniqueKey);
-  const resolvedPosition = providedPosition ?? position;
+  const { position, loading: isPositionLoading, refetch: refetchPosition } = useUserPosition(address, chainId, market.uniqueKey);
+  const resolvedPosition = position ?? (isPositionLoading ? (providedPosition ?? null) : null);
 
   const handleRefetch = useCallback(() => {
     refetchPosition();

--- a/src/modals/leverage/leverage-modal-global.tsx
+++ b/src/modals/leverage/leverage-modal-global.tsx
@@ -4,12 +4,14 @@ import { useCallback } from 'react';
 import { useConnection } from 'wagmi';
 import { useOraclePrice } from '@/hooks/useOraclePrice';
 import useUserPosition from '@/hooks/useUserPosition';
-import type { Market } from '@/utils/types';
+import type { Market, MarketPosition } from '@/utils/types';
 import { LeverageModal } from './leverage-modal';
 
 type LeverageModalGlobalProps = {
   market: Market;
+  position?: MarketPosition | null;
   defaultMode?: 'leverage' | 'deleverage';
+  defaultLeverageSource?: 'wallet' | 'position';
   toggleLeverageDeleverage?: boolean;
   refetch?: () => void;
   onOpenChange: (open: boolean) => void;
@@ -21,7 +23,9 @@ type LeverageModalGlobalProps = {
  */
 export function LeverageModalGlobal({
   market,
+  position: providedPosition,
   defaultMode,
+  defaultLeverageSource,
   toggleLeverageDeleverage,
   refetch: externalRefetch,
   onOpenChange,
@@ -35,6 +39,7 @@ export function LeverageModalGlobal({
   });
 
   const { position, refetch: refetchPosition } = useUserPosition(address, chainId, market.uniqueKey);
+  const resolvedPosition = providedPosition ?? position;
 
   const handleRefetch = useCallback(() => {
     refetchPosition();
@@ -47,8 +52,9 @@ export function LeverageModalGlobal({
       onOpenChange={onOpenChange}
       oraclePrice={oraclePrice}
       refetch={handleRefetch}
-      position={position}
+      position={resolvedPosition}
       defaultMode={defaultMode}
+      defaultLeverageSource={defaultLeverageSource}
       toggleLeverageDeleverage={toggleLeverageDeleverage}
     />
   );

--- a/src/modals/leverage/leverage-modal.tsx
+++ b/src/modals/leverage/leverage-modal.tsx
@@ -185,6 +185,28 @@ export function LeverageModal({
           label: effectiveMode === 'leverage' ? `Leverage ${market.collateralAsset.symbol}` : `Deleverage ${market.collateralAsset.symbol}`,
         },
       ];
+  const modalDescription = useMemo(() => {
+    if (effectiveMode === 'leverage') {
+      if (defaultLeverageSource === 'position') {
+        return `Borrow more ${market.loanAsset.symbol} against the current position and loop it into ${market.collateralAsset.symbol}. No wallet capital is added.`;
+      }
+      if (isErc4626Route) {
+        return `Add wallet capital, borrow ${market.loanAsset.symbol}, and loop into ${market.collateralAsset.symbol}.`;
+      }
+      if (isSwapRoute) {
+        return `Add wallet capital, borrow ${market.loanAsset.symbol}, and swap into ${market.collateralAsset.symbol}.`;
+      }
+      return `Add wallet capital and borrow against it to increase ${market.collateralAsset.symbol} exposure.`;
+    }
+
+    if (isErc4626Route) {
+      return `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`;
+    }
+    if (isSwapRoute) {
+      return `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`;
+    }
+    return `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`;
+  }, [effectiveMode, defaultLeverageSource, isErc4626Route, isSwapRoute, market.collateralAsset.symbol, market.loanAsset.symbol]);
 
   const {
     data: collateralTokenBalance,
@@ -297,19 +319,7 @@ export function LeverageModal({
             )}
           </div>
         }
-        description={
-          effectiveMode === 'leverage'
-            ? isErc4626Route
-              ? `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-              : isSwapRoute
-                ? `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-                : `Leverage your ${market.collateralAsset.symbol} exposure by looping.`
-            : isErc4626Route
-              ? `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`
-              : isSwapRoute
-                ? `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`
-                : `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`
-        }
+        description={modalDescription}
       />
       <ModalBody>
         {routeContent ? (

--- a/src/modals/leverage/leverage-modal.tsx
+++ b/src/modals/leverage/leverage-modal.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { IoWarningOutline } from 'react-icons/io5';
-import { RiSparklingFill } from 'react-icons/ri';
 import { type Address, erc20Abi } from 'viem';
 import { useConnection, useReadContract } from 'wagmi';
 import { Modal, ModalBody, ModalHeader } from '@/components/common/Modal';
@@ -26,6 +25,7 @@ type LeverageModalProps = {
   isRefreshing?: boolean;
   position: MarketPosition | null;
   defaultMode?: 'leverage' | 'deleverage';
+  defaultLeverageSource?: 'wallet' | 'position';
   toggleLeverageDeleverage?: boolean;
 };
 
@@ -101,6 +101,7 @@ export function LeverageModal({
   isRefreshing = false,
   position,
   defaultMode = 'leverage',
+  defaultLeverageSource = 'wallet',
   toggleLeverageDeleverage = true,
 }: LeverageModalProps): JSX.Element {
   const [mode, setMode] = useState<'leverage' | 'deleverage'>(defaultMode);
@@ -220,6 +221,7 @@ export function LeverageModal({
           currentPosition={position}
           collateralTokenBalance={collateralTokenBalance}
           oraclePrice={oraclePrice}
+          defaultLeverageSource={defaultLeverageSource}
           onSuccess={handleRefreshAll}
           isRefreshing={isRefreshingAnyData}
         />
@@ -236,7 +238,17 @@ export function LeverageModal({
         isRefreshing={isRefreshingAnyData}
       />
     );
-  }, [route, effectiveMode, market, position, collateralTokenBalance, oraclePrice, handleRefreshAll, isRefreshingAnyData]);
+  }, [
+    route,
+    effectiveMode,
+    market,
+    position,
+    collateralTokenBalance,
+    oraclePrice,
+    defaultLeverageSource,
+    handleRefreshAll,
+    isRefreshingAnyData,
+  ]);
 
   const mainIcon = (
     <div className="flex -space-x-2">
@@ -276,13 +288,6 @@ export function LeverageModal({
               options={modeOptions}
               onValueChange={(nextMode) => setMode(nextMode as 'leverage' | 'deleverage')}
             />
-            <Badge
-              variant="default"
-              className="inline-flex items-center gap-1"
-            >
-              <RiSparklingFill className="h-3 w-3 text-yellow-400" />
-              New
-            </Badge>
             {(route || availableRouteModes.length > 0) && (
               <RouteModeBadge
                 value={displayedRouteMode}

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -29,7 +29,9 @@ export type ModalProps = {
   // Leverage & Deleverage
   leverage: {
     market: Market;
+    position?: MarketPosition | null;
     defaultMode?: 'leverage' | 'deleverage';
+    defaultLeverageSource?: 'wallet' | 'position';
     toggleLeverageDeleverage?: boolean;
     refetch?: () => void;
   };

--- a/src/utils/positions.ts
+++ b/src/utils/positions.ts
@@ -55,6 +55,7 @@ export type PositionSnapshotsWithOracleResult = {
 
 export type BorrowPositionRow = {
   market: MorphoMarket;
+  position: MarketPosition;
   state: {
     borrowAssets: string;
     borrowShares: string;
@@ -618,6 +619,7 @@ export function buildBorrowPositionRows(positions: MarketPositionWithEarnings[])
 
       return {
         market: position.market,
+        position,
         state: {
           borrowAssets: position.state.borrowAssets,
           borrowShares: position.state.borrowShares,


### PR DESCRIPTION
## Summary
- add an `Increase Leverage` shortcut to borrowed-position rows that opens the existing leverage modal in position-sourced mode
- let users loop additional debt into collateral without adding wallet capital, while showing current vs updated leverage and LTV
- pass the known position row into the modal so the positions page does not render an empty/current-position fallback
- keep existing wallet-capital leverage and deleverage modes in the same modal; no new change-position modal/page
- keep borrowed table loan/collateral amounts on one line

## Transaction boundary
- no changes to leverage/deleverage composer files:
  - `src/hooks/leverage/leverageWithErc4626Deposit.ts`
  - `src/hooks/leverage/leverageWithSwap.ts`
  - `src/hooks/deleverage/deleverageWithErc4626Redeem.ts`
  - `src/hooks/deleverage/deleverageWithSwap.ts`
  - `src/hooks/leverage/velora-transaction.ts`
  - `src/hooks/leverage/bundler3.ts`
  - `src/hooks/useDeleverageTransaction.ts`
- `useLeverageQuote` adds one explicit exact-debt quote path for existing-position leverage
- `useLeverageTransaction` only skips wallet token Permit2/approval gates when there is no initial capital transfer; the composer inputs remain the same shape

## Validation
- `npx ultracite fix`
- `npx ultracite check`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `git diff -- src/hooks/leverage/leverageWithErc4626Deposit.ts src/hooks/leverage/leverageWithSwap.ts src/hooks/deleverage/deleverageWithErc4626Redeem.ts src/hooks/deleverage/deleverageWithSwap.ts src/hooks/leverage/velora-transaction.ts src/hooks/leverage/bundler3.ts src/hooks/useDeleverageTransaction.ts` returned empty
- local `/positions` smoke on `localhost:3001` returned HTTP 200; browser smoke found existing app-level WalletConnect/Radix risk-notice warnings, not a leverage-modal regression

## LOC
- final diff: 12 files, +581/-187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Increase Leverage** action in position actions.
  * Leverage flows now support using an **existing position** as the source, not just wallet funds.
  * Added clearer leverage and LTV summary panels in leverage/deleverage screens.

* **Improvements**
  * Leverage and deleverage previews now show more accurate labels, balances, and projected leverage changes.
  * The leverage button and step flow now adapt based on the selected funding source.

* **Bug Fixes**
  * Improved handling for leverage quotes and transaction preparation across wallet-funded and position-based flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->