### PR TITLE
Filter small markets from discovery badges

### DIFF
--- a/src/features/market-detail/components/market-header.tsx
+++ b/src/features/market-detail/components/market-header.tsx
@@ -35,6 +35,7 @@ import {
   MARKET_DISCOVERY_CATEGORIES,
   MARKET_DISCOVERY_CATEGORY_META,
   getMarketDiscoveryKey,
+  isMarketDiscoveryEligible,
   type MarketDiscoveryCategory,
 } from '@/features/markets/market-discovery';
 import { useMarketDiscoveryFlagsMap, type MarketDiscoveryFlag } from '@/hooks/queries/useMarketDiscoveryFlagsQuery';
@@ -520,12 +521,12 @@ export function MarketHeader({
     defer: true,
   });
   const discoveryItems = useMemo(() => {
-    if (!discoveryKey || !discoveryFlagsResponse?.flags) {
+    if (!market || !discoveryKey || !discoveryFlagsResponse?.flags || !isMarketDiscoveryEligible(market)) {
       return [];
     }
 
     return getDiscoveryItems(flagsByMarket.get(discoveryKey) ?? [], categoriesByMarket.get(discoveryKey));
-  }, [categoriesByMarket, discoveryFlagsResponse?.flags, discoveryKey, flagsByMarket]);
+  }, [categoriesByMarket, discoveryFlagsResponse?.flags, discoveryKey, flagsByMarket, market]);
 
   if (isLoading || !market) {
     return <MarketHeaderSkeleton />;

--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -12,6 +12,7 @@ import { TrustedByCell } from '@/features/autovault/components/trusted-vault-bad
 import type { TrustedVault } from '@/constants/vaults/known_vaults';
 import type { MarketV2SupplyingVault } from '@/data-sources/monarch-api/vaults';
 import type { MarketDiscoveryCategory } from '@/features/markets/market-discovery';
+import { isMarketDiscoveryEligible } from '@/features/markets/market-discovery';
 import { useMarketDiscoveryFlagsMap } from '@/hooks/queries/useMarketDiscoveryFlagsQuery';
 import { useRateLabel } from '@/hooks/useRateLabel';
 import { useStyledToast } from '@/hooks/useStyledToast';
@@ -135,8 +136,9 @@ export function MarketTableBody({
         const isStared = starredMarkets.includes(item.uniqueKey);
         const marketKey = getMetricsKey(item.morphoBlue.chain.id, item.uniqueKey);
         const metrics = metricsMap.get(marketKey);
-        const discoveryFlags = flagsByMarket.get(marketKey) ?? [];
-        const marketDiscoveryCategories = categoriesByMarket.get(marketKey);
+        const isDiscoveryEligible = isMarketDiscoveryEligible(item);
+        const discoveryFlags = isDiscoveryEligible ? (flagsByMarket.get(marketKey) ?? []) : [];
+        const marketDiscoveryCategories = isDiscoveryEligible ? categoriesByMarket.get(marketKey) : undefined;
         const resolvedDiscoveryCategories = discoveryDataLoaded
           ? (marketDiscoveryCategories ?? new Set<MarketDiscoveryCategory>())
           : marketDiscoveryCategories;

--- a/src/features/markets/market-discovery.ts
+++ b/src/features/markets/market-discovery.ts
@@ -1,4 +1,7 @@
+import type { Market } from '@/utils/types';
+
 export const MARKET_DISCOVERY_CATEGORIES = ['newOpportunities', 'trending', 'popular'] as const;
+export const MARKET_DISCOVERY_MIN_MARKET_SIZE_USD = 50_000;
 
 export type MarketDiscoveryCategory = (typeof MARKET_DISCOVERY_CATEGORIES)[number];
 
@@ -24,3 +27,12 @@ export const MARKET_DISCOVERY_CATEGORY_META: Record<
 };
 
 export const getMarketDiscoveryKey = (chainId: number, uniqueKey: string): string => `${chainId}-${uniqueKey.toLowerCase()}`;
+
+export const getMarketDiscoverySizeUsd = (market: Market): number => {
+  const supplyUsd = Number(market.state?.supplyAssetsUsd ?? 0);
+  const borrowUsd = Number(market.state?.borrowAssetsUsd ?? 0);
+  return Math.max(supplyUsd, borrowUsd);
+};
+
+export const isMarketDiscoveryEligible = (market: Market): boolean =>
+  getMarketDiscoverySizeUsd(market) >= MARKET_DISCOVERY_MIN_MARKET_SIZE_USD;

--- a/src/hooks/useFilteredMarkets.ts
+++ b/src/hooks/useFilteredMarkets.ts
@@ -10,6 +10,7 @@ import { useTokensQuery } from '@/hooks/queries/useTokensQuery';
 import { useOfficialTrendingMarketKeys, useCustomTagMarketKeys, getMetricsKey } from '@/hooks/queries/useMarketMetricsQuery';
 import { useMarketDiscoveryPriorityMap } from '@/hooks/queries/useMarketDiscoveryFlagsQuery';
 import { filterMarkets, sortMarkets, createPropertySort, createStarredSort } from '@/utils/marketFilters';
+import { isMarketDiscoveryEligible } from '@/features/markets/market-discovery';
 import { SortColumn } from '@/features/markets/components/constants';
 import { getMarketRateEnrichmentKey, type MarketRateEnrichmentMap } from '@/utils/market-rate-enrichment';
 import { isMarketVisibleWithWhitelistGuard } from '@/utils/markets';
@@ -59,8 +60,8 @@ const prioritizeDiscoveryMarkets = (markets: Market[], discoveryPriorityMap: Map
   return [...markets].sort((a, b) => {
     const aKey = getMetricsKey(a.morphoBlue.chain.id, a.uniqueKey);
     const bKey = getMetricsKey(b.morphoBlue.chain.id, b.uniqueKey);
-    const aPriority = discoveryPriorityMap.get(aKey);
-    const bPriority = discoveryPriorityMap.get(bKey);
+    const aPriority = isMarketDiscoveryEligible(a) ? discoveryPriorityMap.get(aKey) : undefined;
+    const bPriority = isMarketDiscoveryEligible(b) ? discoveryPriorityMap.get(bKey) : undefined;
 
     if (aPriority === undefined && bPriority === undefined) {
       return 0;


### PR DESCRIPTION
## Summary
- add a shared 0k market-size floor for discovery eligibility
- stop tiny markets from receiving discovery badges on the markets table and market detail header
- avoid prioritizing sub-threshold markets when discovery categories are active

## Validation
- pnpm exec ultracite fix
- pnpm exec ultracite check
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market discovery eligibility based on market size.
  * Discovery indicators now only appear for eligible markets.
  * Market discovery ordering now respects the new eligibility rules.

* **Bug Fixes**
  * Prevented discovery badges and categories from showing on ineligible markets.
  * Improved consistency in discovery-related market sorting and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->