### PR TITLE
Add clean existing-position leverage flow

### DIFF
--- a/src/features/positions/components/borrow-position-actions-dropdown.tsx
+++ b/src/features/positions/components/borrow-position-actions-dropdown.tsx
@@ -3,24 +3,26 @@
 import type React from 'react';
 import { IoEllipsisVertical } from 'react-icons/io5';
 import { BsArrowDownLeftCircle, BsArrowUpRightCircle } from 'react-icons/bs';
-import { TbTrendingDown } from 'react-icons/tb';
+import { TbAdjustmentsHorizontal } from 'react-icons/tb';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
 type BorrowPositionActionsDropdownProps = {
   isOwner: boolean;
   isActiveDebt: boolean;
+  canAdjustLeverage: boolean;
   onBorrowMoreClick: () => void;
   onRepayClick: () => void;
-  onDeleverageClick: () => void;
+  onAdjustLeverageClick: () => void;
 };
 
 export function BorrowPositionActionsDropdown({
   isOwner,
   isActiveDebt,
+  canAdjustLeverage,
   onBorrowMoreClick,
   onRepayClick,
-  onDeleverageClick,
+  onAdjustLeverageClick,
 }: BorrowPositionActionsDropdownProps) {
   const handleClick = (event: React.MouseEvent) => {
     event.stopPropagation();
@@ -64,14 +66,14 @@ export function BorrowPositionActionsDropdown({
           >
             {isActiveDebt ? 'Repay' : 'Manage'}
           </DropdownMenuItem>
-          {isActiveDebt && (
+          {canAdjustLeverage && (
             <DropdownMenuItem
-              onClick={onDeleverageClick}
-              startContent={<TbTrendingDown className="h-4 w-4" />}
+              onClick={onAdjustLeverageClick}
+              startContent={<TbAdjustmentsHorizontal className="h-4 w-4" />}
               disabled={!isOwner}
               className={isOwner ? '' : 'cursor-not-allowed opacity-50'}
             >
-              Deleverage
+              Adjust LTV
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>

--- a/src/features/positions/components/borrowed-morpho-blue-table.tsx
+++ b/src/features/positions/components/borrowed-morpho-blue-table.tsx
@@ -263,6 +263,7 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                         <BorrowPositionActionsDropdown
                           isOwner={isOwner}
                           isActiveDebt={row.isActiveDebt}
+                          canAdjustLeverage={row.collateralAmount > 0}
                           onBorrowMoreClick={() =>
                             open('borrow', {
                               market: row.market,
@@ -283,11 +284,13 @@ export function BorrowedMorphoBlueTable({ account, positions, onRefetch, isRefet
                               },
                             })
                           }
-                          onDeleverageClick={() =>
+                          onAdjustLeverageClick={() =>
                             open('leverage', {
                               market: row.market,
-                              defaultMode: 'deleverage',
-                              toggleLeverageDeleverage: false,
+                              position: row.position,
+                              defaultMode: 'leverage',
+                              defaultLeverageSource: 'position',
+                              toggleLeverageDeleverage: true,
                               refetch: () => {
                                 void onRefetch();
                               },

--- a/src/hooks/leverage/math.ts
+++ b/src/hooks/leverage/math.ts
@@ -4,6 +4,7 @@ import { LEVERAGE_MIN_MULTIPLIER_BPS, LEVERAGE_MULTIPLIER_SCALE_BPS } from './ty
 export const LEVERAGE_SLIPPAGE_BUFFER_BPS = 9_950n; // 0.50% tolerance
 export const BPS_SCALE = 10_000n;
 export const WAD_TO_BPS_SCALE = 100_000_000_000_000n;
+const LTV_WAD_SCALE = 10n ** 18n;
 const ASSET_INPUT_SHARE_SLIPPAGE_BUFFER_BPS = 50n; // 0.50%
 const MORPHO_VIRTUAL_SHARES = 1_000_000n;
 const MORPHO_VIRTUAL_ASSETS = 1n;
@@ -173,6 +174,49 @@ export const computeLeverageProjectedPosition = ({
   projectedBorrowAssets: currentBorrowAssets + addedBorrowAssets,
   projectedCollateralAssets: currentCollateralAssets + addedCollateralAssets,
 });
+
+export type TargetDebtAdjustmentDirection = 'increase' | 'decrease' | 'none';
+
+/**
+ * Computes the loan-asset delta required to move the whole position to a target LTV.
+ *
+ * WHY: existing-position leverage is not a fresh isolated loop. Borrowing `x` and
+ * redepositing the swapped collateral changes both sides of the current position:
+ * `(debt + x) / (collateralValue + x) = targetLtv`. Deleveraging is the inverse:
+ * `(debt - x) / (collateralValue - x) = targetLtv`. The optional collateral
+ * value factor lets callers conservatively account for slippage/fees before
+ * quote results are available.
+ */
+export const computeDebtAdjustmentForTargetLtv = ({
+  currentBorrowAssets,
+  currentCollateralValueInLoan,
+  collateralValueFactorBps = BPS_SCALE,
+  targetLtv,
+}: {
+  currentBorrowAssets: bigint;
+  currentCollateralValueInLoan: bigint;
+  collateralValueFactorBps?: bigint;
+  targetLtv: bigint;
+}): { direction: TargetDebtAdjustmentDirection; amount: bigint } => {
+  if (currentCollateralValueInLoan <= 0n || targetLtv <= 0n) {
+    return currentBorrowAssets > 0n ? { direction: 'decrease', amount: currentBorrowAssets } : { direction: 'none', amount: 0n };
+  }
+
+  const safeCollateralValueFactorBps =
+    collateralValueFactorBps <= 0n ? 0n : collateralValueFactorBps > BPS_SCALE ? BPS_SCALE : collateralValueFactorBps;
+  const denominator = LTV_WAD_SCALE - (targetLtv * safeCollateralValueFactorBps) / BPS_SCALE;
+  if (denominator <= 0n) return { direction: 'none', amount: 0n };
+
+  const signedNumerator = targetLtv * currentCollateralValueInLoan - LTV_WAD_SCALE * currentBorrowAssets;
+  if (signedNumerator === 0n) return { direction: 'none', amount: 0n };
+
+  const absNumerator = signedNumerator > 0n ? signedNumerator : -signedNumerator;
+  const amount = (absNumerator + denominator - 1n) / denominator;
+  return {
+    direction: signedNumerator > 0n ? 'increase' : 'decrease',
+    amount,
+  };
+};
 
 export type DeleverageProjectedPosition = {
   usesCloseRoute: boolean;
@@ -348,6 +392,12 @@ export const withSlippageCeil = (value: bigint, slippageBps?: number): bigint =>
   if (value <= 0n) return 0n;
   const ceilBps = FRACTIONAL_BPS_DENOMINATOR + getSlippageToleranceBps(slippageBps);
   return (value * ceilBps + FRACTIONAL_BPS_DENOMINATOR - 1n) / FRACTIONAL_BPS_DENOMINATOR;
+};
+
+export const withSlippageInverseCeil = (value: bigint, slippageBps?: number): bigint => {
+  if (value <= 0n) return 0n;
+  const floorBps = getSlippageFloorBps(slippageBps);
+  return (value * FRACTIONAL_BPS_DENOMINATOR + floorBps - 1n) / floorBps;
 };
 
 /**

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -18,8 +18,14 @@ type UseLeverageQuoteParams = {
    * Exact user-entered starting capital, denominated by `inputMode`.
    * - `loan`: market loan asset amount
    * - `collateral`: market collateral token amount
+   * Ignored when `positionDebtInputAmount` is set.
    */
   initialCapitalInputAmount: bigint;
+  /**
+   * Exact extra debt to loop from an existing position. When set, the quote has no wallet-funded
+   * initial leg: the flash-loaned debt is converted into collateral and supplied back to the same market.
+   */
+  positionDebtInputAmount?: bigint;
   inputMode: 'collateral' | 'loan';
   slippageBps: number;
   multiplierBps: bigint;
@@ -248,6 +254,7 @@ export function useLeverageQuote({
   chainId,
   route,
   initialCapitalInputAmount,
+  positionDebtInputAmount,
   inputMode,
   slippageBps,
   multiplierBps,
@@ -257,35 +264,61 @@ export function useLeverageQuote({
   collateralTokenDecimals,
   userAddress,
 }: UseLeverageQuoteParams): LeverageQuote {
+  const isPositionDebtInput = positionDebtInputAmount !== undefined;
+  const safeInitialCapitalInputAmount = isPositionDebtInput ? 0n : initialCapitalInputAmount;
+  const safePositionDebtInputAmount = positionDebtInputAmount ?? 0n;
   const isLoanAssetInput = inputMode === 'loan';
-  const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput;
+  const walletLoanInputFlashLoanAssetAmount = isLoanAssetInput
+    ? computeLeveragedExtraAmount(safeInitialCapitalInputAmount, multiplierBps)
+    : 0n;
+  const exactLoanInputFlashLoanAssetAmount = isPositionDebtInput ? safePositionDebtInputAmount : walletLoanInputFlashLoanAssetAmount;
+  const exactLoanInputSellAmount = isPositionDebtInput
+    ? safePositionDebtInputAmount
+    : isLoanAssetInput
+      ? safeInitialCapitalInputAmount + exactLoanInputFlashLoanAssetAmount
+      : 0n;
+  const isSwapExactLoanInput = route?.kind === 'swap' && (isPositionDebtInput || isLoanAssetInput);
+  const isSwapLoanAssetInput = route?.kind === 'swap' && isLoanAssetInput && !isPositionDebtInput;
   const swapExecutionAddress = route?.kind === 'swap' ? route.paraswapAdapterAddress : null;
+  const erc4626PreviewDepositAmount = isPositionDebtInput
+    ? safePositionDebtInputAmount
+    : isLoanAssetInput
+      ? safeInitialCapitalInputAmount
+      : 0n;
 
   const {
-    data: previewDepositCollateralSharesFromUserLoanAssets,
+    data: previewDepositCollateralSharesFromLoanAssets,
     isLoading: isLoadingErc4626Deposit,
     error: erc4626DepositError,
   } = useReadContract({
     address: route?.kind === 'erc4626' ? route.collateralVault : undefined,
     abi: erc4626Abi,
     functionName: 'previewDeposit',
-    // `previewDeposit(user loan assets)` -> ERC4626 collateral shares minted from that exact asset input.
-    args: [initialCapitalInputAmount],
+    // `previewDeposit(loan assets)` -> ERC4626 collateral shares minted from that exact asset input.
+    args: [erc4626PreviewDepositAmount],
     chainId,
     query: {
-      enabled: route?.kind === 'erc4626' && isLoanAssetInput && initialCapitalInputAmount > 0n,
+      enabled: route?.kind === 'erc4626' && erc4626PreviewDepositAmount > 0n,
     },
   });
 
   const quotedInitialCapitalCollateralTokenAmount = useMemo(() => {
+    if (isPositionDebtInput) return 0n;
     if (!route) return 0n;
     if (isSwapLoanAssetInput) return 0n;
-    if (!isLoanAssetInput) return initialCapitalInputAmount;
+    if (!isLoanAssetInput) return safeInitialCapitalInputAmount;
     // `previewDeposit(initialCapitalInputAmount)` returns the ERC4626 collateral-share amount minted by
     // depositing the user's exact loan-token asset input into the vault.
-    if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromUserLoanAssets as bigint | undefined) ?? 0n;
+    if (route.kind === 'erc4626') return (previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n;
     return 0n;
-  }, [route, isSwapLoanAssetInput, isLoanAssetInput, initialCapitalInputAmount, previewDepositCollateralSharesFromUserLoanAssets]);
+  }, [
+    isPositionDebtInput,
+    route,
+    isSwapLoanAssetInput,
+    isLoanAssetInput,
+    safeInitialCapitalInputAmount,
+    previewDepositCollateralSharesFromLoanAssets,
+  ]);
 
   const initialCapitalCollateralTokenAmount = useMemo(() => {
     if (route?.kind !== 'erc4626' || !isLoanAssetInput) return quotedInitialCapitalCollateralTokenAmount;
@@ -293,8 +326,11 @@ export function useLeverageQuote({
   }, [route, isLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, slippageBps]);
 
   const targetFlashCollateralTokenAmount = useMemo(
-    () => (isSwapLoanAssetInput ? 0n : computeFlashCollateralAmount(quotedInitialCapitalCollateralTokenAmount, multiplierBps)),
-    [isSwapLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, multiplierBps],
+    () =>
+      isPositionDebtInput || isSwapLoanAssetInput
+        ? 0n
+        : computeFlashCollateralAmount(quotedInitialCapitalCollateralTokenAmount, multiplierBps),
+    [isPositionDebtInput, isSwapLoanAssetInput, quotedInitialCapitalCollateralTokenAmount, multiplierBps],
   );
 
   const {
@@ -342,9 +378,9 @@ export function useLeverageQuote({
       }),
   });
 
-  const swapLoanInputCombinedQuoteQuery = useQuery({
+  const swapExactLoanInputQuoteQuery = useQuery({
     queryKey: [
-      'leverage-swap-loan-input-combined-quote',
+      'leverage-swap-exact-loan-input-quote',
       chainId,
       route?.kind === 'swap' ? route.paraswapAdapterAddress : null,
       route?.kind === 'swap' ? route.generalAdapterAddress : null,
@@ -353,15 +389,15 @@ export function useLeverageQuote({
       collateralTokenAddress,
       collateralTokenDecimals,
       swapExecutionAddress,
-      initialCapitalInputAmount.toString(),
-      multiplierBps.toString(),
+      isPositionDebtInput ? 'position' : 'wallet-loan',
+      exactLoanInputSellAmount.toString(),
+      exactLoanInputFlashLoanAssetAmount.toString(),
       slippageBps,
       userAddress ?? null,
     ],
-    enabled: route?.kind === 'swap' && isLoanAssetInput && initialCapitalInputAmount > 0n && !!userAddress,
+    enabled: isSwapExactLoanInput && exactLoanInputSellAmount > 0n && !!userAddress,
     queryFn: async () => {
-      const flashLoanAssetAmount = computeLeveragedExtraAmount(initialCapitalInputAmount, multiplierBps);
-      if (flashLoanAssetAmount <= 0n) {
+      if (exactLoanInputFlashLoanAssetAmount <= 0n) {
         return {
           flashLoanAssetAmount: 0n,
           flashLegCollateralTokenAmount: 0n,
@@ -370,13 +406,12 @@ export function useLeverageQuote({
         };
       }
 
-      const totalLoanSellAmount = initialCapitalInputAmount + flashLoanAssetAmount;
       const sellRoute = await fetchVeloraPriceRoute({
         srcToken: loanTokenAddress,
         srcDecimals: loanTokenDecimals,
         destToken: collateralTokenAddress,
         destDecimals: collateralTokenDecimals,
-        amount: totalLoanSellAmount,
+        amount: exactLoanInputSellAmount,
         network: chainId,
         userAddress: swapExecutionAddress as `0x${string}`,
         side: 'SELL',
@@ -385,8 +420,8 @@ export function useLeverageQuote({
       const totalCollateralTokenAmountAdded = withSlippageFloor(BigInt(sellRoute.destAmount), slippageBps);
 
       return {
-        flashLoanAssetAmount,
-        flashLegCollateralTokenAmount: 0n,
+        flashLoanAssetAmount: exactLoanInputFlashLoanAssetAmount,
+        flashLegCollateralTokenAmount: isPositionDebtInput ? totalCollateralTokenAmountAdded : 0n,
         totalCollateralTokenAmountAdded,
         priceRoute: sellRoute,
       };
@@ -395,24 +430,34 @@ export function useLeverageQuote({
 
   const flashLegCollateralTokenAmount = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionDebtInput) {
+      if (route.kind === 'swap') return swapExactLoanInputQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
+      return withSlippageFloor((previewDepositCollateralSharesFromLoanAssets as bigint | undefined) ?? 0n, slippageBps);
+    }
     if (route.kind === 'swap') {
-      if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
+      if (isLoanAssetInput) return swapExactLoanInputQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLegCollateralTokenAmount ?? 0n;
     }
     return withSlippageFloor(targetFlashCollateralTokenAmount, slippageBps);
   }, [
     route,
+    isPositionDebtInput,
+    swapExactLoanInputQuoteQuery.data?.flashLegCollateralTokenAmount,
+    previewDepositCollateralSharesFromLoanAssets,
     isLoanAssetInput,
     targetFlashCollateralTokenAmount,
     slippageBps,
-    swapLoanInputCombinedQuoteQuery.data?.flashLegCollateralTokenAmount,
     swapCollateralInputQuoteQuery.data?.flashLegCollateralTokenAmount,
   ]);
 
   const flashLoanAssetAmount = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionDebtInput) {
+      if (route.kind === 'swap') return swapExactLoanInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
+      return safePositionDebtInputAmount;
+    }
     if (route.kind === 'swap') {
-      if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
+      if (isLoanAssetInput) return swapExactLoanInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
       return swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount ?? 0n;
     }
     // `previewMint(targetFlashCollateralTokenAmount)` returns how many loan-token assets the flash leg
@@ -420,38 +465,50 @@ export function useLeverageQuote({
     return previewMintableLoanAssets ?? 0n;
   }, [
     route,
+    isPositionDebtInput,
+    safePositionDebtInputAmount,
+    swapExactLoanInputQuoteQuery.data?.flashLoanAssetAmount,
     isLoanAssetInput,
-    swapLoanInputCombinedQuoteQuery.data?.flashLoanAssetAmount,
     swapCollateralInputQuoteQuery.data?.flashLoanAssetAmount,
     previewMintableLoanAssets,
   ]);
 
   const totalCollateralTokenAmountAdded = useMemo(() => {
     if (!route) return 0n;
+    if (isPositionDebtInput) return flashLegCollateralTokenAmount;
     if (route.kind === 'swap') {
-      if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.totalCollateralTokenAmountAdded ?? 0n;
+      if (isLoanAssetInput) return swapExactLoanInputQuoteQuery.data?.totalCollateralTokenAmountAdded ?? 0n;
       return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
     }
     return initialCapitalCollateralTokenAmount + flashLegCollateralTokenAmount;
   }, [
     route,
+    isPositionDebtInput,
     isLoanAssetInput,
     initialCapitalCollateralTokenAmount,
     flashLegCollateralTokenAmount,
-    swapLoanInputCombinedQuoteQuery.data?.totalCollateralTokenAmountAdded,
+    swapExactLoanInputQuoteQuery.data?.totalCollateralTokenAmountAdded,
   ]);
 
   const swapPriceRoute = useMemo(() => {
     if (route?.kind !== 'swap') return null;
-    if (isLoanAssetInput) return swapLoanInputCombinedQuoteQuery.data?.priceRoute ?? null;
+    if (isPositionDebtInput || isLoanAssetInput) return swapExactLoanInputQuoteQuery.data?.priceRoute ?? null;
     return swapCollateralInputQuoteQuery.data?.priceRoute ?? null;
-  }, [route, isLoanAssetInput, swapLoanInputCombinedQuoteQuery.data?.priceRoute, swapCollateralInputQuoteQuery.data?.priceRoute]);
+  }, [
+    route,
+    isPositionDebtInput,
+    isLoanAssetInput,
+    swapExactLoanInputQuoteQuery.data?.priceRoute,
+    swapCollateralInputQuoteQuery.data?.priceRoute,
+  ]);
 
   const error = useMemo(() => {
     if (!route) return null;
     if (route.kind === 'swap') {
-      if (!userAddress && initialCapitalInputAmount > 0n) return 'Connect wallet to fetch swap-backed leverage route.';
-      const routeError = isLoanAssetInput ? swapLoanInputCombinedQuoteQuery.error : swapCollateralInputQuoteQuery.error;
+      if (!userAddress && (safeInitialCapitalInputAmount > 0n || safePositionDebtInputAmount > 0n)) {
+        return 'Connect wallet to fetch swap-backed leverage route.';
+      }
+      const routeError = isPositionDebtInput || isLoanAssetInput ? swapExactLoanInputQuoteQuery.error : swapCollateralInputQuoteQuery.error;
       if (!routeError) return null;
       return toUserFacingVeloraQuoteError({ error: routeError, action: 'leverage' });
     }
@@ -462,20 +519,39 @@ export function useLeverageQuote({
     route,
     swapExecutionAddress,
     userAddress,
-    initialCapitalInputAmount,
+    safeInitialCapitalInputAmount,
+    safePositionDebtInputAmount,
+    isPositionDebtInput,
     isLoanAssetInput,
-    swapLoanInputCombinedQuoteQuery.error,
+    swapExactLoanInputQuoteQuery.error,
     swapCollateralInputQuoteQuery.error,
     erc4626DepositError,
     erc4626MintError,
   ]);
 
-  const isLoading =
-    !!route &&
-    (route.kind === 'swap'
-      ? (isLoanAssetInput && (swapLoanInputCombinedQuoteQuery.isLoading || swapLoanInputCombinedQuoteQuery.isFetching)) ||
-        (!isLoanAssetInput && (swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching))
-      : isLoadingErc4626Deposit || isLoadingErc4626Mint);
+  const isLoading = useMemo(() => {
+    if (!route) return false;
+
+    if (route.kind !== 'swap') {
+      return isLoadingErc4626Deposit || isLoadingErc4626Mint;
+    }
+
+    if (isPositionDebtInput || isLoanAssetInput) {
+      return swapExactLoanInputQuoteQuery.isLoading || swapExactLoanInputQuoteQuery.isFetching;
+    }
+
+    return swapCollateralInputQuoteQuery.isLoading || swapCollateralInputQuoteQuery.isFetching;
+  }, [
+    route,
+    isLoadingErc4626Deposit,
+    isLoadingErc4626Mint,
+    isPositionDebtInput,
+    isLoanAssetInput,
+    swapExactLoanInputQuoteQuery.isLoading,
+    swapExactLoanInputQuoteQuery.isFetching,
+    swapCollateralInputQuoteQuery.isLoading,
+    swapCollateralInputQuoteQuery.isFetching,
+  ]);
 
   return {
     initialCapitalCollateralTokenAmount,

--- a/src/hooks/useLeverageTransaction.ts
+++ b/src/hooks/useLeverageTransaction.ts
@@ -80,7 +80,6 @@ export function useLeverageTransaction({
   const { address: account, chainId } = useConnection();
   const toast = useStyledToast();
   const isSwapRoute = route?.kind === 'swap';
-  const usePermit2ForRoute = usePermit2Setting;
 
   const bundlerAddress = useMemo<Address>(() => {
     if (route?.kind === 'swap') {
@@ -105,6 +104,8 @@ export function useLeverageTransaction({
   const initialCapitalInputTokenSymbol = initialCapitalUsesLoanAsset ? market.loanAsset.symbol : market.collateralAsset.symbol;
   const initialCapitalInputTokenDecimals = initialCapitalUsesLoanAsset ? market.loanAsset.decimals : market.collateralAsset.decimals;
   const initialCapitalTransferAmount = initialCapitalUsesLoanAsset ? initialCapitalInputAmount : initialCapitalCollateralTokenAmount;
+  const requiresInitialCapitalTransfer = initialCapitalTransferAmount > 0n;
+  const usePermit2ForRoute = usePermit2Setting && requiresInitialCapitalTransfer;
   const approvalSpender = route?.kind === 'swap' ? route.generalAdapterAddress : bundlerAddress;
 
   const {
@@ -142,10 +143,13 @@ export function useLeverageTransaction({
     tokenSymbol: initialCapitalInputTokenSymbol,
     chainId: market.morphoBlue.chain.id,
   });
+  const isApprovedForTransfer = !requiresInitialCapitalTransfer || isApproved;
 
   const { isConfirming: leveragePending, sendTransactionAsync } = useTransactionWithToast({
     toastId: 'leverage',
-    pendingText: `Leveraging ${formatBalance(initialCapitalInputAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`,
+    pendingText: requiresInitialCapitalTransfer
+      ? `Leveraging ${formatBalance(initialCapitalTransferAmount, initialCapitalInputTokenDecimals)} ${initialCapitalInputTokenSymbol}`
+      : `Increasing leverage on ${market.collateralAsset.symbol}`,
     successText: 'Leverage Executed',
     errorText: 'Failed to execute leverage',
     chainId,
@@ -160,15 +164,33 @@ export function useLeverageTransaction({
     () => ({
       title: 'Leverage',
       description: `${market.collateralAsset.symbol} leveraged using ${market.loanAsset.symbol} debt`,
-      tokenSymbol: initialCapitalInputTokenSymbol,
-      amount: initialCapitalInputAmount,
+      tokenSymbol: requiresInitialCapitalTransfer ? initialCapitalInputTokenSymbol : market.loanAsset.symbol,
+      amount: requiresInitialCapitalTransfer ? initialCapitalTransferAmount : flashLoanAssetAmount,
       marketId: market.uniqueKey,
     }),
-    [market.collateralAsset.symbol, market.loanAsset.symbol, initialCapitalInputTokenSymbol, initialCapitalInputAmount, market.uniqueKey],
+    [
+      market.collateralAsset.symbol,
+      market.loanAsset.symbol,
+      initialCapitalInputTokenSymbol,
+      requiresInitialCapitalTransfer,
+      initialCapitalTransferAmount,
+      flashLoanAssetAmount,
+      market.uniqueKey,
+    ],
   );
 
   const getStepsForFlow = useCallback(
     (isPermit2: boolean, isSwap: boolean) => {
+      const approvalStep = requiresInitialCapitalTransfer
+        ? [
+            {
+              id: 'approve_token' as const,
+              title: `Approve ${initialCapitalInputTokenSymbol}`,
+              description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
+            },
+          ]
+        : [];
+
       if (isSwap && isPermit2) {
         return [
           {
@@ -201,11 +223,7 @@ export function useLeverageTransaction({
             title: 'Authorize Morpho Adapter',
             description: 'Submit one transaction authorizing Morpho adapter actions on your position.',
           },
-          {
-            id: 'approve_token',
-            title: `Approve ${initialCapitalInputTokenSymbol}`,
-            description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
-          },
+          ...approvalStep,
           {
             id: 'execute',
             title: 'Confirm Leverage',
@@ -245,11 +263,7 @@ export function useLeverageTransaction({
           title: 'Authorize Morpho Bundler',
           description: 'Submit one transaction authorizing bundler actions on your Morpho position.',
         },
-        {
-          id: 'approve_token',
-          title: `Approve ${initialCapitalInputTokenSymbol}`,
-          description: `Approve ${initialCapitalInputTokenSymbol} transfer for the leverage flow.`,
-        },
+        ...approvalStep,
         {
           id: 'execute',
           title: 'Confirm Leverage',
@@ -257,7 +271,7 @@ export function useLeverageTransaction({
         },
       ];
     },
-    [initialCapitalInputTokenSymbol],
+    [initialCapitalInputTokenSymbol, requiresInitialCapitalTransfer],
   );
 
   const getLeverageExecutionPreflight = useCallback((): LeverageExecutionPreflight | null => {
@@ -273,8 +287,10 @@ export function useLeverageTransaction({
 
     const hasCollateralOutput =
       route.kind === 'swap' && initialCapitalUsesLoanAsset ? totalCollateralTokenAmountAdded > 0n : flashLegCollateralTokenAmount > 0n;
-    if (initialCapitalInputAmount <= 0n || flashLoanAssetAmount <= 0n || !hasCollateralOutput) {
-      toast.info('Invalid leverage inputs', 'Set initial capital and multiplier above 1x before submitting.');
+    // Existing-position leverage has no wallet transfer. The executable invariant is still the same
+    // flash-loan loop: positive debt input plus positive collateral output.
+    if (flashLoanAssetAmount <= 0n || !hasCollateralOutput) {
+      toast.info('Invalid leverage inputs', 'Set leverage inputs above zero before submitting.');
       return null;
     }
     if (collateralAssetPriceUsd == null || !Number.isFinite(collateralAssetPriceUsd) || collateralAssetPriceUsd <= 0) {
@@ -318,7 +334,6 @@ export function useLeverageTransaction({
     initialCapitalUsesLoanAsset,
     totalCollateralTokenAmountAdded,
     flashLegCollateralTokenAmount,
-    initialCapitalInputAmount,
     flashLoanAssetAmount,
     collateralAssetPriceUsd,
     market.collateralAsset.decimals,
@@ -361,7 +376,7 @@ export function useLeverageTransaction({
           authorizePermit2,
           ensureBundlerAuthorization,
           signForBundlers,
-          isApproved,
+          isApproved: isApprovedForTransfer,
           approve,
           updateStep: execution.updateStep,
           sendTransactionAsync,
@@ -387,7 +402,7 @@ export function useLeverageTransaction({
           authorizePermit2,
           ensureBundlerAuthorization,
           signForBundlers,
-          isApproved,
+          isApproved: isApprovedForTransfer,
           approve,
           updateStep: execution.updateStep,
           sendTransactionAsync,
@@ -412,7 +427,7 @@ export function useLeverageTransaction({
       authorizePermit2,
       ensureBundlerAuthorization,
       signForBundlers,
-      isApproved,
+      isApprovedForTransfer,
       approve,
       sendTransactionAsync,
     ],
@@ -492,7 +507,7 @@ export function useLeverageTransaction({
           : 'authorize_bundler_sig'
         : 'approve_permit2'
       : isBundlerAuthorized
-        ? isApproved
+        ? isApprovedForTransfer
           ? 'execute'
           : 'approve_token'
         : 'authorize_bundler_tx';
@@ -503,7 +518,7 @@ export function useLeverageTransaction({
       errorTitle: 'Error',
       logLabel: 'approveAndLeverage',
     });
-  }, [usePermit2ForRoute, permit2Authorized, isBundlerAuthorized, isApproved, runLeverageFlow]);
+  }, [usePermit2ForRoute, permit2Authorized, isBundlerAuthorized, isApprovedForTransfer, runLeverageFlow]);
 
   const signAndLeverage = useCallback(async () => {
     if (!usePermit2ForRoute) {

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { erc20Abi, formatUnits } from 'viem';
 import { useConnection, useReadContract } from 'wagmi';
 import { BorrowPositionRiskCard } from '@/modals/borrow/components/borrow-position-risk-card';
 import { PreviewSectionHeader } from '@/modals/borrow/components/preview-section-header';
-import { LTV_WAD, computeLtv } from '@/modals/borrow/components/helpers';
+import { LTV_WAD, computeLtv, getCollateralValueInLoan } from '@/modals/borrow/components/helpers';
 import { HelpTooltipIcon } from '@/components/shared/help-tooltip-icon';
 import { RateFormatted } from '@/components/shared/rate-formatted';
 import { TooltipContent as SharedTooltipContent } from '@/components/shared/tooltip-content';
@@ -14,8 +14,10 @@ import { ExecuteTransactionButton } from '@/components/ui/ExecuteTransactionButt
 import { IconSwitch } from '@/components/ui/icon-switch';
 import { Tooltip } from '@/components/ui/tooltip';
 import {
+  BPS_SCALE,
   clampTargetLtvBps,
   clampMultiplierBps,
+  computeDebtAdjustmentForTargetLtv,
   computeMaxMultiplierBpsForTargetLtv,
   convertVaultSharesToUnderlyingAssets,
   computeLeverageProjectedPosition,
@@ -25,6 +27,7 @@ import {
   parseUnsignedBigInt,
   toScaledRatio,
   targetLtvBpsFromMultiplier,
+  WAD_TO_BPS_SCALE,
 } from '@/hooks/leverage/math';
 import { LEVERAGE_DEFAULT_MULTIPLIER_BPS } from '@/hooks/leverage/types';
 import { useMerklHoldIncentivesQuery } from '@/hooks/queries/useMerklHoldIncentivesQuery';
@@ -49,11 +52,13 @@ type AddCollateralAndLeverageProps = {
   currentPosition: MarketPosition | null;
   collateralTokenBalance: bigint | undefined;
   oraclePrice: bigint;
+  defaultLeverageSource?: 'wallet' | 'position';
   onSuccess?: () => void;
   isRefreshing?: boolean;
 };
 
 const LEVERAGE_SAFE_LTV_BUFFER_BPS = 100n; // keep a 1% buffer below liquidation LTV
+const LEVERAGE_FEE_BUFFER_BPS = 1n; // fee is 0.75 bps, rounded up for target-LTV sizing
 const TARGET_INPUT_DEBOUNCE_MS = 300;
 const INLINE_VALUE_TOOLTIP_CLASS_NAME = 'px-4 py-3 text-xs';
 
@@ -63,6 +68,7 @@ export function AddCollateralAndLeverage({
   currentPosition,
   collateralTokenBalance,
   oraclePrice,
+  defaultLeverageSource = 'wallet',
   onSuccess,
   isRefreshing = false,
 }: AddCollateralAndLeverageProps): JSX.Element {
@@ -90,6 +96,33 @@ export function AddCollateralAndLeverage({
   const [targetMultiplierBps, setTargetMultiplierBps] = useState<bigint>(defaultMultiplierBps);
   const [targetLtvIntentBps, setTargetLtvIntentBps] = useState<bigint>(defaultTargetLtvIntentBps);
   const [swapSlippagePercent, setSwapSlippagePercent] = useState<number>(DEFAULT_SLIPPAGE_PERCENT);
+  const [leverageSource, setLeverageSource] = useState<'wallet' | 'position'>(defaultLeverageSource);
+  const previousUseExistingPositionSourceRef = useRef(false);
+  const hasSyncedPositionTargetRef = useRef(false);
+
+  const currentCollateralAssetsRaw = parseUnsignedBigInt(currentPosition?.state.collateral);
+  const currentBorrowAssetsRaw = parseUnsignedBigInt(currentPosition?.state.borrowAssets);
+  const currentCollateralAssets = currentCollateralAssetsRaw ?? 0n;
+  const currentBorrowAssets = currentBorrowAssetsRaw ?? 0n;
+  const canLoopExistingPosition = currentCollateralAssets > 0n;
+  const selectedLeverageSource = canLoopExistingPosition ? leverageSource : 'wallet';
+  const useExistingPositionSource = selectedLeverageSource === 'position';
+  const hasInvalidExistingPositionData =
+    useExistingPositionSource && (currentCollateralAssetsRaw == null || currentBorrowAssetsRaw == null);
+  const currentCollateralValueInLoan = useMemo(
+    () => getCollateralValueInLoan(currentCollateralAssets, oraclePrice),
+    [currentCollateralAssets, oraclePrice],
+  );
+  const currentLTV = useMemo(
+    () =>
+      computeLtv({
+        borrowAssets: currentBorrowAssets,
+        collateralAssets: currentCollateralAssets,
+        oraclePrice,
+      }),
+    [currentBorrowAssets, currentCollateralAssets, oraclePrice],
+  );
+  const currentLtvBps = useMemo(() => ltvWadToBps(currentLTV), [currentLTV]);
 
   const multiplierBps = useMemo(() => clampMultiplierBps(targetMultiplierBps, maxMultiplierBps), [targetMultiplierBps, maxMultiplierBps]);
   const targetLtvBps = useMemo(
@@ -97,9 +130,28 @@ export function AddCollateralAndLeverage({
     [multiplierBps, maxTargetLtvBps],
   );
   const swapSlippageBps = useMemo(() => slippagePercentToBps(swapSlippagePercent), [swapSlippagePercent]);
+  const positionCollateralValueFactorBps = useMemo(() => {
+    const roundedSlippageBps = BigInt(Math.max(0, Math.ceil(swapSlippageBps)));
+    const factorBps = BPS_SCALE - roundedSlippageBps - LEVERAGE_FEE_BUFFER_BPS;
+    return factorBps > 0n ? factorBps : 0n;
+  }, [swapSlippageBps]);
+  const targetLtvWad = useMemo(() => targetLtvIntentBps * WAD_TO_BPS_SCALE, [targetLtvIntentBps]);
+  const positionTargetDebtAdjustment = useMemo(
+    () =>
+      computeDebtAdjustmentForTargetLtv({
+        collateralValueFactorBps: positionCollateralValueFactorBps,
+        currentBorrowAssets,
+        currentCollateralValueInLoan,
+        targetLtv: targetLtvWad,
+      }),
+    [currentBorrowAssets, currentCollateralValueInLoan, positionCollateralValueFactorBps, targetLtvWad],
+  );
+  const positionDebtInputAmount =
+    useExistingPositionSource && positionTargetDebtAdjustment.direction === 'increase' ? positionTargetDebtAdjustment.amount : 0n;
   const isErc4626Route = route?.kind === 'erc4626';
   const isSwapRoute = route?.kind === 'swap';
   const canUseLoanAssetInput = isErc4626Route || isSwapRoute;
+  const useLoanAssetInputForTransaction = !useExistingPositionSource && useLoanAssetInput;
 
   const { data: loanTokenBalance, refetch: refetchLoanTokenBalance } = useReadContract({
     address: market.loanAsset.address as `0x${string}`,
@@ -108,12 +160,12 @@ export function AddCollateralAndLeverage({
     abi: erc20Abi,
     chainId: market.morphoBlue.chain.id,
     query: {
-      enabled: !!account && useLoanAssetInput,
+      enabled: !!account && useLoanAssetInputForTransaction,
     },
   });
 
   useEffect(() => {
-    // The initial-capital field flips between loan-asset units and collateral-token units.
+    // The amount field flips between collateral-token, loan-token, and loop-more debt units.
     setInitialCapitalInputAmount(0n);
     setInitialCapitalInputError(null);
   }, [useLoanAssetInput]);
@@ -122,6 +174,31 @@ export function AddCollateralAndLeverage({
     if (canUseLoanAssetInput) return;
     setUseLoanAssetInput(false);
   }, [canUseLoanAssetInput]);
+
+  useEffect(() => {
+    const sourceChanged = previousUseExistingPositionSourceRef.current !== useExistingPositionSource;
+    previousUseExistingPositionSourceRef.current = useExistingPositionSource;
+
+    if (!useExistingPositionSource) {
+      hasSyncedPositionTargetRef.current = false;
+      if (sourceChanged) {
+        setInitialCapitalInputAmount(0n);
+        setInitialCapitalInputError(null);
+      }
+      return;
+    }
+
+    if (sourceChanged) {
+      setUseLoanAssetInput(false);
+      setInitialCapitalInputAmount(0n);
+      setInitialCapitalInputError(null);
+    }
+
+    if (!hasSyncedPositionTargetRef.current && currentCollateralValueInLoan > 0n) {
+      setTargetLtvIntentBps(clampTargetLtvBps(currentLtvBps, maxTargetLtvBps));
+      hasSyncedPositionTargetRef.current = true;
+    }
+  }, [useExistingPositionSource, currentCollateralValueInLoan, currentLtvBps, maxTargetLtvBps]);
 
   useEffect(() => {
     const clampedMultiplier = clampMultiplierBps(targetMultiplierBps, maxMultiplierBps);
@@ -140,7 +217,8 @@ export function AddCollateralAndLeverage({
     chainId: market.morphoBlue.chain.id,
     route,
     initialCapitalInputAmount,
-    inputMode: useLoanAssetInput ? 'loan' : 'collateral',
+    positionDebtInputAmount: useExistingPositionSource ? (hasInvalidExistingPositionData ? 0n : positionDebtInputAmount) : undefined,
+    inputMode: useLoanAssetInputForTransaction ? 'loan' : 'collateral',
     multiplierBps,
     loanTokenAddress: market.loanAsset.address,
     loanTokenDecimals: market.loanAsset.decimals,
@@ -150,8 +228,6 @@ export function AddCollateralAndLeverage({
     slippageBps: swapSlippageBps,
   });
 
-  const currentCollateralAssets = BigInt(currentPosition?.state.collateral ?? 0);
-  const currentBorrowAssets = BigInt(currentPosition?.state.borrowAssets ?? 0);
   const hasQuoteChanges = quote.totalCollateralTokenAmountAdded > 0n && quote.flashLoanAssetAmount > 0n;
   const collateralAssetPriceUsd = useMemo(() => {
     const totalCollateralAssets = BigInt(market.state.collateralAssets);
@@ -239,16 +315,6 @@ export function AddCollateralAndLeverage({
     [projectedBorrowAssets, projectedCollateralAssets, oraclePrice],
   );
 
-  const currentLTV = useMemo(
-    () =>
-      computeLtv({
-        borrowAssets: currentBorrowAssets,
-        collateralAssets: currentCollateralAssets,
-        oraclePrice,
-      }),
-    [currentBorrowAssets, currentCollateralAssets, oraclePrice],
-  );
-
   const syncInputFieldsFromMultiplier = useCallback(
     (nextMultiplierBps: bigint) => {
       const clampedMultiplier = clampMultiplierBps(nextMultiplierBps, maxMultiplierBps);
@@ -261,14 +327,24 @@ export function AddCollateralAndLeverage({
 
   const handleTransactionSuccess = useCallback(() => {
     // WHY: after a confirmed leverage tx, reset drafts so the panel reflects refreshed onchain position state.
+    if (useExistingPositionSource) {
+      hasSyncedPositionTargetRef.current = false;
+    }
     setInitialCapitalInputAmount(0n);
     setInitialCapitalInputError(null);
     syncInputFieldsFromMultiplier(defaultMultiplierBps);
-    if (useLoanAssetInput) {
+    if (useLoanAssetInputForTransaction) {
       void refetchLoanTokenBalance();
     }
     if (onSuccess) onSuccess();
-  }, [defaultMultiplierBps, onSuccess, refetchLoanTokenBalance, syncInputFieldsFromMultiplier, useLoanAssetInput]);
+  }, [
+    defaultMultiplierBps,
+    onSuccess,
+    refetchLoanTokenBalance,
+    syncInputFieldsFromMultiplier,
+    useExistingPositionSource,
+    useLoanAssetInputForTransaction,
+  ]);
 
   const {
     transaction,
@@ -288,7 +364,7 @@ export function AddCollateralAndLeverage({
     totalCollateralTokenAmountAdded: quote.totalCollateralTokenAmountAdded,
     collateralAssetPriceUsd,
     swapPriceRoute: quote.swapPriceRoute,
-    useLoanAssetInput,
+    useLoanAssetInput: useLoanAssetInputForTransaction,
     slippageBps: swapSlippageBps,
     onSuccess: handleTransactionSuccess,
   });
@@ -317,11 +393,12 @@ export function AddCollateralAndLeverage({
   }, [isLeverageFeeReady, usePermit2Setting, permit2Authorized, signAndLeverage, approveAndLeverage]);
 
   const projectedOverLimit = projectedLTV >= lltv;
+  const positionProjectedAboveTarget = useExistingPositionSource && isLeverageFeeReady && projectedLTV > targetLtvWad + WAD_TO_BPS_SCALE;
   const insufficientLiquidity = quote.flashLoanAssetAmount > marketLiquidity;
-  const inputAssetSymbol = useLoanAssetInput ? market.loanAsset.symbol : market.collateralAsset.symbol;
-  const inputAssetDecimals = useLoanAssetInput ? market.loanAsset.decimals : market.collateralAsset.decimals;
-  const inputAssetBalance = useLoanAssetInput ? (loanTokenBalance as bigint | undefined) : collateralTokenBalance;
-  const inputTokenIconAddress = useLoanAssetInput ? market.loanAsset.address : market.collateralAsset.address;
+  const inputAssetSymbol = useLoanAssetInputForTransaction ? market.loanAsset.symbol : market.collateralAsset.symbol;
+  const inputAssetDecimals = useLoanAssetInputForTransaction ? market.loanAsset.decimals : market.collateralAsset.decimals;
+  const inputAssetBalance = useLoanAssetInputForTransaction ? (loanTokenBalance as bigint | undefined) : collateralTokenBalance;
+  const inputTokenIconAddress = useLoanAssetInputForTransaction ? market.loanAsset.address : market.collateralAsset.address;
   const flashBorrowPreview = useMemo(
     () => formatTokenAmountPreview(quote.flashLoanAssetAmount, market.loanAsset.decimals),
     [quote.flashLoanAssetAmount, market.loanAsset.decimals],
@@ -346,20 +423,33 @@ export function AddCollateralAndLeverage({
     () => formatTokenAmountPreview(quote.flashLegCollateralTokenAmount, market.collateralAsset.decimals),
     [quote.flashLegCollateralTokenAmount, market.collateralAsset.decimals],
   );
-  const collateralPreviewForDisplay = isSwapRoute && !useLoanAssetInput ? swapCollateralOutPreview : totalCollateralAddedPreview;
-  const collateralPreviewLabel = isSwapRoute
-    ? useLoanAssetInput
-      ? 'Total Collateral Added (Min.)'
-      : 'Collateral From Swap (Min.)'
-    : isErc4626Route
-      ? 'Total Collateral Added (Min.)'
-      : 'Total Collateral Added';
+  const collateralPreviewForDisplay =
+    isSwapRoute && !useLoanAssetInputForTransaction ? swapCollateralOutPreview : totalCollateralAddedPreview;
+  const collateralPreviewLabel = useExistingPositionSource
+    ? isSwapRoute
+      ? 'Collateral From Loop (Min.)'
+      : 'Collateral Added (Min.)'
+    : isSwapRoute
+      ? useLoanAssetInputForTransaction
+        ? 'Total Collateral Added (Min.)'
+        : 'Collateral From Swap (Min.)'
+      : isErc4626Route
+        ? 'Total Collateral Added (Min.)'
+        : 'Total Collateral Added';
   const hasExecutableInitialCapitalConversion = useMemo(() => {
-    if (!useLoanAssetInput) return true;
+    if (useExistingPositionSource) return true;
+    if (!useLoanAssetInputForTransaction) return true;
     if (isSwapRoute) return quote.totalCollateralTokenAmountAdded > 0n;
     if (isErc4626Route) return quote.initialCapitalCollateralTokenAmount > 0n;
     return false;
-  }, [useLoanAssetInput, isSwapRoute, isErc4626Route, quote.totalCollateralTokenAmountAdded, quote.initialCapitalCollateralTokenAmount]);
+  }, [
+    useExistingPositionSource,
+    useLoanAssetInputForTransaction,
+    isSwapRoute,
+    isErc4626Route,
+    quote.totalCollateralTokenAmountAdded,
+    quote.initialCapitalCollateralTokenAmount,
+  ]);
   const swapRatePreviewText = useMemo(() => {
     if (!isSwapRoute || !quote.swapPriceRoute) return null;
 
@@ -495,7 +585,7 @@ export function AddCollateralAndLeverage({
   const contributedCapitalAssets = useMemo(() => {
     if (addedCollateralAssets <= 0n) return null;
 
-    if (isSwapRoute && useLoanAssetInput) {
+    if (isSwapRoute && useLoanAssetInputForTransaction) {
       const totalLoanInput = initialCapitalInputAmount + addedBorrowAssets;
       if (totalLoanInput <= 0n) return null;
 
@@ -515,7 +605,7 @@ export function AddCollateralAndLeverage({
     isSwapRoute,
     quote.initialCapitalCollateralTokenAmount,
     quote.totalCollateralTokenAmountAdded,
-    useLoanAssetInput,
+    useLoanAssetInputForTransaction,
   ]);
   const holdRewardsApy = useMemo(() => {
     const holdRewardAprDecimal = merklHoldIncentives.holdRewardAprDecimal;
@@ -594,13 +684,17 @@ export function AddCollateralAndLeverage({
     if (previewLeveredCarryOnCapitalRate == null) return 'text-secondary';
     return previewLeveredCarryOnCapitalRate >= 0 ? 'text-emerald-500' : 'text-red-500';
   }, [previewLeveredCarryOnCapitalRate]);
+  const hasRequiredInput = useExistingPositionSource
+    ? positionDebtInputAmount > 0n && !hasInvalidExistingPositionData
+    : initialCapitalInputAmount > 0n && initialCapitalInputError === null;
+  const positionTargetNeedsDeleverage = useExistingPositionSource && positionTargetDebtAdjustment.direction === 'decrease';
 
   return (
     <div className="bg-surface relative w-full max-w-lg rounded-lg">
       {!transaction?.isModalVisible && (
         <div className="flex flex-col">
           <PreviewSectionHeader
-            title="Leverage Preview"
+            title={useExistingPositionSource ? 'Increase LTV Preview' : 'Leverage Preview'}
             onRefresh={onSuccess}
             isRefreshing={isRefreshing}
           />
@@ -619,102 +713,146 @@ export function AddCollateralAndLeverage({
           />
 
           <div className="mt-2 space-y-3">
-            <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Initial Capital</p>
-                {canUseLoanAssetInput && (
-                  <div className="flex items-center gap-2">
-                    <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
-                    <IconSwitch
-                      size="sm"
-                      selected={useLoanAssetInput}
-                      onChange={setUseLoanAssetInput}
-                      thumbIcon={null}
-                      classNames={{
-                        wrapper: 'mr-0 h-4 w-9',
-                        thumb: 'h-3 w-3',
-                      }}
-                    />
-                  </div>
-                )}
+            {canLoopExistingPosition && (
+              <div className="grid grid-cols-2 gap-1 rounded border border-white/10 bg-hovered p-1">
+                {[
+                  { value: 'wallet', label: 'Add Capital' },
+                  { value: 'position', label: 'Loop More' },
+                ].map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selectedLeverageSource === option.value}
+                    onClick={() => setLeverageSource(option.value as 'wallet' | 'position')}
+                    className={
+                      selectedLeverageSource === option.value
+                        ? 'rounded bg-surface px-3 py-2 text-sm text-primary shadow-sm transition-colors'
+                        : 'rounded px-3 py-2 text-sm text-secondary transition-colors hover:bg-surface/60 hover:text-primary'
+                    }
+                  >
+                    {option.label}
+                  </button>
+                ))}
               </div>
-              <Input
-                decimals={inputAssetDecimals}
-                max={inputAssetBalance}
-                setValue={setInitialCapitalInputAmount}
-                setError={setInitialCapitalInputError}
-                exceedMaxErrMessage="Insufficient Balance"
-                value={initialCapitalInputAmount}
-                inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
-                endAdornment={
-                  <TokenIcon
-                    address={inputTokenIconAddress}
-                    chainId={market.morphoBlue.chain.id}
-                    symbol={inputAssetSymbol}
-                    width={16}
-                    height={16}
-                  />
-                }
-              />
-              <div className="mt-1 flex items-start gap-3 text-xs">
-                {initialCapitalInputError && <p className="text-red-500">{initialCapitalInputError}</p>}
-                <span className="ml-auto text-right text-secondary">
-                  Balance: {formatBalance(inputAssetBalance ?? 0n, inputAssetDecimals)} {inputAssetSymbol}
-                </span>
-              </div>
-            </div>
+            )}
 
-            <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">
-                  {useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}
-                </p>
-                <div className="flex items-center gap-2">
-                  <div className="text-xs text-secondary">Use LTV</div>
-                  <IconSwitch
-                    size="sm"
-                    selected={useTargetLtvInput}
-                    onChange={handleTargetInputModeChange}
-                    thumbIcon={null}
-                    classNames={{
-                      wrapper: 'mr-0 h-4 w-9',
-                      thumb: 'h-3 w-3',
-                    }}
-                  />
+            {useExistingPositionSource ? (
+              <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+                <p className="mb-1 font-monospace text-[11px] uppercase tracking-[0.12em] text-secondary">Target LTV</p>
+                <Input
+                  decimals={2}
+                  setValue={(nextTargetLtvBps) => setTargetLtvIntentBps(clampTargetLtvBps(nextTargetLtvBps, maxTargetLtvBps))}
+                  value={targetLtvIntentBps}
+                  inputClassName="h-10 rounded bg-surface px-3 py-2 pr-10 text-base font-medium tabular-nums"
+                  endAdornment={<span className="text-xs text-secondary">%</span>}
+                  debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
+                />
+                <div className="mt-1 flex items-start gap-3 text-xs">
+                  <span className="ml-auto text-right text-secondary">Current: {(Number(ltvWadToBps(currentLTV)) / 100).toFixed(2)}%</span>
                 </div>
               </div>
-              <div className="relative min-w-0">
-                {useTargetLtvInput ? (
+            ) : (
+              <>
+                <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">Add Capital</p>
+                    {canUseLoanAssetInput && (
+                      <div className="flex items-center gap-2">
+                        <div className="text-xs text-secondary">Use {market.loanAsset.symbol}</div>
+                        <IconSwitch
+                          size="sm"
+                          selected={useLoanAssetInput}
+                          onChange={setUseLoanAssetInput}
+                          thumbIcon={null}
+                          classNames={{
+                            wrapper: 'mr-0 h-4 w-9',
+                            thumb: 'h-3 w-3',
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
                   <Input
-                    decimals={2}
-                    setValue={(nextTargetLtvBps) => {
-                      const clampedTargetLtvBps = clampTargetLtvBps(nextTargetLtvBps, maxTargetLtvBps);
-                      setTargetLtvIntentBps(clampedTargetLtvBps);
-                      setTargetMultiplierBps(multiplierBpsFromTargetLtv(clampedTargetLtvBps, maxMultiplierBps));
-                    }}
-                    value={targetLtvIntentBps}
-                    inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
-                    endAdornment={<span className="text-xs text-secondary">%</span>}
-                    debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
+                    decimals={inputAssetDecimals}
+                    max={inputAssetBalance}
+                    setValue={setInitialCapitalInputAmount}
+                    setError={setInitialCapitalInputError}
+                    exceedMaxErrMessage="Insufficient Balance"
+                    value={initialCapitalInputAmount}
+                    inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
+                    endAdornment={
+                      <TokenIcon
+                        address={inputTokenIconAddress}
+                        chainId={market.morphoBlue.chain.id}
+                        symbol={inputAssetSymbol}
+                        width={16}
+                        height={16}
+                      />
+                    }
                   />
-                ) : (
-                  <Input
-                    decimals={4}
-                    setValue={syncInputFieldsFromMultiplier}
-                    value={multiplierBps}
-                    inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
-                    endAdornment={<span className="text-xs text-secondary">x</span>}
-                    debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
-                  />
-                )}
-              </div>
-            </div>
+                  <div className="mt-1 flex items-start gap-3 text-xs">
+                    {initialCapitalInputError && <p className="text-red-500">{initialCapitalInputError}</p>}
+                    <span className="ml-auto text-right text-secondary">
+                      Balance: {formatBalance(inputAssetBalance ?? 0n, inputAssetDecimals)} {inputAssetSymbol}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <p className="text-[11px] uppercase tracking-[0.12em] text-secondary">
+                      {useTargetLtvInput ? 'Target LTV' : 'Target Multiplier'}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <div className="text-xs text-secondary">Use LTV</div>
+                      <IconSwitch
+                        size="sm"
+                        selected={useTargetLtvInput}
+                        onChange={handleTargetInputModeChange}
+                        thumbIcon={null}
+                        classNames={{
+                          wrapper: 'mr-0 h-4 w-9',
+                          thumb: 'h-3 w-3',
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className="relative min-w-0">
+                    {useTargetLtvInput ? (
+                      <Input
+                        decimals={2}
+                        setValue={(nextTargetLtvBps) => {
+                          const clampedTargetLtvBps = clampTargetLtvBps(nextTargetLtvBps, maxTargetLtvBps);
+                          setTargetLtvIntentBps(clampedTargetLtvBps);
+                          setTargetMultiplierBps(multiplierBpsFromTargetLtv(clampedTargetLtvBps, maxMultiplierBps));
+                        }}
+                        value={targetLtvIntentBps}
+                        inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
+                        endAdornment={<span className="text-xs text-secondary">%</span>}
+                        debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
+                      />
+                    ) : (
+                      <Input
+                        decimals={4}
+                        setValue={syncInputFieldsFromMultiplier}
+                        value={multiplierBps}
+                        inputClassName="h-10 rounded bg-hovered px-3 py-2 pr-10 text-base font-medium tabular-nums"
+                        endAdornment={<span className="text-xs text-secondary">x</span>}
+                        debounceSetValueMs={TARGET_INPUT_DEBOUNCE_MS}
+                      />
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
 
             <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
               <p className="mb-2 text-[11px] uppercase tracking-[0.12em] text-secondary">Transaction Preview</p>
               <div className="space-y-1 text-xs">
                 <div className="flex items-center justify-between">
-                  <span className="text-secondary">{isSwapRoute ? 'Flash Borrow Required' : 'Flash Borrow'}</span>
+                  <span className="text-secondary">
+                    {useExistingPositionSource ? 'Borrow More' : isSwapRoute ? 'Flash Borrow Required' : 'Flash Borrow'}
+                  </span>
                   <span className="tabular-nums inline-flex items-center gap-1.5">
                     <Tooltip content={<span className="text-xs">{flashBorrowPreview.full}</span>}>
                       <span className="cursor-help border-b border-dotted border-white/40">{flashBorrowPreview.compact}</span>
@@ -846,31 +984,40 @@ export function AddCollateralAndLeverage({
                             {isNetRateLoading ? '...' : renderRateFromDisplayMode(previewExpectedNetRate)}
                           </span>
                         </div>
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-0.5">
-                            <span className="text-secondary">{leveredCarryLabel}</span>
-                            <HelpTooltipIcon
-                              content={
-                                <SharedTooltipContent
-                                  title={leveredCarryLabel}
-                                  detail={leveredCarryDetail}
-                                  secondaryDetail={leveredCarrySecondaryDetail}
-                                />
-                              }
-                              ariaLabel={`Explain ${leveredCarryLabel}`}
-                              className="h-auto w-auto"
-                            />
+                        {!useExistingPositionSource && (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-0.5">
+                              <span className="text-secondary">{leveredCarryLabel}</span>
+                              <HelpTooltipIcon
+                                content={
+                                  <SharedTooltipContent
+                                    title={leveredCarryLabel}
+                                    detail={leveredCarryDetail}
+                                    secondaryDetail={leveredCarrySecondaryDetail}
+                                  />
+                                }
+                                ariaLabel={`Explain ${leveredCarryLabel}`}
+                                className="h-auto w-auto"
+                              />
+                            </div>
+                            <span className={`tabular-nums ${leveredCarryRateClass}`}>
+                              {isLeveredCarryLoading ? '...' : renderRateFromDisplayMode(previewLeveredCarryOnCapitalRate)}
+                            </span>
                           </div>
-                          <span className={`tabular-nums ${leveredCarryRateClass}`}>
-                            {isLeveredCarryLoading ? '...' : renderRateFromDisplayMode(previewLeveredCarryOnCapitalRate)}
-                          </span>
-                        </div>
+                        )}
                       </>
                     )}
                   </>
                 )}
               </div>
               {quote.error && <p className="mt-2 text-xs text-red-500">{quote.error}</p>}
+              {hasInvalidExistingPositionData && (
+                <p className="mt-2 text-xs text-red-500">Unable to read valid position data. Refresh balances and try again.</p>
+              )}
+              {positionTargetNeedsDeleverage && <p className="mt-2 text-xs text-red-500">Target LTV is below current position LTV.</p>}
+              {positionProjectedAboveTarget && (
+                <p className="mt-2 text-xs text-red-500">Projected LTV is above target after route quote. Lower the target or refresh.</p>
+              )}
               {!quote.error && leverageFeeReadinessError && <p className="mt-2 text-xs text-red-500">{leverageFeeReadinessError}</p>}
               {isErc4626Route && vaultRateInsight.error && (
                 <p className="mt-2 text-xs text-red-500">Failed to fetch 3-day vault/borrow rates: {vaultRateInsight.error}</p>
@@ -895,20 +1042,20 @@ export function AddCollateralAndLeverage({
                 isLoading={isLoadingPermit2 || leveragePending || quote.isLoading}
                 disabled={
                   route == null ||
-                  initialCapitalInputError !== null ||
+                  !hasRequiredInput ||
                   quote.error !== null ||
-                  initialCapitalInputAmount <= 0n ||
                   !isBundlerAuthorizationReady ||
                   !hasExecutableInitialCapitalConversion ||
                   !isLeverageFeeReady ||
                   quote.flashLoanAssetAmount <= 0n ||
+                  positionProjectedAboveTarget ||
                   projectedOverLimit ||
                   insufficientLiquidity
                 }
                 variant="primary"
                 className="min-w-32"
               >
-                Leverage
+                {useExistingPositionSource ? 'Increase LTV' : 'Leverage'}
               </ExecuteTransactionButton>
             </div>
 

--- a/src/modals/leverage/components/remove-collateral-and-deleverage.tsx
+++ b/src/modals/leverage/components/remove-collateral-and-deleverage.tsx
@@ -8,12 +8,28 @@ import { TokenIcon } from '@/components/shared/token-icon';
 import { SlippageInlineEditor } from '@/features/swap/components/SlippageInlineEditor';
 import { DEFAULT_SLIPPAGE_PERCENT, slippagePercentToBps } from '@/features/swap/constants';
 import { formatSwapRatePreview } from '@/features/swap/utils/quote-preview';
-import { computeDeleverageProjectedPosition, formatTokenAmountPreview, parseUnsignedBigInt } from '@/hooks/leverage/math';
+import {
+  clampTargetLtvBps,
+  computeDebtAdjustmentForTargetLtv,
+  computeDeleverageProjectedPosition,
+  formatTokenAmountPreview,
+  ltvWadToBps,
+  parseUnsignedBigInt,
+  WAD_TO_BPS_SCALE,
+  withSlippageInverseCeil,
+} from '@/hooks/leverage/math';
 import { useDeleverageQuote } from '@/hooks/useDeleverageQuote';
 import { useDeleverageTransaction } from '@/hooks/useDeleverageTransaction';
 import type { Market, MarketPosition } from '@/utils/types';
 import type { LeverageRoute } from '@/hooks/leverage/types';
-import { computeLtv, formatLtvPercent, getLTVColor } from '@/modals/borrow/components/helpers';
+import {
+  computeLtv,
+  computeRequiredCollateralAssets,
+  formatLtvPercent,
+  getCollateralValueInLoan,
+  getLTVColor,
+  LTV_WAD,
+} from '@/modals/borrow/components/helpers';
 import { BorrowPositionRiskCard } from '@/modals/borrow/components/borrow-position-risk-card';
 import { PreviewSectionHeader } from '@/modals/borrow/components/preview-section-header';
 
@@ -36,9 +52,8 @@ export function RemoveCollateralAndDeleverage({
 }: RemoveCollateralAndDeleverageProps): JSX.Element {
   const { address: account } = useConnection();
   const isSwapRoute = route?.kind === 'swap';
-  const [withdrawCollateralAmount, setWithdrawCollateralAmount] = useState<bigint>(0n);
+  const [targetLtvBps, setTargetLtvBps] = useState<bigint | null>(null);
   const [swapSlippagePercent, setSwapSlippagePercent] = useState<number>(DEFAULT_SLIPPAGE_PERCENT);
-  const [withdrawInputError, setWithdrawInputError] = useState<string | null>(null);
 
   const currentCollateralAssetsRaw = parseUnsignedBigInt(currentPosition?.state.collateral);
   const currentBorrowAssetsRaw = parseUnsignedBigInt(currentPosition?.state.borrowAssets);
@@ -50,8 +65,53 @@ export function RemoveCollateralAndDeleverage({
   const currentBorrowAssets = currentBorrowAssetsRaw ?? 0n;
   const currentBorrowShares = currentBorrowSharesRaw ?? 0n;
   const lltv = lltvRaw ?? 0n;
-  const quoteWithdrawCollateralAmount = hasInvalidPositionData ? 0n : withdrawCollateralAmount;
+  const currentLTV = useMemo(
+    () =>
+      computeLtv({
+        borrowAssets: currentBorrowAssets,
+        collateralAssets: currentCollateralAssets,
+        oraclePrice,
+      }),
+    [currentBorrowAssets, currentCollateralAssets, oraclePrice],
+  );
+  const currentLtvBps = useMemo(() => ltvWadToBps(currentLTV), [currentLTV]);
+  const effectiveTargetLtvBps = targetLtvBps ?? currentLtvBps;
+  const currentCollateralValueInLoan = useMemo(
+    () => getCollateralValueInLoan(currentCollateralAssets, oraclePrice),
+    [currentCollateralAssets, oraclePrice],
+  );
+  const targetDebtAdjustment = useMemo(
+    () =>
+      computeDebtAdjustmentForTargetLtv({
+        currentBorrowAssets,
+        currentCollateralValueInLoan,
+        targetLtv: effectiveTargetLtvBps * WAD_TO_BPS_SCALE,
+      }),
+    [currentBorrowAssets, currentCollateralValueInLoan, effectiveTargetLtvBps],
+  );
   const swapSlippageBps = useMemo(() => slippagePercentToBps(swapSlippagePercent), [swapSlippagePercent]);
+  const targetRepayAmount =
+    effectiveTargetLtvBps === 0n
+      ? currentBorrowAssets
+      : targetDebtAdjustment.direction === 'decrease'
+        ? targetDebtAdjustment.amount > currentBorrowAssets
+          ? currentBorrowAssets
+          : targetDebtAdjustment.amount
+        : 0n;
+  const targetRepayAmountWithSlippage = withSlippageInverseCeil(targetRepayAmount, swapSlippageBps);
+  const targetWithdrawCollateralAmount =
+    effectiveTargetLtvBps === 0n
+      ? currentCollateralAssets
+      : computeRequiredCollateralAssets({
+          // WHY: this is only the seed amount for the route quote. The risk preview below remains
+          // authoritative because the live swap/vault quote can move after slippage and fees.
+          borrowAssets: targetRepayAmountWithSlippage,
+          oraclePrice,
+          targetLtv: LTV_WAD,
+        });
+  const withdrawCollateralAmount =
+    targetWithdrawCollateralAmount > currentCollateralAssets ? currentCollateralAssets : targetWithdrawCollateralAmount;
+  const quoteWithdrawCollateralAmount = hasInvalidPositionData ? 0n : withdrawCollateralAmount;
 
   const quote = useDeleverageQuote({
     chainId: market.morphoBlue.chain.id,
@@ -97,16 +157,6 @@ export function RemoveCollateralAndDeleverage({
     ],
   );
 
-  const currentLTV = useMemo(
-    () =>
-      computeLtv({
-        borrowAssets: currentBorrowAssets,
-        collateralAssets: currentCollateralAssets,
-        oraclePrice,
-      }),
-    [currentBorrowAssets, currentCollateralAssets, oraclePrice],
-  );
-
   const projectedLTV = useMemo(
     () =>
       computeLtv({
@@ -125,8 +175,7 @@ export function RemoveCollateralAndDeleverage({
 
   const handleTransactionSuccess = useCallback(() => {
     // WHY: clear unwind draft after confirmation so users see the refreshed live position, not stale input.
-    setWithdrawCollateralAmount(0n);
-    setWithdrawInputError(null);
+    setTargetLtvBps(null);
     if (onSuccess) onSuccess();
   }, [onSuccess]);
 
@@ -154,7 +203,7 @@ export function RemoveCollateralAndDeleverage({
   const handleDeleverage = useCallback(() => {
     if (
       hasInvalidPositionData ||
-      withdrawInputError ||
+      targetDebtAdjustment.direction === 'increase' ||
       quote.closeRouteRequiresResolution ||
       withdrawCollateralAmount > projection.maxWithdrawCollateral
     ) {
@@ -163,7 +212,7 @@ export function RemoveCollateralAndDeleverage({
     void authorizeAndDeleverage();
   }, [
     hasInvalidPositionData,
-    withdrawInputError,
+    targetDebtAdjustment.direction,
     quote.closeRouteRequiresResolution,
     withdrawCollateralAmount,
     projection.maxWithdrawCollateral,
@@ -176,6 +225,7 @@ export function RemoveCollateralAndDeleverage({
   const displayProjectedLTV = previewHasTransientState ? settledProjectedLtvRef.current : projectedLTV;
   const shouldShowProjectedRisk = hasChanges && !previewHasTransientState;
   const exceedsMaxWithdraw = withdrawCollateralAmount > projection.maxWithdrawCollateral;
+  const targetNeedsLeverage = targetDebtAdjustment.direction === 'increase';
   const projectedOverLimit = displayProjectedLTV >= lltv;
   const flashBorrowPreview = useMemo(
     () => formatTokenAmountPreview(projection.flashLoanAmountForTx, market.loanAsset.decimals),
@@ -190,14 +240,6 @@ export function RemoveCollateralAndDeleverage({
     [withdrawCollateralAmount, market.collateralAsset.decimals],
   );
   const collateralFlowLabel = isSwapRoute ? 'Collateral Sold' : 'Collateral Unwound';
-
-  const handleWithdrawAmountChange = useCallback(
-    (nextWithdrawAmount: bigint) => {
-      clearExecutionError();
-      setWithdrawCollateralAmount(nextWithdrawAmount);
-    },
-    [clearExecutionError],
-  );
 
   const handleSwapSlippageChange = useCallback(
     (nextSlippagePercent: number) => {
@@ -241,7 +283,7 @@ export function RemoveCollateralAndDeleverage({
       {!transaction?.isModalVisible && (
         <div className="flex flex-col">
           <PreviewSectionHeader
-            title="Deleverage Preview"
+            title="Decrease LTV Preview"
             onRefresh={onSuccess}
             isRefreshing={isRefreshing}
           />
@@ -260,31 +302,21 @@ export function RemoveCollateralAndDeleverage({
 
           <div className="mt-2 space-y-3">
             <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
-              <p className="mb-1 font-monospace text-[11px] uppercase tracking-[0.12em] text-secondary">
-                Collateral To Unwind {market.collateralAsset.symbol}
-              </p>
+              <p className="mb-1 font-monospace text-[11px] uppercase tracking-[0.12em] text-secondary">Target LTV</p>
               <Input
-                decimals={market.collateralAsset.decimals}
-                max={projection.maxWithdrawCollateral}
-                setValue={handleWithdrawAmountChange}
-                setError={setWithdrawInputError}
-                exceedMaxErrMessage="Exceeds deleverageable collateral"
-                value={withdrawCollateralAmount}
-                inputClassName="h-10 rounded bg-surface px-3 py-2 text-base font-medium tabular-nums"
-                endAdornment={
-                  <TokenIcon
-                    address={market.collateralAsset.address}
-                    chainId={market.morphoBlue.chain.id}
-                    symbol={market.collateralAsset.symbol}
-                    width={16}
-                    height={16}
-                  />
-                }
+                decimals={2}
+                setValue={(nextTargetLtvBps) => {
+                  clearExecutionError();
+                  setTargetLtvBps(clampTargetLtvBps(nextTargetLtvBps));
+                }}
+                value={effectiveTargetLtvBps}
+                inputClassName="h-10 rounded bg-surface px-3 py-2 pr-10 text-base font-medium tabular-nums"
+                endAdornment={<span className="text-xs text-secondary">%</span>}
+                debounceSetValueMs={300}
               />
-              {withdrawInputError && <p className="mt-1 text-right text-xs text-red-500">{withdrawInputError}</p>}
-              {!withdrawInputError && exceedsMaxWithdraw && (
-                <p className="mt-1 text-right text-xs text-red-500">Exceeds deleverageable collateral</p>
-              )}
+              <p className="mt-1 text-right text-xs text-secondary">Current: {formatLtvPercent(currentLTV)}%</p>
+              {targetNeedsLeverage && <p className="mt-1 text-right text-xs text-red-500">Select Increase LTV to target a higher LTV.</p>}
+              {exceedsMaxWithdraw && <p className="mt-1 text-right text-xs text-red-500">Exceeds deleverageable collateral</p>}
             </div>
 
             <div className="rounded border border-white/10 bg-hovered px-3 py-2.5">
@@ -377,7 +409,7 @@ export function RemoveCollateralAndDeleverage({
                 disabled={
                   route == null ||
                   hasInvalidPositionData ||
-                  withdrawInputError !== null ||
+                  targetNeedsLeverage ||
                   quote.error !== null ||
                   quote.closeRouteRequiresResolution ||
                   exceedsMaxWithdraw ||
@@ -388,7 +420,7 @@ export function RemoveCollateralAndDeleverage({
                 variant="primary"
                 className="min-w-32"
               >
-                Deleverage
+                {effectiveTargetLtvBps === 0n ? 'Unwind' : 'Decrease LTV'}
               </ExecuteTransactionButton>
             </div>
 

--- a/src/modals/leverage/leverage-modal-global.tsx
+++ b/src/modals/leverage/leverage-modal-global.tsx
@@ -4,12 +4,14 @@ import { useCallback } from 'react';
 import { useConnection } from 'wagmi';
 import { useOraclePrice } from '@/hooks/useOraclePrice';
 import useUserPosition from '@/hooks/useUserPosition';
-import type { Market } from '@/utils/types';
+import type { Market, MarketPosition } from '@/utils/types';
 import { LeverageModal } from './leverage-modal';
 
 type LeverageModalGlobalProps = {
   market: Market;
+  position?: MarketPosition | null;
   defaultMode?: 'leverage' | 'deleverage';
+  defaultLeverageSource?: 'wallet' | 'position';
   toggleLeverageDeleverage?: boolean;
   refetch?: () => void;
   onOpenChange: (open: boolean) => void;
@@ -21,7 +23,9 @@ type LeverageModalGlobalProps = {
  */
 export function LeverageModalGlobal({
   market,
+  position: providedPosition,
   defaultMode,
+  defaultLeverageSource,
   toggleLeverageDeleverage,
   refetch: externalRefetch,
   onOpenChange,
@@ -35,6 +39,8 @@ export function LeverageModalGlobal({
   });
 
   const { position, refetch: refetchPosition } = useUserPosition(address, chainId, market.uniqueKey);
+  // Prefer the live position, but keep the row-seeded position when fallback APIs return null.
+  const resolvedPosition = position ?? providedPosition ?? null;
 
   const handleRefetch = useCallback(() => {
     refetchPosition();
@@ -47,8 +53,9 @@ export function LeverageModalGlobal({
       onOpenChange={onOpenChange}
       oraclePrice={oraclePrice}
       refetch={handleRefetch}
-      position={position}
+      position={resolvedPosition}
       defaultMode={defaultMode}
+      defaultLeverageSource={defaultLeverageSource}
       toggleLeverageDeleverage={toggleLeverageDeleverage}
     />
   );

--- a/src/modals/leverage/leverage-modal.tsx
+++ b/src/modals/leverage/leverage-modal.tsx
@@ -10,6 +10,7 @@ import { TokenIcon } from '@/components/shared/token-icon';
 import { Badge } from '@/components/ui/badge';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { getSpecialErc4626LeverageConfig, isSpecialErc4626LeverageMarket } from '@/config/leverage';
+import { parseUnsignedBigInt } from '@/hooks/leverage/math';
 import { useLeverageRouteAvailability } from '@/hooks/leverage/useLeverageRouteAvailability';
 import { useAppSettings } from '@/stores/useAppSettings';
 import type { LeverageRoute } from '@/hooks/leverage/types';
@@ -26,6 +27,7 @@ type LeverageModalProps = {
   isRefreshing?: boolean;
   position: MarketPosition | null;
   defaultMode?: 'leverage' | 'deleverage';
+  defaultLeverageSource?: 'wallet' | 'position';
   toggleLeverageDeleverage?: boolean;
 };
 
@@ -101,6 +103,7 @@ export function LeverageModal({
   isRefreshing = false,
   position,
   defaultMode = 'leverage',
+  defaultLeverageSource = 'wallet',
   toggleLeverageDeleverage = true,
 }: LeverageModalProps): JSX.Element {
   const [mode, setMode] = useState<'leverage' | 'deleverage'>(defaultMode);
@@ -153,7 +156,6 @@ export function LeverageModal({
     swapRoute,
   ]);
   const isErc4626Route = route?.kind === 'erc4626';
-  const isSwapRoute = route?.kind === 'swap';
   const hasAcknowledgedSpecialBundlerWarning =
     !isSpecialErc4626BundlerMarket || !specialErc4626LeverageConfig
       ? true
@@ -173,10 +175,11 @@ export function LeverageModal({
   }, [route, availableRouteModes, routeMode]);
 
   const effectiveMode = mode;
+  const hasPositionCollateral = (parseUnsignedBigInt(position?.state.collateral) ?? 0n) > 0n;
   const modeOptions: { value: string; label: string }[] = toggleLeverageDeleverage
     ? [
-        { value: 'leverage', label: `Leverage ${market.collateralAsset.symbol}` },
-        { value: 'deleverage', label: `Deleverage ${market.collateralAsset.symbol}` },
+        { value: 'leverage', label: hasPositionCollateral ? 'Increase LTV' : `Leverage ${market.collateralAsset.symbol}` },
+        { value: 'deleverage', label: hasPositionCollateral ? 'Decrease LTV' : `Deleverage ${market.collateralAsset.symbol}` },
       ]
     : [
         {
@@ -184,6 +187,11 @@ export function LeverageModal({
           label: effectiveMode === 'leverage' ? `Leverage ${market.collateralAsset.symbol}` : `Deleverage ${market.collateralAsset.symbol}`,
         },
       ];
+  const modalDescription = hasPositionCollateral
+    ? `Set a target LTV. Higher targets borrow and loop more; lower targets unwind and repay ${market.loanAsset.symbol}.`
+    : effectiveMode === 'leverage'
+      ? `Add capital and borrow ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
+      : `Withdraw collateral from the loop and repay ${market.loanAsset.symbol}.`;
 
   const {
     data: collateralTokenBalance,
@@ -220,6 +228,7 @@ export function LeverageModal({
           currentPosition={position}
           collateralTokenBalance={collateralTokenBalance}
           oraclePrice={oraclePrice}
+          defaultLeverageSource={defaultLeverageSource}
           onSuccess={handleRefreshAll}
           isRefreshing={isRefreshingAnyData}
         />
@@ -236,7 +245,17 @@ export function LeverageModal({
         isRefreshing={isRefreshingAnyData}
       />
     );
-  }, [route, effectiveMode, market, position, collateralTokenBalance, oraclePrice, handleRefreshAll, isRefreshingAnyData]);
+  }, [
+    route,
+    effectiveMode,
+    market,
+    position,
+    collateralTokenBalance,
+    oraclePrice,
+    defaultLeverageSource,
+    handleRefreshAll,
+    isRefreshingAnyData,
+  ]);
 
   const mainIcon = (
     <div className="flex -space-x-2">
@@ -292,19 +311,7 @@ export function LeverageModal({
             )}
           </div>
         }
-        description={
-          effectiveMode === 'leverage'
-            ? isErc4626Route
-              ? `Leverage ERC4626 vault exposure by looping ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-              : isSwapRoute
-                ? `Leverage ${market.collateralAsset.symbol} exposure by swapping borrowed ${market.loanAsset.symbol} into ${market.collateralAsset.symbol}.`
-                : `Leverage your ${market.collateralAsset.symbol} exposure by looping.`
-            : isErc4626Route
-              ? `Reduce ERC4626 leveraged exposure by unwinding your ${market.collateralAsset.symbol} loop.`
-              : isSwapRoute
-                ? `Reduce leveraged exposure by swapping withdrawn ${market.collateralAsset.symbol} into ${market.loanAsset.symbol}.`
-                : `Reduce leveraged ${market.collateralAsset.symbol} exposure by unwinding your loop.`
-        }
+        description={modalDescription}
       />
       <ModalBody>
         {routeContent ? (

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -29,7 +29,9 @@ export type ModalProps = {
   // Leverage & Deleverage
   leverage: {
     market: Market;
+    position?: MarketPosition | null;
     defaultMode?: 'leverage' | 'deleverage';
+    defaultLeverageSource?: 'wallet' | 'position';
     toggleLeverageDeleverage?: boolean;
     refetch?: () => void;
   };

--- a/src/utils/positions.ts
+++ b/src/utils/positions.ts
@@ -55,6 +55,7 @@ export type PositionSnapshotsWithOracleResult = {
 
 export type BorrowPositionRow = {
   market: MorphoMarket;
+  position: MarketPosition;
   state: {
     borrowAssets: string;
     borrowShares: string;
@@ -618,6 +619,7 @@ export function buildBorrowPositionRows(positions: MarketPositionWithEarnings[])
 
       return {
         market: position.market,
+        position,
         state: {
           borrowAssets: position.state.borrowAssets,
           borrowShares: position.state.borrowShares,


### PR DESCRIPTION
## Summary
- Rebuild the existing-position leverage shortcut around **target LTV**, not borrowed-asset amount.
- Replace separate position actions with one `Adjust LTV` shortcut from borrowed positions with collateral.
- Keep the modal structure conservative:
  - `Add Capital`: existing create/top-up leverage path with wallet input and target multiplier/LTV.
  - `Increase LTV`: existing-position loop-more path with no wallet capital input.
  - `Decrease LTV`: existing-position unwind path driven by target LTV.
- Keep low-level leverage/deleverage transaction composers unchanged. This PR derives safer inputs before the existing quote/transaction boundaries.

## New Flow
- If there is no existing position collateral, users use the normal `Leverage` flow. Zero added capital remains non-executable.
- If there is an existing position, `Adjust LTV` opens the leverage modal on `Increase LTV` with the existing position seeded.
- `Increase LTV` accepts a target LTV and computes extra debt from the whole position:
  - `(current debt + x) / (current collateral value + adjusted x) = target LTV`
  - `adjusted x` conservatively accounts for slippage plus leverage fee before quote results are available
  - wallet capital is forced to `0n`, so no wallet token approval/Permit2 is required
  - final submit is blocked if the quoted/projected whole-position LTV is still materially above target
- `Decrease LTV` accepts a target LTV and computes the unwind seed from the whole position:
  - `(current debt - x) / (current collateral value - x) = target LTV`
  - target `0%` is the unwind-to-zero path
  - the repay seed uses an inverse slippage buffer before entering the existing deleverage quote path
- The shared risk preview is still the only current/projected position preview. No duplicate Current/Updated summary boxes were added.

## Four Golden Paths
1. **Add collateral and create leverage**
   - Open Leverage normally.
   - Enter `Add Capital` and target multiplier/LTV.
   - Existing wallet-funded quote/transaction path remains in use.

2. **Increase LTV without adding wallet capital**
   - Open `Adjust LTV` from an existing position.
   - Use `Increase LTV`, enter target LTV.
   - The modal derives the required borrow/loop amount from the whole current position, then swaps/deposits it back into collateral.

3. **Decrease LTV by removing debt and collateral**
   - Switch to `Decrease LTV`, enter a lower target LTV.
   - The modal derives the unwind amount from the whole current position, then uses the existing deleverage quote/transaction path.

4. **Unwind to zero**
   - In `Decrease LTV`, set target LTV to `0`.
   - Full-close close-route logic remains the existing deleverage behavior.

## Review Notes
- Addressed the first CodeRabbit findings:
  - source selector exposes `aria-pressed`
  - seeded row position remains the fallback when live position lookup returns empty
- Addressed the latest CodeRabbit findings:
  - target LTV draft no longer resets on live position refresh
  - `Decrease LTV` no longer treats initial state as a full unwind intent
  - deleverage target repay seed uses inverse slippage buffering
  - increase-LTV debt sizing accounts for slippage/fee loss and blocks if quoted projection still exceeds target
- The Gemini effect-consolidation comment became outdated after removing the separate position-debt input state.

## Verification / No-Mistake Checks
- `pnpm exec tsx -e '...'` target-LTV math smoke test:
  - increase from 50% to 60%
  - buffered increase with slippage/fee factor
  - decrease from 50% to 40%
  - unwind target `0%`
  - no-debt loop-more to 50%
  - inverse slippage seed
- `npx ultracite fix`
- `pnpm typecheck`
- `npx ultracite check`
- `git diff --check`
- `pnpm build`
- `pnpm check`
- Guarded low-level tx composers against `origin/master` drift:
  - `src/hooks/leverage/leverageWithErc4626Deposit.ts`
  - `src/hooks/leverage/leverageWithSwap.ts`
  - `src/hooks/deleverage/deleverageWithErc4626Redeem.ts`
  - `src/hooks/deleverage/deleverageWithSwap.ts`
  - `src/hooks/useDeleverageQuote.ts`
  - `src/hooks/useDeleverageTransaction.ts`

Supersedes #595.
