### PR TITLE
Abdicate AutoVault gate setters during initialization

### DIFF
--- a/src/abis/morpho-market-v1-adapter-v2-factory.ts
+++ b/src/abis/morpho-market-v1-adapter-v2-factory.ts
@@ -2,10 +2,33 @@ import type { Abi } from 'viem';
 
 export const adapterV2FactoryAbi = [
   {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'parentVault', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'morphoMarketV1AdapterV2', type: 'address' },
+    ],
+    name: 'CreateMorphoMarketV1AdapterV2',
+    type: 'event',
+  },
+  {
     inputs: [{ internalType: 'address', name: 'parentVault', type: 'address' }],
     name: 'createMorphoMarketV1AdapterV2',
-    outputs: [],
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
     stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'isMorphoMarketV1AdapterV2',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'parentVault', type: 'address' }],
+    name: 'morphoMarketV1AdapterV2',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
     type: 'function',
   },
 ] as const satisfies Abi;

--- a/src/components/layout/header/HeaderMenuItems.tsx
+++ b/src/components/layout/header/HeaderMenuItems.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import { FaRegMoon } from 'react-icons/fa';
 import { LuSunMedium } from 'react-icons/lu';
-import { RiBookLine, RiBriefcaseLine, RiDiscordFill, RiLineChartLine, RiPieChart2Line, RiSwapLine } from 'react-icons/ri';
+import { RiBookLine, RiBriefcaseLine, RiDiscordFill, RiLineChartLine, RiSafeLine, RiSwapLine } from 'react-icons/ri';
 import { useConnection } from 'wagmi';
 import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { useModal } from '@/hooks/useModal';
