### PR TITLE
Color reward side badges

### DIFF
--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-green-100 text-green-700 ring-green-500/40 dark:bg-green-800/30 dark:text-green-400 dark:ring-green-400/40',
+    badgeClassName: 'bg-green-800 text-green-200',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-red-100 text-red-700 ring-red-500/40 dark:bg-red-800/30 dark:text-red-400 dark:ring-red-400/40',
+    badgeClassName: 'bg-red-800 text-red-200',
   },
 };
 
@@ -46,7 +46,7 @@ function RewardSideIcon({ side, size }: { side: RewardSide; size: number }) {
         aria-hidden="true"
       />
       <span
-        className={`absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full border border-background font-monospace font-medium shadow-sm ring-1 ${config.badgeClassName}`}
+        className={`absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full border border-background font-monospace font-medium ${config.badgeClassName}`}
         style={{
           width: badgeSize,
           height: badgeSize,

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-green-100 text-green-800 dark:bg-green-400/10 dark:text-green-300',
+    badgeClassName: 'bg-white text-green-800 dark:bg-white dark:text-green-800',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-red-100 text-red-800 dark:bg-red-400/10 dark:text-red-300',
+    badgeClassName: 'bg-white text-red-800 dark:bg-white dark:text-red-800',
   },
 };
 

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-white text-green-800 dark:bg-white dark:text-green-800',
+    badgeClassName: 'bg-white text-green-500 dark:bg-white dark:text-green-500',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-white text-red-800 dark:bg-white dark:text-red-800',
+    badgeClassName: 'bg-white text-red-500 dark:bg-white dark:text-red-500',
   },
 };
 

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-white text-green-500 dark:bg-white dark:text-green-500',
+    badgeClassName: 'bg-green-500 text-white',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-white text-red-500 dark:bg-white dark:text-red-500',
+    badgeClassName: 'bg-red-500 text-white',
   },
 };
 

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-green-500 text-green-950',
+    badgeClassName: 'bg-green-100 text-green-800 dark:bg-green-400/10 dark:text-green-300',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-red-500 text-[#350707]',
+    badgeClassName: 'bg-red-100 text-red-800 dark:bg-red-400/10 dark:text-red-300',
   },
 };
 

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-[#4a6b58] text-[#e2f0e6]',
+    badgeClassName: 'bg-green-500 text-green-950',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-[#7b5a53] text-[#f4ddd7]',
+    badgeClassName: 'bg-red-500 text-[#350707]',
   },
 };
 

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -16,9 +16,17 @@ type RewardSide = 'supplier' | 'borrower';
 
 const REWARD_SIDES: RewardSide[] = ['supplier', 'borrower'];
 
-const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string }> = {
-  supplier: { letter: 'S', label: 'Supplier rewards' },
-  borrower: { letter: 'B', label: 'Borrower rewards' },
+const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; badgeClassName: string }> = {
+  supplier: {
+    letter: 'S',
+    label: 'Supplier rewards',
+    badgeClassName: 'bg-green-100 text-green-600 ring-green-500/40 dark:bg-green-800/30 dark:text-green-400 dark:ring-green-400/40',
+  },
+  borrower: {
+    letter: 'B',
+    label: 'Borrower rewards',
+    badgeClassName: 'bg-red-100 text-red-600 ring-red-500/40 dark:bg-red-800/30 dark:text-red-400 dark:ring-red-400/40',
+  },
 };
 
 function RewardSideIcon({ side, size }: { side: RewardSide; size: number }) {
@@ -38,7 +46,7 @@ function RewardSideIcon({ side, size }: { side: RewardSide; size: number }) {
         aria-hidden="true"
       />
       <span
-        className="absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full border border-background bg-surface font-monospace font-medium text-primary shadow-sm ring-1 ring-border"
+        className={`absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full border border-background font-monospace font-medium shadow-sm ring-1 ${config.badgeClassName}`}
         style={{
           width: badgeSize,
           height: badgeSize,

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-green-100 text-green-600 ring-green-500/40 dark:bg-green-800/30 dark:text-green-400 dark:ring-green-400/40',
+    badgeClassName: 'bg-green-100 text-green-700 ring-green-500/40 dark:bg-green-800/30 dark:text-green-400 dark:ring-green-400/40',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-red-100 text-red-600 ring-red-500/40 dark:bg-red-800/30 dark:text-red-400 dark:ring-red-400/40',
+    badgeClassName: 'bg-red-100 text-red-700 ring-red-500/40 dark:bg-red-800/30 dark:text-red-400 dark:ring-red-400/40',
   },
 };
 

--- a/src/features/markets/components/rewards-indicator.tsx
+++ b/src/features/markets/components/rewards-indicator.tsx
@@ -20,12 +20,12 @@ const REWARD_SIDE_CONFIG: Record<RewardSide, { letter: string; label: string; ba
   supplier: {
     letter: 'S',
     label: 'Supplier rewards',
-    badgeClassName: 'bg-green-800 text-green-200',
+    badgeClassName: 'bg-[#4a6b58] text-[#e2f0e6]',
   },
   borrower: {
     letter: 'B',
     label: 'Borrower rewards',
-    badgeClassName: 'bg-red-800 text-red-200',
+    badgeClassName: 'bg-[#7b5a53] text-[#f4ddd7]',
   },
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the reward indicator badge styling to vary by side (supplier vs borrower) using side-specific class configuration.
  * Improved badge rendering so the two sides are visually distinct at a glance, enhancing clarity in the markets UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->