### PR TITLE
Fix mobile earnings period selector

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -82,7 +82,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
-        className={cn('p-1', position === 'popper' && 'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]')}
+        className={cn('max-h-[var(--radix-select-content-available-height)] p-1', position === 'popper' && 'w-full min-w-[var(--radix-select-trigger-width)]')}
       >
         {children}
       </SelectPrimitive.Viewport>


### PR DESCRIPTION
## Summary
- let shared Radix select menus expand to the available viewport height
- restore access to 3-month, 6-month, and all-time earnings periods on mobile

## Validation
- npx ultracite check src/components/ui/select.tsx
- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved select menu sizing to better match the available screen height.
  * Ensured pop-up select menus maintain the trigger’s width and minimum width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->