@@ -85,11 +85,11 @@ export function HeaderMenuItems({ iconSide = 'end', itemClassName, onSelect }: H
         Positions
       </DropdownMenuItem>
       <DropdownMenuItem
-        {...iconProps(<RiPieChart2Line className="h-4 w-4" />)}
+        {...iconProps(<RiSafeLine className="h-4 w-4" />)}
         className={itemClassName}
-        onClick={() => handleNavigation('/analysis')}
+        onClick={() => handleNavigation('/autovault')}
       >
-        Analytics
+        Autovaults
       </DropdownMenuItem>
 
       <DropdownMenuSeparator />

--- a/src/features/autovault/components/vault-detail/modals/vault-initialization-modal.tsx
+++ b/src/features/autovault/components/vault-detail/modals/vault-initialization-modal.tsx
@@ -49,10 +49,12 @@ function StepIndicator({ currentStep }: { currentStep: StepId }) {
 
 function DeployAdapterStep({
   isDeploying,
+  isCheckingAdapter,
   adapterDetected,
   adapterAddress,
 }: {
   isDeploying: boolean;
+  isCheckingAdapter: boolean;
   adapterDetected: boolean;
   adapterAddress: Address;
 }) {
@@ -61,8 +63,16 @@ function DeployAdapterStep({
       <p className="text-sm text-secondary">Deploy a Morpho Market adapter so this vault can allocate assets into Morpho Blue markets.</p>
       <div className="space-y-2">
         <div className="flex items-center gap-2 text-xs text-secondary">
-          {isDeploying && <Spinner size={12} />}
-          <span>{adapterDetected ? `Adapter detected: ${shortenAddress(adapterAddress)}` : isDeploying ? 'Deploying adapter...' : ''}</span>
+          {(isDeploying || isCheckingAdapter) && <Spinner size={12} />}
+          <span>
+            {adapterDetected
+              ? `Adapter detected: ${shortenAddress(adapterAddress)}`
+              : isDeploying
+                ? 'Deploying adapter...'
+                : isCheckingAdapter
+                  ? 'Checking adapter...'
+                  : ''}
+          </span>
         </div>
       </div>
     </div>
@@ -232,7 +242,12 @@ export function VaultInitializationModal() {
   });
 
   // Fetch adapter
-  const { primaryAdapter: marketAdapter, refetch: refetchAdapter } = useMorphoMarketAdapters({
+  const {
+    primaryAdapter: marketAdapter,
+    refetch: refetchAdapter,
+    isLoading: isAdapterLoading,
+    isFetching: isAdapterFetching,
+  } = useMorphoMarketAdapters({
     vaultAddress: vaultAddressValue,
     chainId,
   });
@@ -254,6 +269,7 @@ export function VaultInitializationModal() {
   // Adapter is detected if Monarch has indexed it or we just deployed it locally.
   const adapterAddress = deployedAdapter === ZERO_ADDRESS ? (marketAdapter ?? ZERO_ADDRESS) : deployedAdapter;
   const adapterDetected = adapterAddress !== ZERO_ADDRESS;
+  const isCheckingAdapter = (isAdapterLoading || isAdapterFetching) && !adapterDetected;
 
   const { deploy, isDeploying, canDeploy, factoryAddress } = useDeployMorphoMarketAdapter({
     vaultAddress: vaultAddressValue,
@@ -339,10 +355,10 @@ export function VaultInitializationModal() {
 
   // Auto-advance when adapter already exists in Monarch data.
   useEffect(() => {
-    if (marketAdapter != null && marketAdapter !== ZERO_ADDRESS && stepIndex === 0 && deployedAdapter === ZERO_ADDRESS) {
+    if (adapterDetected && stepIndex === 0) {
       setStepIndex(1);
     }
-  }, [marketAdapter, stepIndex, deployedAdapter]);
+  }, [adapterDetected, stepIndex]);
 
   const canCompleteInitialization = adapterAddress !== ZERO_ADDRESS && registryAddress !== ZERO_ADDRESS;
 
@@ -368,12 +384,12 @@ export function VaultInitializationModal() {
         <Button
           variant="primary"
           className="min-w-[150px]"
-          disabled={!canDeploy || isDeploying}
+          disabled={!canDeploy || isDeploying || isCheckingAdapter}
           onClick={() => void handleDeploy()}
         >
-          {isDeploying ? (
+          {isDeploying || isCheckingAdapter ? (
             <span className="flex items-center gap-2">
-              <Spinner size={12} /> Deploying...
+              <Spinner size={12} /> {isDeploying ? 'Deploying...' : 'Checking...'}
             </span>
           ) : (
             'Deploy adapter'
@@ -455,6 +471,7 @@ export function VaultInitializationModal() {
         {currentStep === 'deploy' && (
           <DeployAdapterStep
             isDeploying={isDeploying}
+            isCheckingAdapter={isCheckingAdapter}
             adapterDetected={adapterDetected}
             adapterAddress={adapterAddress}
           />

--- a/src/features/autovault/vault-view.tsx
+++ b/src/features/autovault/vault-view.tsx
@@ -240,7 +240,7 @@ export default function VaultContent() {
               <div className="space-y-1">
                 <p className="text-sm text-primary">Complete vault setup</p>
                 <p className="text-sm text-secondary">
-                  Initialize your vault by deploying an adapter, and setting caps to start auto earning.
+                  Run the setup multicall to link the adapter, set the registry, and lock required controls.
                 </p>
               </div>
               <Button

--- a/src/features/vault/vault-view.tsx
+++ b/src/features/vault/vault-view.tsx
@@ -495,7 +495,7 @@ export default function VaultContent() {
               <div className="space-y-1">
                 <p className="text-sm text-primary">Complete vault setup</p>
                 <p className="text-sm text-secondary">
-                  Initialize your vault by deploying an adapter, and setting caps to start auto earning.
+                  Run the setup multicall to link the adapter, set the registry, and lock required controls.
                 </p>
               </div>
               <Button

--- a/src/hooks/useMorphoMarketAdapters.ts
+++ b/src/hooks/useMorphoMarketAdapters.ts
@@ -1,8 +1,10 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { type Address, zeroAddress } from 'viem';
+import { useReadContracts } from 'wagmi';
+import { adapterV2FactoryAbi } from '@/abis/morpho-market-v1-adapter-v2-factory';
 import { useVaultV2Data } from './useVaultV2Data';
 import { parseCapIdParams } from '@/utils/morpho';
-import type { SupportedNetworks } from '@/utils/networks';
+import { getAgentConfig, type SupportedNetworks } from '@/utils/networks';
 import { hasPositiveVaultCap } from '@/utils/vaultAllocation';
 
 export type VaultMarketAdapter = {
@@ -24,6 +26,44 @@ const getAddressKey = (address: string | undefined): string => address?.toLowerC
 
 export function useMorphoMarketAdapters({ vaultAddress, chainId }: { vaultAddress?: Address; chainId: SupportedNetworks }) {
   const query = useVaultV2Data({ vaultAddress, chainId });
+  const factoryAddress = useMemo(() => {
+    try {
+      return getAgentConfig(chainId)?.marketAdapterFactory ?? null;
+    } catch (_error) {
+      return null;
+    }
+  }, [chainId]);
+  const canReadFactoryAdapter = Boolean(vaultAddress && factoryAddress);
+
+  const {
+    data: factoryAdapterResults,
+    isFetching: isFetchingFactoryAdapter,
+    isLoading: isLoadingFactoryAdapter,
+    refetch: refetchFactoryAdapter,
+  } = useReadContracts({
+    contracts:
+      vaultAddress && factoryAddress
+        ? [
+            {
+              address: factoryAddress,
+              abi: adapterV2FactoryAbi,
+              functionName: 'morphoMarketV1AdapterV2',
+              args: [vaultAddress],
+              chainId,
+            },
+          ]
+        : [],
+    query: {
+      enabled: canReadFactoryAdapter,
+      staleTime: 10_000,
+      refetchOnWindowFocus: false,
+    },
+  });
+
+  const factoryAdapter =
+    factoryAdapterResults?.[0]?.status === 'success' && factoryAdapterResults[0].result !== zeroAddress
+      ? (factoryAdapterResults[0].result.toLowerCase() as Address)
+      : undefined;
 
   const capSummaryByAdapter = useMemo(() => {
     const summaries = new Map<string, AdapterCapSummary>();
@@ -60,7 +100,11 @@ export function useMorphoMarketAdapters({ vaultAddress, chainId }: { vaultAddres
   const adapters = useMemo<VaultMarketAdapter[]>(() => {
     const adapterDetails = query.data?.adapterDetails ?? [];
     const adapterDetailsByAddress = new Map(adapterDetails.map((adapterDetail) => [getAddressKey(adapterDetail.address), adapterDetail]));
-    const adapterAddresses = [...(query.data?.adapters ?? []), ...adapterDetails.map((adapterDetail) => adapterDetail.address)];
+    const adapterAddresses = [
+      ...(factoryAdapter ? [factoryAdapter] : []),
+      ...(query.data?.adapters ?? []),
+      ...adapterDetails.map((adapterDetail) => adapterDetail.address),
+    ];
     const seenAddresses = new Set<string>();
 
     return adapterAddresses
@@ -78,7 +122,7 @@ export function useMorphoMarketAdapters({ vaultAddress, chainId }: { vaultAddres
           {
             adapter: adapterKey as Address,
             adapterType: adapterDetail?.adapterType,
-            factoryAddress: adapterDetail?.factoryAddress as Address | undefined,
+            factoryAddress: (adapterDetail?.factoryAddress as Address | undefined) ?? factoryAddress ?? undefined,
             hasPositiveAdapterCap: capSummary?.hasPositiveAdapterCap ?? false,
             id: `${chainId}-${vaultAddress ?? 'unknown'}-${adapterKey}`,
             marketCapCount: capSummary?.marketCapCount ?? 0,
@@ -97,7 +141,7 @@ export function useMorphoMarketAdapters({ vaultAddress, chainId }: { vaultAddres
 
         return 0;
       });
-  }, [capSummaryByAdapter, chainId, query.data?.adapterDetails, query.data?.adapters, vaultAddress]);
+  }, [capSummaryByAdapter, chainId, factoryAdapter, factoryAddress, query.data?.adapterDetails, query.data?.adapters, vaultAddress]);
 
   const configuredAdapters = useMemo(
     () => adapters.filter((adapter) => adapter.marketCapCount > 0 || adapter.hasPositiveAdapterCap),
@@ -114,17 +158,22 @@ export function useMorphoMarketAdapters({ vaultAddress, chainId }: { vaultAddres
     };
   }, [adapters, configuredAdapters]);
 
+  const refetch = useCallback(async () => {
+    const [queryResult] = await Promise.all([query.refetch(), canReadFactoryAdapter ? refetchFactoryAdapter() : Promise.resolve(null)]);
+    return queryResult;
+  }, [canReadFactoryAdapter, query.refetch, refetchFactoryAdapter]);
+
   return {
     primaryAdapter,
     primaryAdapterType,
     primaryFactoryAddress,
     adapters,
     configuredAdapters,
-    isFetching: query.isFetching,
-    isLoading: query.isLoading,
+    isFetching: query.isFetching || isFetchingFactoryAdapter,
+    isLoading: query.isLoading || isLoadingFactoryAdapter,
     error: query.error,
-    refetch: query.refetch,
-    isRefetching: query.isRefetching,
+    refetch,
+    isRefetching: query.isRefetching || isFetchingFactoryAdapter,
     hasAdapters: adapters.length > 0,
     hasMultipleAdapters: adapters.length > 1,
   };

--- a/src/hooks/useVaultPage.ts
+++ b/src/hooks/useVaultPage.ts
@@ -5,6 +5,7 @@ import { useMorphoMarketAdapters } from './useMorphoMarketAdapters';
 import { useVaultAllocations } from './useVaultAllocations';
 import { useVaultV2 } from './useVaultV2';
 import { useVaultV2Data } from './useVaultV2Data';
+import { useVaultV2InitializationStatus } from './useVaultV2InitializationStatus';
 import { formatBalance } from '@/utils/balance';
 
 type UseVaultPageArgs = {
@@ -31,20 +32,34 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
   const vaultDataQuery = useVaultV2Data({ vaultAddress, chainId });
   const contract = useVaultV2({ vaultAddress, chainId, connectedAddress, onTransactionSuccess: vaultDataQuery.refetch });
   const adapterQuery = useMorphoMarketAdapters({ vaultAddress, chainId });
+  const initializationStatus = useVaultV2InitializationStatus({
+    adapterAddress: adapterQuery.primaryAdapter,
+    chainId,
+    vaultAddress,
+  });
   const allocationsQuery = useVaultAllocations({ vaultAddress, chainId });
   const { refetch: refetchVaultData } = vaultDataQuery;
   const { refetch: refetchContract } = contract;
   const { refetch: refetchAdapter } = adapterQuery;
+  const { refetch: refetchInitializationStatus } = initializationStatus;
   const { refetch: refetchAllocations } = allocationsQuery;
   const hasResolvedAdapterState = !adapterQuery.isLoading && !adapterQuery.error;
+  const hasResolvedInitializationState = !initializationStatus.isLoading && !initializationStatus.error;
   const hasResolvedVaultState = !vaultDataQuery.isLoading && !vaultDataQuery.isError;
 
   // Complex derived state: isVaultInitialized (needs multiple sources)
   const isVaultInitialized = useMemo(() => {
-    if (!hasResolvedAdapterState || !hasResolvedVaultState) return false;
+    if (!hasResolvedAdapterState || !hasResolvedInitializationState || !hasResolvedVaultState) return false;
     if (!adapterQuery.primaryAdapter) return false;
-    return vaultDataQuery.data !== null && vaultDataQuery.data !== undefined;
-  }, [adapterQuery.primaryAdapter, hasResolvedAdapterState, hasResolvedVaultState, vaultDataQuery.data]);
+    return vaultDataQuery.data !== null && vaultDataQuery.data !== undefined && initializationStatus.isComplete;
+  }, [
+    adapterQuery.primaryAdapter,
+    hasResolvedAdapterState,
+    hasResolvedInitializationState,
+    hasResolvedVaultState,
+    initializationStatus.isComplete,
+    vaultDataQuery.data,
+  ]);
 
   const needsAdapterDeployment = useMemo(
     () => hasResolvedAdapterState && !adapterQuery.primaryAdapter,
@@ -76,9 +91,9 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
 
   // Complex derived state: needsInitialization
   const needsInitialization = useMemo(() => {
-    const isLoading = vaultDataQuery.isLoading || contract.isLoading || adapterQuery.isLoading;
+    const isLoading = vaultDataQuery.isLoading || contract.isLoading || adapterQuery.isLoading || initializationStatus.isLoading;
     if (isLoading) return false;
-    if (!hasResolvedAdapterState || !hasResolvedVaultState) return false;
+    if (!hasResolvedAdapterState || !hasResolvedInitializationState || !hasResolvedVaultState) return false;
     if (isVaultInitialized) return false;
     return true;
   }, [
@@ -86,7 +101,9 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
     contract.isLoading,
     adapterQuery.isLoading,
     hasResolvedAdapterState,
+    hasResolvedInitializationState,
     hasResolvedVaultState,
+    initializationStatus.isLoading,
     isVaultInitialized,
   ]);
 
@@ -95,8 +112,9 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
     void refetchVaultData();
     void refetchContract();
     void refetchAdapter();
+    void refetchInitializationStatus();
     void refetchAllocations();
-  }, [refetchVaultData, refetchContract, refetchAdapter, refetchAllocations]);
+  }, [refetchVaultData, refetchContract, refetchAdapter, refetchInitializationStatus, refetchAllocations]);
 
   // Return ONLY computed/derived state - no raw data!
   return {
@@ -104,6 +122,7 @@ export function useVaultPage({ vaultAddress, chainId, connectedAddress }: UseVau
     isVaultInitialized,
     needsAdapterDeployment,
     needsInitialization,
+    missingInitializationRequirements: initializationStatus.missingRequirements,
     vaultAPY,
     vault24hEarnings: null,
     isAPYLoading: allocationsQuery.loading,

--- a/src/hooks/useVaultV2.ts
+++ b/src/hooks/useVaultV2.ts
@@ -1,10 +1,16 @@
 import { useCallback, useMemo } from 'react';
-import { type Address, encodeFunctionData, toFunctionSelector, zeroAddress } from 'viem';
+import { type Address, encodeFunctionData, zeroAddress } from 'viem';
 import { useQueryClient } from '@tanstack/react-query';
 import { useConnection, useChainId, useReadContracts } from 'wagmi';
 import { vaultv2Abi } from '@/abis/vaultv2';
 import type { VaultV2Cap } from '@/data-sources/monarch-api/vaults';
 import type { SupportedNetworks } from '@/utils/networks';
+import {
+  VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY,
+  VAULT_V2_DEFAULT_MAX_RATE,
+  VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS,
+  VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR,
+} from '@/utils/vaultV2Setup';
 import { MONARCH_VAULT_QUERY_REFETCH_DELAYS_MS, refetchVaultQueryData } from './useVaultQueryRefresh';
 import { useTransactionWithToast } from './useTransactionWithToast';
 import type { Market } from '@/utils/types';
@@ -16,17 +22,8 @@ export type PerformanceFeeConfig = {
   recipient: Address;
 };
 
-const VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES = [
-  'setReceiveSharesGate(address)',
-  'setSendSharesGate(address)',
-  'setReceiveAssetsGate(address)',
-  'setSendAssetsGate(address)',
-] as const;
-
-const VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS = VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES.map(toFunctionSelector);
-
 function buildVaultV2GateAbdicationCalls(): `0x${string}`[] {
-  return VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS.flatMap((selector) => {
+  return VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS.flatMap((selector) => {
     const abdicateGateSetterTx = encodeFunctionData({
       abi: vaultv2Abi,
       functionName: 'abdicate',
@@ -281,9 +278,8 @@ export function useVaultV2({
         txs.push(setCuratorTx);
       }
 
-      // Abdicate the full gate setter surface during initialization. The first three
-      // gates preserve non-custodial exits; send-assets only gates deposits, but
-      // Monarch-created vaults should not retain curator control over any gate.
+      // Abdicate exit-critical gate setters during initialization so the curator
+      // cannot later lock users out of shares or asset withdrawals.
       txs.push(...buildVaultV2GateAbdicationCalls());
 
       // Step 2. Commit to Morpho registry.
@@ -316,26 +312,37 @@ export function useVaultV2({
 
       txs.push(submitAddAdapterTx, addAdapterTx);
 
+      const setForceDeallocatePenaltyTx = encodeFunctionData({
+        abi: vaultv2Abi,
+        functionName: 'setForceDeallocatePenalty',
+        args: [marketAdapter, VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY],
+      });
+
+      const submitSetForceDeallocatePenaltyTx = encodeFunctionData({
+        abi: vaultv2Abi,
+        functionName: 'submit',
+        args: [setForceDeallocatePenaltyTx],
+      });
+
+      txs.push(submitSetForceDeallocatePenaltyTx, setForceDeallocatePenaltyTx);
+
       // Note: Adapter cap will be set when user configures market caps in settings
       // (EditCaps.tsx automatically ensures adapter cap is 100% + maxUint128)
 
-      // Note: do not do this for maximized flexibility for now: open in the future!
       // Step 5. Abdicate registry control.
-      // const setAdapterRegistrySelector = toFunctionSelector('setAdapterRegistry(address)');
+      const abdicateSetAdapterRegistryTx = encodeFunctionData({
+        abi: vaultv2Abi,
+        functionName: 'abdicate',
+        args: [VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR],
+      });
 
-      // const abdicateSetAdapterRegistryTx = encodeFunctionData({
-      //   abi: vaultv2Abi,
-      //   functionName: 'abdicate',
-      //   args: [setAdapterRegistrySelector],
-      // });
+      const submitAbdicateSetAdapterRegistryTx = encodeFunctionData({
+        abi: vaultv2Abi,
+        functionName: 'submit',
+        args: [abdicateSetAdapterRegistryTx],
+      });
 
-      // const submitAbdicateSetAdapterRegistryTx = encodeFunctionData({
-      //   abi: vaultv2Abi,
-      //   functionName: 'submit',
-      //   args: [abdicateSetAdapterRegistryTx],
-      // });
-
-      // txs.push(submitAbdicateSetAdapterRegistryTx, abdicateSetAdapterRegistryTx);
+      txs.push(submitAbdicateSetAdapterRegistryTx, abdicateSetAdapterRegistryTx);
 
       // Step 6.1 Set user as allocator (for withdrawal / setting Withdrawal Data)
       const setSelfAllocatorTx = encodeFunctionData({
@@ -356,7 +363,7 @@ export function useVaultV2({
       const setMaxAPYTx = encodeFunctionData({
         abi: vaultv2Abi,
         functionName: 'setMaxRate',
-        args: [63419583967n], // max max rate = 200e16 / (86400 * 365) // 200% APR
+        args: [VAULT_V2_DEFAULT_MAX_RATE],
       });
 
       txs.push(setMaxAPYTx);

--- a/src/hooks/useVaultV2.ts
+++ b/src/hooks/useVaultV2.ts
@@ -16,16 +16,16 @@ export type PerformanceFeeConfig = {
   recipient: Address;
 };
 
-export const VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES = [
+const VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES = [
   'setReceiveSharesGate(address)',
   'setSendSharesGate(address)',
   'setReceiveAssetsGate(address)',
   'setSendAssetsGate(address)',
 ] as const;
 
-export const VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS = VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES.map(toFunctionSelector);
+const VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS = VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES.map(toFunctionSelector);
 
-export function buildVaultV2GateAbdicationCalls(): `0x${string}`[] {
+function buildVaultV2GateAbdicationCalls(): `0x${string}`[] {
   return VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS.flatMap((selector) => {
     const abdicateGateSetterTx = encodeFunctionData({
       abi: vaultv2Abi,
@@ -281,10 +281,9 @@ export function useVaultV2({
         txs.push(setCuratorTx);
       }
 
-      // Abdicate the full gate setter surface during initialization. Morpho flags
-      // receive-shares, send-shares, and receive-assets gates as critical; send-assets
-      // belongs to the same transfer-gate family, so Monarch-created vaults should not
-      // retain curator control over it either.
+      // Abdicate the full gate setter surface during initialization. The first three
+      // gates preserve non-custodial exits; send-assets only gates deposits, but
+      // Monarch-created vaults should not retain curator control over any gate.
       txs.push(...buildVaultV2GateAbdicationCalls());
 
       // Step 2. Commit to Morpho registry.

--- a/src/hooks/useVaultV2.ts
+++ b/src/hooks/useVaultV2.ts
@@ -9,8 +9,10 @@ import {
   VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY,
   VAULT_V2_DEFAULT_MAX_RATE,
   VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS,
+  VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS,
   VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR,
 } from '@/utils/vaultV2Setup';
+import { getClient } from '@/utils/rpc';
 import { MONARCH_VAULT_QUERY_REFETCH_DELAYS_MS, refetchVaultQueryData } from './useVaultQueryRefresh';
 import { useTransactionWithToast } from './useTransactionWithToast';
 import type { Market } from '@/utils/types';
@@ -22,21 +24,27 @@ export type PerformanceFeeConfig = {
   recipient: Address;
 };
 
-function buildVaultV2GateAbdicationCalls(): `0x${string}`[] {
-  return VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS.flatMap((selector) => {
-    const abdicateGateSetterTx = encodeFunctionData({
+const normalizeAddress = (address: Address | string | undefined): string => address?.toLowerCase() ?? '';
+
+function buildTimelockedCall(tx: `0x${string}`): `0x${string}`[] {
+  const submitTx = encodeFunctionData({
+    abi: vaultv2Abi,
+    functionName: 'submit',
+    args: [tx],
+  });
+
+  return [submitTx, tx];
+}
+
+function buildVaultV2AbdicationCalls(selectors: readonly `0x${string}`[]): `0x${string}`[] {
+  return selectors.flatMap((selector) => {
+    const abdicateTx = encodeFunctionData({
       abi: vaultv2Abi,
       functionName: 'abdicate',
       args: [selector],
     });
 
-    const submitAbdicateGateSetterTx = encodeFunctionData({
-      abi: vaultv2Abi,
-      functionName: 'submit',
-      args: [abdicateGateSetterTx],
-    });
-
-    return [submitAbdicateGateSetterTx, abdicateGateSetterTx];
+    return buildTimelockedCall(abdicateTx);
   });
 }
 
@@ -54,13 +62,7 @@ function buildPerformanceFeeCalls(config: PerformanceFeeConfig): `0x${string}`[]
     args: [config.recipient],
   });
 
-  const submitSetRecipientTx = encodeFunctionData({
-    abi: vaultv2Abi,
-    functionName: 'submit',
-    args: [setRecipientTx],
-  });
-
-  txs.push(submitSetRecipientTx, setRecipientTx);
+  txs.push(...buildTimelockedCall(setRecipientTx));
 
   // Then set fee
   const setFeeTx = encodeFunctionData({
@@ -69,13 +71,7 @@ function buildPerformanceFeeCalls(config: PerformanceFeeConfig): `0x${string}`[]
     args: [config.fee],
   });
 
-  const submitSetFeeTx = encodeFunctionData({
-    abi: vaultv2Abi,
-    functionName: 'submit',
-    args: [setFeeTx],
-  });
-
-  txs.push(submitSetFeeTx, setFeeTx);
+  txs.push(...buildTimelockedCall(setFeeTx));
 
   return txs;
 }
@@ -247,6 +243,57 @@ export function useVaultV2({
     async (morphoRegistry: Address, marketAdapter: Address, allocator?: Address, _name?: string, _symbol?: string): Promise<boolean> => {
       if (!account || !vaultAddress || marketAdapter === zeroAddress) return false;
 
+      const client = getClient(chainIdToUse);
+      const contractBase = { address: vaultAddress, abi: vaultv2Abi } as const;
+      const allocatorToCheck = allocator ?? zeroAddress;
+      const [
+        currentCuratorResult,
+        currentRegistryResult,
+        isAdapterResult,
+        forceDeallocatePenaltyResult,
+        isSelfAllocatorResult,
+        maxRateResult,
+        isInitialAllocatorResult,
+        performanceFeeResult,
+        performanceFeeRecipientResult,
+      ] = await client.multicall({
+        contracts: [
+          { ...contractBase, functionName: 'curator', args: [] },
+          { ...contractBase, functionName: 'adapterRegistry', args: [] },
+          { ...contractBase, functionName: 'isAdapter', args: [marketAdapter] },
+          { ...contractBase, functionName: 'forceDeallocatePenalty', args: [marketAdapter] },
+          { ...contractBase, functionName: 'isAllocator', args: [account] },
+          { ...contractBase, functionName: 'maxRate', args: [] },
+          { ...contractBase, functionName: 'isAllocator', args: [allocatorToCheck] },
+          { ...contractBase, functionName: 'performanceFee', args: [] },
+          { ...contractBase, functionName: 'performanceFeeRecipient', args: [] },
+        ],
+        allowFailure: true,
+      });
+      const abdicationResults = await client.multicall({
+        contracts: VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS.map((selector) => ({
+          ...contractBase,
+          functionName: 'abdicated' as const,
+          args: [selector],
+        })),
+        allowFailure: true,
+      });
+      const currentCurator = currentCuratorResult.status === 'success' ? (currentCuratorResult.result as Address) : curator;
+      const currentRegistry = currentRegistryResult.status === 'success' ? (currentRegistryResult.result as Address) : zeroAddress;
+      const isAdapterLinked = isAdapterResult.status === 'success' && isAdapterResult.result === true;
+      const currentForceDeallocatePenalty =
+        forceDeallocatePenaltyResult.status === 'success' ? (forceDeallocatePenaltyResult.result as bigint) : 0n;
+      const isSelfAllocator = isSelfAllocatorResult.status === 'success' && isSelfAllocatorResult.result === true;
+      const currentMaxRate = maxRateResult.status === 'success' ? (maxRateResult.result as bigint) : 0n;
+      const isInitialAllocator = isInitialAllocatorResult.status === 'success' && isInitialAllocatorResult.result === true;
+      const currentPerformanceFee = performanceFeeResult.status === 'success' ? (performanceFeeResult.result as bigint) : undefined;
+      const currentPerformanceFeeRecipient =
+        performanceFeeRecipientResult.status === 'success' ? (performanceFeeRecipientResult.result as Address) : undefined;
+      const abdicatedSelectors = new Set(
+        VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS.filter(
+          (_selector, index) => abdicationResults[index]?.status === 'success' && abdicationResults[index]?.result === true,
+        ),
+      );
       const txs: `0x${string}`[] = [];
 
       // Step 0 (Optional). Set vault metadata if provided (no timelock needed)
@@ -269,7 +316,7 @@ export function useVaultV2({
       }
 
       // Step 1. Assign curator if unset.
-      if (curator === zeroAddress) {
+      if (currentCurator === zeroAddress) {
         const setCuratorTx = encodeFunctionData({
           abi: vaultv2Abi,
           functionName: 'setCurator',
@@ -280,115 +327,95 @@ export function useVaultV2({
 
       // Abdicate exit-critical gate setters during initialization so the curator
       // cannot later lock users out of shares or asset withdrawals.
-      txs.push(...buildVaultV2GateAbdicationCalls());
+      const gateSettersToAbdicate = VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS.filter((selector) => !abdicatedSelectors.has(selector));
+      txs.push(...buildVaultV2AbdicationCalls(gateSettersToAbdicate));
 
       // Step 2. Commit to Morpho registry.
-      const setRegistryTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'setAdapterRegistry',
-        args: [morphoRegistry],
-      });
+      if (normalizeAddress(currentRegistry) !== morphoRegistry.toLowerCase()) {
+        const setRegistryTx = encodeFunctionData({
+          abi: vaultv2Abi,
+          functionName: 'setAdapterRegistry',
+          args: [morphoRegistry],
+        });
 
-      const submitSetRegistryTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'submit',
-        args: [setRegistryTx],
-      });
-
-      txs.push(submitSetRegistryTx, setRegistryTx);
+        txs.push(...buildTimelockedCall(setRegistryTx));
+      }
 
       // Step 3. Register the deployed adapter.
-      const addAdapterTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'addAdapter',
-        args: [marketAdapter],
-      });
+      if (!isAdapterLinked) {
+        const addAdapterTx = encodeFunctionData({
+          abi: vaultv2Abi,
+          functionName: 'addAdapter',
+          args: [marketAdapter],
+        });
 
-      const submitAddAdapterTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'submit',
-        args: [addAdapterTx],
-      });
+        txs.push(...buildTimelockedCall(addAdapterTx));
+      }
 
-      txs.push(submitAddAdapterTx, addAdapterTx);
+      if (currentForceDeallocatePenalty !== VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY) {
+        const setForceDeallocatePenaltyTx = encodeFunctionData({
+          abi: vaultv2Abi,
+          functionName: 'setForceDeallocatePenalty',
+          args: [marketAdapter, VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY],
+        });
 
-      const setForceDeallocatePenaltyTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'setForceDeallocatePenalty',
-        args: [marketAdapter, VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY],
-      });
-
-      const submitSetForceDeallocatePenaltyTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'submit',
-        args: [setForceDeallocatePenaltyTx],
-      });
-
-      txs.push(submitSetForceDeallocatePenaltyTx, setForceDeallocatePenaltyTx);
+        txs.push(...buildTimelockedCall(setForceDeallocatePenaltyTx));
+      }
 
       // Note: Adapter cap will be set when user configures market caps in settings
       // (EditCaps.tsx automatically ensures adapter cap is 100% + maxUint128)
 
       // Step 5. Abdicate registry control.
-      const abdicateSetAdapterRegistryTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'abdicate',
-        args: [VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR],
-      });
-
-      const submitAbdicateSetAdapterRegistryTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'submit',
-        args: [abdicateSetAdapterRegistryTx],
-      });
-
-      txs.push(submitAbdicateSetAdapterRegistryTx, abdicateSetAdapterRegistryTx);
+      if (!abdicatedSelectors.has(VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR)) {
+        txs.push(...buildVaultV2AbdicationCalls([VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR]));
+      }
 
       // Step 6.1 Set user as allocator (for withdrawal / setting Withdrawal Data)
-      const setSelfAllocatorTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'setIsAllocator',
-        args: [account, true],
-      });
+      if (!isSelfAllocator) {
+        const setSelfAllocatorTx = encodeFunctionData({
+          abi: vaultv2Abi,
+          functionName: 'setIsAllocator',
+          args: [account, true],
+        });
 
-      const submitSetSelfAllocatorTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'submit',
-        args: [setSelfAllocatorTx],
-      });
-
-      txs.push(submitSetSelfAllocatorTx, setSelfAllocatorTx);
+        txs.push(...buildTimelockedCall(setSelfAllocatorTx));
+      }
 
       // Step 6.2 As allocator, set max apy
-      const setMaxAPYTx = encodeFunctionData({
-        abi: vaultv2Abi,
-        functionName: 'setMaxRate',
-        args: [VAULT_V2_DEFAULT_MAX_RATE],
-      });
+      if (currentMaxRate !== VAULT_V2_DEFAULT_MAX_RATE) {
+        const setMaxAPYTx = encodeFunctionData({
+          abi: vaultv2Abi,
+          functionName: 'setMaxRate',
+          args: [VAULT_V2_DEFAULT_MAX_RATE],
+        });
 
-      txs.push(setMaxAPYTx);
+        txs.push(setMaxAPYTx);
+      }
 
       // Step 6.3 (Optional). Set initial allocator if provided.
-      if (allocator && allocator !== zeroAddress) {
+      if (allocator && allocator !== zeroAddress && !isInitialAllocator) {
         const setAllocatorTx = encodeFunctionData({
           abi: vaultv2Abi,
           functionName: 'setIsAllocator',
           args: [allocator, true],
         });
 
-        const submitSetAllocatorTx = encodeFunctionData({
-          abi: vaultv2Abi,
-          functionName: 'submit',
-          args: [setAllocatorTx],
-        });
+        txs.push(...buildTimelockedCall(setAllocatorTx));
+      }
 
-        txs.push(submitSetAllocatorTx, setAllocatorTx);
+      // Step 6.4 (Optional). Apply performance fee if allocator is a known agent with a fee.
+      const agent = allocator && allocator !== zeroAddress ? findAgent(allocator) : undefined;
+      if (
+        agent?.performanceFee !== undefined &&
+        agent.performanceFeeRecipient &&
+        (currentPerformanceFee !== agent.performanceFee ||
+          normalizeAddress(currentPerformanceFeeRecipient) !== agent.performanceFeeRecipient.toLowerCase())
+      ) {
+        txs.push(...buildPerformanceFeeCalls({ fee: agent.performanceFee, recipient: agent.performanceFeeRecipient }));
+      }
 
-        // Step 6.4 (Optional). Apply performance fee if allocator is a known agent with a fee.
-        const agent = findAgent(allocator);
-        if (agent?.performanceFee !== undefined && agent.performanceFeeRecipient) {
-          txs.push(...buildPerformanceFeeCalls({ fee: agent.performanceFee, recipient: agent.performanceFeeRecipient }));
-        }
+      if (txs.length === 0) {
+        return true;
       }
 
       // Step 7. Execute multicall with all steps.

--- a/src/hooks/useVaultV2.ts
+++ b/src/hooks/useVaultV2.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { type Address, encodeFunctionData, zeroAddress } from 'viem';
+import { type Address, encodeFunctionData, toFunctionSelector, zeroAddress } from 'viem';
 import { useQueryClient } from '@tanstack/react-query';
 import { useConnection, useChainId, useReadContracts } from 'wagmi';
 import { vaultv2Abi } from '@/abis/vaultv2';
@@ -15,6 +15,33 @@ export type PerformanceFeeConfig = {
   fee: bigint;
   recipient: Address;
 };
+
+export const VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES = [
+  'setReceiveSharesGate(address)',
+  'setSendSharesGate(address)',
+  'setReceiveAssetsGate(address)',
+  'setSendAssetsGate(address)',
+] as const;
+
+export const VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS = VAULT_V2_ABDICATED_GATE_SETTER_SIGNATURES.map(toFunctionSelector);
+
+export function buildVaultV2GateAbdicationCalls(): `0x${string}`[] {
+  return VAULT_V2_ABDICATED_GATE_SETTER_SELECTORS.flatMap((selector) => {
+    const abdicateGateSetterTx = encodeFunctionData({
+      abi: vaultv2Abi,
+      functionName: 'abdicate',
+      args: [selector],
+    });
+
+    const submitAbdicateGateSetterTx = encodeFunctionData({
+      abi: vaultv2Abi,
+      functionName: 'submit',
+      args: [abdicateGateSetterTx],
+    });
+
+    return [submitAbdicateGateSetterTx, abdicateGateSetterTx];
+  });
+}
 
 /**
  * Builds timelocked transaction calls for setting performance fee recipient and fee.
@@ -253,6 +280,12 @@ export function useVaultV2({
         });
         txs.push(setCuratorTx);
       }
+
+      // Abdicate the full gate setter surface during initialization. Morpho flags
+      // receive-shares, send-shares, and receive-assets gates as critical; send-assets
+      // belongs to the same transfer-gate family, so Monarch-created vaults should not
+      // retain curator control over it either.
+      txs.push(...buildVaultV2GateAbdicationCalls());
 
       // Step 2. Commit to Morpho registry.
       const setRegistryTx = encodeFunctionData({

--- a/src/hooks/useVaultV2InitializationStatus.ts
+++ b/src/hooks/useVaultV2InitializationStatus.ts
@@ -1,0 +1,151 @@
+import { useCallback, useMemo } from 'react';
+import { type Address, zeroAddress } from 'viem';
+import { useReadContracts } from 'wagmi';
+import { vaultv2Abi } from '@/abis/vaultv2';
+import { getNetworkConfig, type SupportedNetworks } from '@/utils/networks';
+import { VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY, VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS } from '@/utils/vaultV2Setup';
+
+export type VaultV2MissingSetupRequirement = 'adapter' | 'adapterRegistry' | 'curator' | 'forceDeallocatePenalty' | 'setupAbdications';
+
+const normalizeAddress = (value: unknown): string => (typeof value === 'string' ? value.toLowerCase() : '');
+
+export function useVaultV2InitializationStatus({
+  adapterAddress,
+  chainId,
+  vaultAddress,
+}: {
+  adapterAddress?: Address;
+  chainId: SupportedNetworks;
+  vaultAddress?: Address;
+}) {
+  const expectedRegistry = useMemo(() => {
+    try {
+      return getNetworkConfig(chainId).vaultConfig?.morphoRegistry;
+    } catch (_error) {
+      return undefined;
+    }
+  }, [chainId]);
+
+  const vaultAddressToCheck = vaultAddress ?? zeroAddress;
+  const adapterAddressToCheck = adapterAddress ?? zeroAddress;
+  const enabled = vaultAddressToCheck !== zeroAddress;
+
+  const {
+    data: setupCoreResults,
+    error,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useReadContracts({
+    allowFailure: true,
+    contracts: enabled
+      ? [
+          {
+            address: vaultAddressToCheck,
+            abi: vaultv2Abi,
+            functionName: 'adapterRegistry',
+            args: [],
+            chainId,
+          },
+          {
+            address: vaultAddressToCheck,
+            abi: vaultv2Abi,
+            functionName: 'curator',
+            args: [],
+            chainId,
+          },
+          {
+            address: vaultAddressToCheck,
+            abi: vaultv2Abi,
+            functionName: 'isAdapter',
+            args: [adapterAddressToCheck],
+            chainId,
+          },
+          {
+            address: vaultAddressToCheck,
+            abi: vaultv2Abi,
+            functionName: 'forceDeallocatePenalty',
+            args: [adapterAddressToCheck],
+            chainId,
+          },
+        ]
+      : [],
+    query: {
+      enabled,
+      staleTime: 10_000,
+      refetchOnWindowFocus: false,
+    },
+  });
+
+  const {
+    data: abdicationResults,
+    error: abdicationError,
+    isFetching: isFetchingAbdications,
+    isLoading: isLoadingAbdications,
+    refetch: refetchAbdications,
+  } = useReadContracts({
+    allowFailure: true,
+    contracts: enabled
+      ? VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS.map((selector) => ({
+          address: vaultAddressToCheck,
+          abi: vaultv2Abi,
+          functionName: 'abdicated' as const,
+          args: [selector],
+          chainId,
+        }))
+      : [],
+    query: {
+      enabled,
+      staleTime: 10_000,
+      refetchOnWindowFocus: false,
+    },
+  });
+
+  const missingRequirements = useMemo<VaultV2MissingSetupRequirement[]>(() => {
+    const adapterRegistry = setupCoreResults?.[0]?.status === 'success' ? (setupCoreResults[0].result as Address) : undefined;
+    const curator = setupCoreResults?.[1]?.status === 'success' ? (setupCoreResults[1].result as Address) : undefined;
+    const isLinkedAdapter = setupCoreResults?.[2]?.status === 'success' ? setupCoreResults[2].result === true : false;
+    const forceDeallocatePenalty = setupCoreResults?.[3]?.status === 'success' ? (setupCoreResults[3].result as bigint) : undefined;
+    const setupAbdicationsComplete = VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS.every(
+      (_selector, index) => abdicationResults?.[index]?.status === 'success' && abdicationResults[index]?.result === true,
+    );
+
+    const missing: VaultV2MissingSetupRequirement[] = [];
+
+    if (!adapterAddress || adapterAddress === zeroAddress || !isLinkedAdapter) {
+      missing.push('adapter');
+    }
+
+    if (expectedRegistry && normalizeAddress(adapterRegistry) !== expectedRegistry.toLowerCase()) {
+      missing.push('adapterRegistry');
+    }
+
+    if (!curator || curator === zeroAddress) {
+      missing.push('curator');
+    }
+
+    if (adapterAddress && adapterAddress !== zeroAddress && forceDeallocatePenalty !== VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY) {
+      missing.push('forceDeallocatePenalty');
+    }
+
+    if (!setupAbdicationsComplete) {
+      missing.push('setupAbdications');
+    }
+
+    return missing;
+  }, [adapterAddress, abdicationResults, expectedRegistry, setupCoreResults]);
+
+  const refetchSetupStatus = useCallback(async () => {
+    const [setupResult] = await Promise.all([refetch(), refetchAbdications()]);
+    return setupResult;
+  }, [refetch, refetchAbdications]);
+
+  return {
+    error: error ?? abdicationError,
+    isComplete: enabled && !isLoading && !isLoadingAbdications && missingRequirements.length === 0,
+    isFetching: isFetching || isFetchingAbdications,
+    isLoading: isLoading || isLoadingAbdications,
+    missingRequirements,
+    refetch: refetchSetupStatus,
+  };
+}

--- a/src/utils/vaultV2Setup.ts
+++ b/src/utils/vaultV2Setup.ts
@@ -1,0 +1,21 @@
+import { toFunctionSelector } from 'viem';
+
+export const VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SIGNATURES = [
+  'setReceiveSharesGate(address)',
+  'setSendSharesGate(address)',
+  'setReceiveAssetsGate(address)',
+] as const;
+
+export const VAULT_V2_SET_ADAPTER_REGISTRY_SIGNATURE = 'setAdapterRegistry(address)' as const;
+
+export const VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS = VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SIGNATURES.map(toFunctionSelector);
+
+export const VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR = toFunctionSelector(VAULT_V2_SET_ADAPTER_REGISTRY_SIGNATURE);
+
+export const VAULT_V2_INITIALIZATION_ABDICATED_SELECTORS = [
+  ...VAULT_V2_EXIT_CRITICAL_GATE_SETTER_SELECTORS,
+  VAULT_V2_SET_ADAPTER_REGISTRY_SELECTOR,
+];
+
+export const VAULT_V2_DEFAULT_FORCE_DEALLOCATE_PENALTY = 5_000_000_000_000_000n; // 0.5%, WAD-scaled.
+export const VAULT_V2_DEFAULT_MAX_RATE = 63_419_583_967n; // 200% APR.


### PR DESCRIPTION
## Summary
- force AutoVault initialization to abdicate transfer/asset gate setter selectors
- centralize gate setter signatures and derive selectors with viem
- include sendAssetsGate with the same gate surface so curator control over all gate setters is removed
