### PR TITLE
Differentiate borrower reward indicators

### DIFF
--- a/src/features/market-detail/components/campaign-badge.tsx
+++ b/src/features/market-detail/components/campaign-badge.tsx
@@ -42,6 +42,7 @@ export function CampaignBadge({ marketId, loanTokenAddress, chainId, whitelisted
   }
 
   const totalBonus = filteredCampaigns.reduce((sum, campaign) => sum + campaign.apr, 0);
+  const rewardSign = filterType === 'borrow' ? '-' : '+';
 
   return (
     <>
@@ -49,17 +50,19 @@ export function CampaignBadge({ marketId, loanTokenAddress, chainId, whitelisted
         type="button"
         onClick={() => setIsModalOpen(true)}
         className="flex items-center transition-opacity hover:opacity-80"
+        aria-label={`Open ${filterType ?? 'market'} reward campaigns, ${rewardSign}${totalBonus.toFixed(1)}%`}
       >
         <Badge
-          variant="success"
+          variant="default"
           size="md"
-          className="flex cursor-pointer items-center px-2 py-1"
+          className="flex cursor-pointer items-center bg-primary/10 px-2 py-1 text-primary dark:bg-primary/10 dark:text-primary"
         >
           <FaGift
             size={15}
             className="mr-1"
           />
-          +{totalBonus.toFixed(1)}%
+          {rewardSign}
+          {totalBonus.toFixed(1)}%
         </Badge>
       </button>
 

--- a/src/features/market-detail/components/campaign-modal.tsx
+++ b/src/features/market-detail/components/campaign-modal.tsx
@@ -6,13 +6,14 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Modal, ModalBody, ModalHeader } from '@/components/common/Modal';
 import { getMerklCampaignURL } from '@/utils/external';
+import { isBorrowCampaign } from '@/utils/merklApi';
 import type { SimplifiedCampaign, MerklCampaignType } from '@/utils/merklTypes';
 
 const CAMPAIGN_TYPE_CONFIG: Record<MerklCampaignType, { badge: string }> = {
   MORPHOSUPPLY: { badge: 'Lender Rewards' },
   MORPHOSUPPLY_SINGLETOKEN: { badge: 'Lender Rewards' },
   MULTILENDBORROW: { badge: 'Lend/Borrow Rewards' },
-  MORPHOBORROW: { badge: 'Borrow Rewards' },
+  MORPHOBORROW: { badge: 'Borrow Rate Offset' },
 };
 
 type CampaignModalProps = {
@@ -48,13 +49,16 @@ function CampaignRow({ campaign }: { campaign: SimplifiedCampaign }) {
   const merklUrl = getMerklCampaignURL(campaign.chainId, campaign.type, urlIdentifier);
 
   const { badge } = CAMPAIGN_TYPE_CONFIG[campaign.type] ?? CAMPAIGN_TYPE_CONFIG.MORPHOSUPPLY;
+  const isBorrowReward = isBorrowCampaign(campaign);
+  const rewardSign = isBorrowReward ? '-' : '+';
+  const rateLabel = isBorrowReward ? 'Borrow APR offset' : 'Reward APR';
 
   return (
     <div className="bg-hovered rounded-sm border border-gray-200/20 p-4 dark:border-gray-600/15">
       {/* Header: Badge + Reward Token + APR */}
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="rounded-sm bg-green-100 px-2 py-1 text-xs text-green-700 dark:bg-green-800 dark:text-green-300">{badge}</span>
+          <span className="rounded-sm bg-primary/10 px-2 py-1 text-xs text-primary">{badge}</span>
           <div className="flex items-center gap-2">
             <Image
               src={campaign.rewardToken.icon}
@@ -66,7 +70,13 @@ function CampaignRow({ campaign }: { campaign: SimplifiedCampaign }) {
             <span className="text-normal">{campaign.rewardToken.symbol}</span>
           </div>
         </div>
-        <span className="text text-green-600 dark:text-green-400">+{campaign.apr.toFixed(2)}% APR</span>
+        <div className="text-right text-primary">
+          <span className="block text-sm">
+            {rewardSign}
+            {campaign.apr.toFixed(2)}% APR
+          </span>
+          <span className="block text-[11px] text-secondary">{rateLabel}</span>
+        </div>
       </div>
 
       {/* Campaign Name */}
@@ -99,6 +109,10 @@ function CampaignRow({ campaign }: { campaign: SimplifiedCampaign }) {
 export function CampaignModal({ isOpen, onClose, campaigns }: CampaignModalProps) {
   if (!isOpen) return null;
 
+  const hasBorrowCampaigns = campaigns.some(isBorrowCampaign);
+  const hasSupplyCampaigns = campaigns.some((campaign) => !isBorrowCampaign(campaign));
+  const isBorrowOnly = hasBorrowCampaigns && !hasSupplyCampaigns;
+
   return (
     <Modal
       isOpen={isOpen}
@@ -110,8 +124,8 @@ export function CampaignModal({ isOpen, onClose, campaigns }: CampaignModalProps
       backdrop="blur"
     >
       <ModalHeader
-        title="Active Reward Campaigns"
-        description="Earn extra incentives from live Merkl programs"
+        title={isBorrowOnly ? 'Active Borrow Incentives' : 'Active Reward Campaigns'}
+        description={isBorrowOnly ? 'Borrower incentives reduce the displayed borrow cost.' : 'Live Merkl incentives for this market.'}
         mainIcon={<ExternalLinkIcon className="h-5 w-5" />}
         onClose={onClose}
       />

--- a/src/features/markets/components/market-details-block.tsx
+++ b/src/features/markets/components/market-details-block.tsx
@@ -60,6 +60,7 @@ export function MarketDetailsBlock({
     [activeCampaigns, mode],
   );
   const hasModeRewards = hasActiveRewards && modeCampaigns.length > 0;
+  const rewardSign = mode === 'borrow' ? '-' : '+';
 
   // Calculate preview state when supplyDelta or borrowDelta is provided
   const previewState = useMemo(() => {
@@ -222,8 +223,9 @@ export function MarketDetailsBlock({
                       <div className="flex items-start justify-between">
                         <p className="flex items-center gap-1 font-zen text-sm opacity-50">Extra Rewards:</p>
                         <div className="flex items-center gap-1">
-                          <p className="text-right text-sm font-bold text-green-600 dark:text-green-400">
-                            +{modeCampaigns.reduce((sum, c) => sum + c.apr, 0).toFixed(2)}%
+                          <p className="text-right text-sm font-bold text-primary">
+                            {rewardSign}
+                            {modeCampaigns.reduce((sum, c) => sum + c.apr, 0).toFixed(2)}%
                           </p>
                           {modeCampaigns.map((campaign) => (
                             <TokenIcon

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -1,10 +1,8 @@
 import { Tooltip } from '@/components/ui/tooltip';
-import Image from 'next/image';
 import { FiGift } from 'react-icons/fi';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { useMarketCampaigns } from '@/hooks/useMarketCampaigns';
 import { isBorrowCampaign } from '@/utils/merklApi';
-import merklLogo from '@/imgs/merkl.jpg';
 
 type RewardsIndicatorProps = {
   size: number;
@@ -13,6 +11,51 @@ type RewardsIndicatorProps = {
   loanTokenAddress?: string;
   whitelisted: boolean; // whitelisted by morpho
 };
+
+type RewardSide = 'supplier' | 'borrower';
+
+const REWARD_SIDES: RewardSide[] = ['supplier', 'borrower'];
+
+const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string }> = {
+  supplier: { letter: 'S', label: 'Supplier rewards' },
+  borrower: { letter: 'B', label: 'Borrower rewards' },
+};
+
+function RewardSideIcon({ side, size }: { side: RewardSide; size: number }) {
+  const config = REWARD_SIDE_CONFIG[side];
+  const badgeSize = Math.max(10, Math.round(size * 0.8));
+  const fontSize = Math.max(8, Math.round(size * 0.5));
+
+  return (
+    <span
+      role="img"
+      aria-label={config.label}
+      className="relative inline-flex shrink-0 items-center justify-center text-primary"
+      style={{ width: size + badgeSize / 2, height: size + badgeSize / 3 }}
+    >
+      <FiGift
+        size={size}
+        aria-hidden="true"
+      />
+      <span
+        className="absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full border border-background bg-surface font-monospace font-medium text-primary shadow-sm ring-1 ring-border"
+        style={{
+          width: badgeSize,
+          height: badgeSize,
+          fontSize,
+          lineHeight: `${badgeSize}px`,
+        }}
+        aria-hidden="true"
+      >
+        {config.letter}
+      </span>
+    </span>
+  );
+}
+
+function getRewardSide(campaign: Parameters<typeof isBorrowCampaign>[0]): RewardSide {
+  return isBorrowCampaign(campaign) ? 'borrower' : 'supplier';
+}
 
 export function RewardsIndicator({ marketId, chainId, loanTokenAddress, whitelisted, size }: RewardsIndicatorProps) {
   const { activeCampaigns, hasActiveRewards, loading } = useMarketCampaigns({
@@ -26,34 +69,44 @@ export function RewardsIndicator({ marketId, chainId, loanTokenAddress, whitelis
     return null;
   }
 
-  // Create tooltip detail with all rewards
   const rewardsList = activeCampaigns
     .map((campaign) => {
-      const rewardType = isBorrowCampaign(campaign) ? 'borrower' : 'supplier';
-      return `${campaign.rewardToken.symbol} ${rewardType} reward +${campaign.apr.toFixed(2)}%`;
+      const rewardSide = getRewardSide(campaign);
+      const rewardSign = rewardSide === 'borrower' ? '-' : '+';
+      const rewardLabel = rewardSide === 'borrower' ? 'borrow APR offset' : 'supplier reward';
+      return `${campaign.rewardToken.symbol} ${rewardLabel} ${rewardSign}${campaign.apr.toFixed(2)}%`;
     })
     .join('\n');
+  const rewardSides = REWARD_SIDES.filter((side) => activeCampaigns.some((campaign) => getRewardSide(campaign) === side));
 
   return (
     <Tooltip
       content={
         <TooltipContent
           icon={
-            <Image
-              src={merklLogo}
-              alt="Merkl"
-              width={24}
-              height={24}
-              className="rounded-full"
-            />
+            <span className="inline-flex items-center gap-1">
+              {rewardSides.map((side) => (
+                <RewardSideIcon
+                  key={side}
+                  side={side}
+                  size={16}
+                />
+              ))}
+            </span>
           }
           title="External Rewards"
           detail={rewardsList}
         />
       }
     >
-      <div>
-        <FiGift size={size} />
+      <div className="flex shrink-0 items-center gap-1">
+        {rewardSides.map((side) => (
+          <RewardSideIcon
+            key={side}
+            side={side}
+            size={size}
+          />
+        ))}
       </div>
     </Tooltip>
   );


### PR DESCRIPTION
## Summary
- replace the generic Merkl reward icon with supplier/borrower gift markers
- render borrower incentives as borrow APR offsets with negative signs
- use primary-color reward styling instead of green on market/detail reward surfaces

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reward and campaign displays now clearly distinguish between supply and borrow incentives.
  * APR values and bonus amounts now use clearer `+` / `-` signs throughout market and campaign views.
  * Reward indicators now show side-specific icons and labels for supplier vs. borrower campaigns.

* **UI Improvements**
  * Updated campaign badges, modal titles, and reward rows for better readability and consistency.
  * Borrow-related incentives now use more descriptive wording in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->