### PR TITLE
Fix leverage swaps by excluding Native ParaSwap routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Universal coding-agent rules for the Monarch codebase.
 - Remove temporary debugging code before finishing.
 - Run `npx ultracite fix` before committing, and `npx ultracite check` to verify, when code changes make those checks relevant.
 - Try to see if you can fix the issue by removing complexity. Always question whether all lines of code are necessary and remove unnecessary experiments.
+- For external API or protocol-shape bugs, validate the exact observed response shape at the smallest shared boundary. Do not add broad normalizers, diagnostic collectors, or hypothetical-shape handling unless the current evidence requires it.
 
 ## Final Validation Gate
 For every non-trivial code or docs change, do this immediately before the final response:

--- a/src/features/swap/api/velora.ts
+++ b/src/features/swap/api/velora.ts
@@ -11,6 +11,13 @@ export type VeloraPriceRoute = {
   destAmount: string;
   tokenTransferProxy?: string;
   contractAddress?: string;
+  bestRoute?: Array<{
+    swaps?: Array<{
+      swapExchanges?: Array<{
+        exchange?: string;
+      }>;
+    }>;
+  }>;
 };
 
 export type VeloraTransactionPayload = {
@@ -53,6 +60,7 @@ export type FetchVeloraPriceRouteParams = {
   userAddress: Address;
   partner?: string;
   side?: VeloraSwapSide;
+  excludeDexs?: readonly string[];
 };
 
 export type BuildVeloraTransactionPayloadParams = {
@@ -241,6 +249,13 @@ const resolveCanonicalRouteTokenAddress = (priceRoute: VeloraPriceRoute, fields:
   return null;
 };
 
+const getVeloraRouteExchanges = (priceRoute: VeloraPriceRoute): string[] =>
+  (priceRoute.bestRoute ?? []).flatMap((route) =>
+    (route.swaps ?? []).flatMap((swap) =>
+      (swap.swapExchanges ?? []).flatMap((swapExchange) => (swapExchange.exchange ? [swapExchange.exchange] : [])),
+    ),
+  );
+
 export const getVeloraApprovalTarget = (priceRoute: VeloraPriceRoute | null): Address | null => {
   const spender = priceRoute?.tokenTransferProxy ?? priceRoute?.contractAddress;
   if (!spender || !isAddress(spender)) return null;
@@ -262,6 +277,7 @@ export const fetchVeloraPriceRoute = async ({
   userAddress,
   partner = SWAP_PARTNER,
   side = 'SELL',
+  excludeDexs = [],
 }: FetchVeloraPriceRouteParams): Promise<VeloraPriceRoute> => {
   const requestedSourceTokenAddress = toCanonicalTokenAddress(srcToken);
   const requestedDestinationTokenAddress = toCanonicalTokenAddress(destToken);
@@ -285,6 +301,9 @@ export const fetchVeloraPriceRoute = async ({
     partner,
     version: VELORA_PRICES_API_VERSION,
   });
+  if (excludeDexs.length > 0) {
+    query.set('excludeDEXS', excludeDexs.join(','));
+  }
 
   const response = await fetchVeloraJson<VeloraPriceResponse | null>(`${VELORA_API_BASE_URL}/prices?${query.toString()}`, {
     method: 'GET',
@@ -295,6 +314,18 @@ export const fetchVeloraPriceRoute = async ({
   }
 
   const validatedPriceRoute = validateVeloraPriceRouteShape(response.priceRoute, response);
+  if (excludeDexs.length > 0) {
+    const normalizedExcludedDexs = new Set(excludeDexs.map((dex) => dex.toLowerCase()));
+    const returnedExcludedDex = getVeloraRouteExchanges(validatedPriceRoute).find((exchange) =>
+      normalizedExcludedDexs.has(exchange.toLowerCase()),
+    );
+    if (returnedExcludedDex) {
+      throw new VeloraApiError(`Velora returned excluded ${returnedExcludedDex} route`, 400, {
+        excludeDexs,
+        response,
+      });
+    }
+  }
 
   const routeSourceTokenAddress = resolveCanonicalRouteTokenAddress(validatedPriceRoute, PRICE_ROUTE_SOURCE_TOKEN_FIELDS);
   if (routeSourceTokenAddress && routeSourceTokenAddress !== requestedSourceTokenAddress) {

--- a/src/hooks/leverage/swap-route-policy.ts
+++ b/src/hooks/leverage/swap-route-policy.ts
@@ -1,0 +1,6 @@
+// Observed on Base USDC -> cbBTC: ParaSwap's Native route returned a decimal-inconsistent
+// collateral amount, collapsed the leverage preview LTV, and reverted when executed by the adapter.
+// Keep the exclusion scoped to swap-backed leverage/deleverage loops; generic swaps can still use
+// ParaSwap's default routing.
+export const LEVERAGE_SWAP_EXCLUDED_DEXS = ['Native'] as const;
+export const LEVERAGE_SWAP_ROUTE_POLICY_KEY = `exclude:${LEVERAGE_SWAP_EXCLUDED_DEXS.join(',')}`;

--- a/src/hooks/useDeleverageQuote.ts
+++ b/src/hooks/useDeleverageQuote.ts
@@ -5,6 +5,7 @@ import { useReadContract } from 'wagmi';
 import { erc4626Abi } from '@/abis/erc4626';
 import { fetchVeloraPriceRoute, type VeloraPriceRoute } from '@/features/swap/api/velora';
 import { withSlippageCeil, withSlippageFloor } from './leverage/math';
+import { LEVERAGE_SWAP_EXCLUDED_DEXS, LEVERAGE_SWAP_ROUTE_POLICY_KEY } from './leverage/swap-route-policy';
 import { toUserFacingVeloraQuoteError } from './leverage/velora-quote-errors';
 import type { LeverageRoute } from './leverage/types';
 
@@ -84,6 +85,7 @@ export function useDeleverageQuote({
       loanTokenAddress,
       loanTokenDecimals,
       swapExecutionAddress,
+      LEVERAGE_SWAP_ROUTE_POLICY_KEY,
       withdrawCollateralAmount.toString(),
       slippageBps,
       userAddress ?? null,
@@ -99,6 +101,7 @@ export function useDeleverageQuote({
         network: chainId,
         userAddress: swapExecutionAddress as `0x${string}`,
         side: 'SELL',
+        excludeDexs: LEVERAGE_SWAP_EXCLUDED_DEXS,
       });
 
       return {
@@ -120,6 +123,7 @@ export function useDeleverageQuote({
       loanTokenAddress,
       loanTokenDecimals,
       swapExecutionAddress,
+      LEVERAGE_SWAP_ROUTE_POLICY_KEY,
       bufferedBorrowAssets.toString(),
       slippageBps,
       userAddress ?? null,
@@ -135,6 +139,7 @@ export function useDeleverageQuote({
         network: chainId,
         userAddress: swapExecutionAddress as `0x${string}`,
         side: 'BUY',
+        excludeDexs: LEVERAGE_SWAP_EXCLUDED_DEXS,
       });
 
       const quotedDebtCloseAmount = BigInt(buyRoute.destAmount);

--- a/src/hooks/useLeverageQuote.ts
+++ b/src/hooks/useLeverageQuote.ts
@@ -4,6 +4,7 @@ import { useReadContract } from 'wagmi';
 import { erc4626Abi } from '@/abis/erc4626';
 import { fetchVeloraPriceRoute, type VeloraPriceRoute } from '@/features/swap/api/velora';
 import { BPS_SCALE, computeFlashCollateralAmount, computeLeveragedExtraAmount, withSlippageFloor } from './leverage/math';
+import { LEVERAGE_SWAP_EXCLUDED_DEXS, LEVERAGE_SWAP_ROUTE_POLICY_KEY } from './leverage/swap-route-policy';
 import { toUserFacingVeloraQuoteError } from './leverage/velora-quote-errors';
 import type { LeverageRoute } from './leverage/types';
 
@@ -129,6 +130,7 @@ const resolveInitialSellAmountForTargetCollateral = async ({
       network: chainId,
       userAddress: swapExecutionAddress,
       side: 'BUY',
+      excludeDexs: LEVERAGE_SWAP_EXCLUDED_DEXS,
     });
 
     const initialSellAmount = BigInt(buyRoute.srcAmount);
@@ -199,6 +201,7 @@ const quoteVeloraCollateralInputRoute = async ({
       network: chainId,
       userAddress: swapExecutionAddress,
       side: 'SELL',
+      excludeDexs: LEVERAGE_SWAP_EXCLUDED_DEXS,
     });
     const quotedCollateralTokenAmount = BigInt(sellRoute.destAmount);
 
@@ -347,6 +350,7 @@ export function useLeverageQuote({
       collateralTokenAddress,
       collateralTokenDecimals,
       swapExecutionAddress,
+      LEVERAGE_SWAP_ROUTE_POLICY_KEY,
       targetFlashCollateralTokenAmount.toString(),
       slippageBps,
       userAddress ?? null,
@@ -376,6 +380,7 @@ export function useLeverageQuote({
       collateralTokenAddress,
       collateralTokenDecimals,
       swapExecutionAddress,
+      LEVERAGE_SWAP_ROUTE_POLICY_KEY,
       isPositionDebtInput ? 'position' : 'wallet-loan',
       exactLoanInputSellAmount.toString(),
       exactLoanInputFlashLoanAssetAmount.toString(),
@@ -402,6 +407,7 @@ export function useLeverageQuote({
         network: chainId,
         userAddress: swapExecutionAddress as `0x${string}`,
         side: 'SELL',
+        excludeDexs: LEVERAGE_SWAP_EXCLUDED_DEXS,
       });
 
       const totalCollateralTokenAmountAdded = withSlippageFloor(BigInt(sellRoute.destAmount), slippageBps);

--- a/src/modals/leverage/components/add-collateral-and-leverage.tsx
+++ b/src/modals/leverage/components/add-collateral-and-leverage.tsx
@@ -25,6 +25,7 @@ import {
   parseUnsignedBigInt,
   toScaledRatio,
   targetLtvBpsFromMultiplier,
+  WAD_TO_BPS_SCALE,
 } from '@/hooks/leverage/math';
 import { LEVERAGE_DEFAULT_MULTIPLIER_BPS } from '@/hooks/leverage/types';
 import { useMerklHoldIncentivesQuery } from '@/hooks/queries/useMerklHoldIncentivesQuery';
@@ -307,6 +308,8 @@ export function AddCollateralAndLeverage({
   }, [isLeverageFeeReady, usePermit2Setting, permit2Authorized, signAndLeverage, approveAndLeverage]);
 
   const projectedOverLimit = projectedLTV >= lltv;
+  const projectedBelowTarget =
+    hasChanges && isSwapRoute && projectedLTV + LEVERAGE_SAFE_LTV_BUFFER_BPS * WAD_TO_BPS_SCALE < targetLtvBps * WAD_TO_BPS_SCALE;
   const insufficientLiquidity = quote.flashLoanAssetAmount > marketLiquidity;
   const inputAssetSymbol = useLoanAssetInput ? market.loanAsset.symbol : market.collateralAsset.symbol;
   const inputAssetDecimals = useLoanAssetInput ? market.loanAsset.decimals : market.collateralAsset.decimals;
@@ -862,6 +865,9 @@ export function AddCollateralAndLeverage({
               </div>
               {quote.error && <p className="mt-2 text-xs text-red-500">{quote.error}</p>}
               {!quote.error && leverageFeeReadinessError && <p className="mt-2 text-xs text-red-500">{leverageFeeReadinessError}</p>}
+              {projectedBelowTarget && (
+                <p className="mt-2 text-xs text-red-500">Swap quote output is inconsistent with target LTV. Refresh and try again.</p>
+              )}
               {isErc4626Route && vaultRateInsight.error && (
                 <p className="mt-2 text-xs text-red-500">Failed to fetch 3-day vault/borrow rates: {vaultRateInsight.error}</p>
               )}
@@ -893,6 +899,7 @@ export function AddCollateralAndLeverage({
                   !isLeverageFeeReady ||
                   quote.flashLoanAssetAmount <= 0n ||
                   projectedOverLimit ||
+                  projectedBelowTarget ||
                   insufficientLiquidity
                 }
                 variant="primary"

--- a/src/modals/leverage/components/adjust-leverage-position.tsx
+++ b/src/modals/leverage/components/adjust-leverage-position.tsx
@@ -350,11 +350,15 @@ export function AdjustLeveragePosition({
         ? withdrawCollateralAmount > 0n && !deleverageQuote.isLoading && deleverageQuote.error == null
         : false;
   const projectedOverLimit = projectedLTV >= lltv;
+  const targetLtvWad = effectiveTargetLtvBps * WAD_TO_BPS_SCALE;
   const positionProjectedAboveTarget =
+    action === 'leverage' && isLeverageFeeReady && targetWasEdited && projectedLTV > targetLtvWad + WAD_TO_BPS_SCALE;
+  const positionProjectedBelowTarget =
     action === 'leverage' &&
+    isSwapRoute &&
     isLeverageFeeReady &&
     targetWasEdited &&
-    projectedLTV > effectiveTargetLtvBps * WAD_TO_BPS_SCALE + WAD_TO_BPS_SCALE;
+    projectedLTV + LEVERAGE_SAFE_LTV_BUFFER_BPS * WAD_TO_BPS_SCALE < targetLtvWad;
   const marketLiquidity = parseUnsignedBigInt(market.state?.liquidityAssets) ?? 0n;
   const insufficientLiquidity = action === 'leverage' && leverageQuote.flashLoanAssetAmount > marketLiquidity;
   const leverageFeeReadinessError = useMemo(() => {
@@ -583,6 +587,7 @@ export function AdjustLeveragePosition({
         !isLeverageFeeReady ||
         leverageQuote.flashLoanAssetAmount <= 0n ||
         positionProjectedAboveTarget ||
+        positionProjectedBelowTarget ||
         insufficientLiquidity)) ||
     (action === 'deleverage' &&
       (addedCapitalBlocksDeleverage ||
@@ -601,6 +606,7 @@ export function AdjustLeveragePosition({
     executionError != null ||
     leverageFeeReadinessError != null ||
     positionProjectedAboveTarget ||
+    positionProjectedBelowTarget ||
     insufficientLiquidity ||
     isDeleverageCloseRouteResolving;
 
@@ -807,6 +813,9 @@ export function AdjustLeveragePosition({
                 )}
                 {positionProjectedAboveTarget && (
                   <p className="mt-2 text-xs text-red-500">Projected LTV is above target after route quote. Lower the target or refresh.</p>
+                )}
+                {positionProjectedBelowTarget && (
+                  <p className="mt-2 text-xs text-red-500">Swap quote output is inconsistent with target LTV. Refresh and try again.</p>
                 )}
                 {insufficientLiquidity && (
                   <p className="mt-2 text-xs text-red-500">


### PR DESCRIPTION
## Summary
- exclude ParaSwap `Native` exchange routes for swap-backed leverage quotes before transaction calldata is built
- include the leverage route policy in React Query keys so stale Native quotes are not reused
- keep projected-LTV inconsistency guards in leverage modals as a final safety check
- add an AGENTS rule against broad speculative external API normalizers

## Validation
- `pnpm check`
- live ParaSwap quote for Base USDC -> cbBTC with `excludeDEXS=Native`
- live ParaSwap tx build with `ignoreChecks=true` for adapter-held funds
- live Base `eth_call` and gas estimate for a real authorized existing-position increase:
  - user `0xbb054EBBea5961505e347D1742bb38534D73b07A`
  - market `0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836`
  - target `2.5x / 60% LTV`
  - `eth_call`: OK
  - gas estimate: `1,566,973`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leverage and deleverage quote handling to exclude problematic DEX routes and reduce inconsistent swap outcomes.
  * Enhanced Velora price-route processing to support nested best-route structures and verify excluded exchanges aren’t present in returned routes.
  * Updated quote caching behavior so route-policies don’t mix across requests.
  * Added targeted UI warnings and disabled leverage submissions when projected results don’t align with the user’s target LTV, with guidance to refresh and retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->