### PR TITLE
Fix Safari Markets storage crash

### DIFF
--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -62,6 +62,7 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 - Use an existing persisted Zustand store for user preferences or shared app state.
 - Use the project storage adapter (`local-storage-fallback`) only inside a small shared utility when the value is a browser-scoped hint or cache, not durable app state.
 - Storage utilities must namespace keys, normalize values, and catch unavailable-storage or quota failures.
+- Large API responses and metadata caches must use the IndexedDB-backed API response cache, not persisted Zustand/localStorage. Measure representative serialized payloads when cache size is not obviously bounded below WebKit's quota.
 - Validate SSR/client boundaries when persistence touches browser-only APIs.
 - Preset or subscription toggles must not delete user-owned persisted selections. Preserve the raw user list and dedupe or hide preset overlaps in derived views unless the user explicitly removes them.
 

--- a/src/hooks/useOracleMetadata.ts
+++ b/src/hooks/useOracleMetadata.ts
@@ -1,8 +1,9 @@
 import { useEffect, useMemo } from 'react';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useDeferredQueryEnable } from '@/hooks/useDeferredQueryEnable';
-import { useApiResponseCache } from '@/stores/useApiResponseCache';
-import { ALL_SUPPORTED_NETWORKS, type SupportedNetworks } from '@/utils/networks';
+import { usePersistedApiResponse } from '@/hooks/usePersistedApiResponse';
+import { SupportedNetworks } from '@/utils/networks';
+import { createPersistedApiResponseKey } from '@/utils/persistedApiResponseCache';
 
 /**
  * Oracle Metadata Types
@@ -139,7 +140,10 @@ export function getOracleMetadataKey(chainId: number, oracleAddress: string): st
   return `${chainId}-${oracleAddress.toLowerCase()}`;
 }
 
-const getOracleMetadataCacheKey = (chainId: number): string => `${ORACLE_GIST_BASE_URL ?? 'unset'}:${chainId}`;
+const getOracleMetadataCacheKey = (chainId: number): string =>
+  // Oracle metadata exceeds Safari's localStorage quota when chains are combined,
+  // so each chain uses the shared IndexedDB-backed API response cache.
+  createPersistedApiResponseKey('oracle-metadata:v1', [ORACLE_GIST_BASE_URL ?? 'unset', chainId]);
 
 /**
  * Fetch oracle metadata directly from the centralized Gist.
@@ -197,23 +201,28 @@ type OracleMetadataQueryOptions = {
 export function useOracleMetadata(chainId: SupportedNetworks | number | undefined, options?: OracleMetadataQueryOptions) {
   const requestedEnabled = Boolean(chainId) && (options?.enabled ?? true);
   const enabled = useDeferredQueryEnable(requestedEnabled, options?.defer ?? false, 2500);
-  const cacheKey = chainId == null ? null : getOracleMetadataCacheKey(chainId);
-  const cachedMetadata = useApiResponseCache((state) => (cacheKey ? state.oracleMetadataByKey[cacheKey] : undefined));
-  const setCachedMetadata = useApiResponseCache((state) => state.setOracleMetadata);
+  const cacheKey = getOracleMetadataCacheKey(chainId ?? 0);
+  const {
+    entry: cachedMetadata,
+    isReady: isPersistedCacheReady,
+    write: writeCachedMetadata,
+  } = usePersistedApiResponse<OracleMetadataFile>(cacheKey);
 
   const query = useQuery({
-    queryKey: ['oracle-metadata', ORACLE_GIST_BASE_URL ?? 'unset', chainId],
+    queryKey: isPersistedCacheReady
+      ? ['oracle-metadata', ORACLE_GIST_BASE_URL ?? 'unset', chainId]
+      : ['oracle-metadata', 'persisted-cache-loading', cacheKey],
     queryFn: () => (chainId ? fetchOracleMetadata(chainId) : Promise.resolve(null)),
-    enabled,
-    initialData: requestedEnabled ? cachedMetadata?.data : undefined,
-    initialDataUpdatedAt: requestedEnabled ? cachedMetadata?.updatedAt : undefined,
+    enabled: enabled && isPersistedCacheReady,
+    initialData: requestedEnabled && isPersistedCacheReady ? cachedMetadata?.data : undefined,
+    initialDataUpdatedAt: requestedEnabled && isPersistedCacheReady ? cachedMetadata?.updatedAt : undefined,
     refetchOnMount: true,
     staleTime: 1000 * 60 * 30, // 30 minutes
     gcTime: 1000 * 60 * 60, // 1 hour
   });
 
   useEffect(() => {
-    if (!cacheKey || !query.data?.oracles?.length || !query.isSuccess || !query.isFetchedAfterMount) {
+    if (!query.data?.oracles?.length || !query.isSuccess || !query.isFetchedAfterMount) {
       return;
     }
 
@@ -221,14 +230,15 @@ export function useOracleMetadata(chainId: SupportedNetworks | number | undefine
       return;
     }
 
-    setCachedMetadata(cacheKey, query.data);
-  }, [cacheKey, cachedMetadata?.updatedAt, query.data, query.dataUpdatedAt, query.isFetchedAfterMount, query.isSuccess, setCachedMetadata]);
+    writeCachedMetadata({ data: query.data, updatedAt: query.dataUpdatedAt });
+  }, [cachedMetadata?.updatedAt, query.data, query.dataUpdatedAt, query.isFetchedAfterMount, query.isSuccess, writeCachedMetadata]);
 
   const data = useMemo(() => transformToRecord(query.data), [query.data]);
 
   return {
     ...query,
     data,
+    isLoading: requestedEnabled && !cachedMetadata && (!isPersistedCacheReady || !enabled || query.isLoading),
   };
 }
 
@@ -295,65 +305,42 @@ export function getMetaOracleDataFromMetadata(
  */
 export function useAllOracleMetadata(options?: OracleMetadataQueryOptions) {
   const requestedEnabled = options?.enabled ?? true;
-  const enabled = useDeferredQueryEnable(requestedEnabled, options?.defer ?? false, 2500);
-  const cachedMetadataByKey = useApiResponseCache((state) => state.oracleMetadataByKey);
-  const setCachedMetadata = useApiResponseCache((state) => state.setOracleMetadata);
-
-  const queries = useQueries({
-    queries: ALL_SUPPORTED_NETWORKS.map((chainId) => {
-      const cacheKey = getOracleMetadataCacheKey(chainId);
-      const cachedMetadata = cachedMetadataByKey[cacheKey];
-
-      return {
-        queryKey: ['oracle-metadata', ORACLE_GIST_BASE_URL ?? 'unset', chainId],
-        queryFn: () => fetchOracleMetadata(chainId),
-        enabled,
-        initialData: requestedEnabled ? cachedMetadata?.data : undefined,
-        initialDataUpdatedAt: requestedEnabled ? cachedMetadata?.updatedAt : undefined,
-        refetchOnMount: true,
-        staleTime: 1000 * 60 * 30,
-        gcTime: 1000 * 60 * 60,
-      };
-    }),
-  });
-
-  const hasAllRequestedData = queries.every((query) => query.data !== undefined);
-  const isLoading =
-    requestedEnabled && !hasAllRequestedData && (!enabled || queries.some((q) => q.isLoading || (q.isFetching && q.data === undefined)));
+  const mainnetQuery = useOracleMetadata(SupportedNetworks.Mainnet, options);
+  const optimismQuery = useOracleMetadata(SupportedNetworks.Optimism, options);
+  const baseQuery = useOracleMetadata(SupportedNetworks.Base, options);
+  const polygonQuery = useOracleMetadata(SupportedNetworks.Polygon, options);
+  const unichainQuery = useOracleMetadata(SupportedNetworks.Unichain, options);
+  const arbitrumQuery = useOracleMetadata(SupportedNetworks.Arbitrum, options);
+  const etherlinkQuery = useOracleMetadata(SupportedNetworks.Etherlink, options);
+  const hyperEvmQuery = useOracleMetadata(SupportedNetworks.HyperEVM, options);
+  const monadQuery = useOracleMetadata(SupportedNetworks.Monad, options);
+  const katanaQuery = useOracleMetadata(SupportedNetworks.Katana, options);
+  const queries = [
+    mainnetQuery,
+    optimismQuery,
+    baseQuery,
+    polygonQuery,
+    unichainQuery,
+    arbitrumQuery,
+    etherlinkQuery,
+    hyperEvmQuery,
+    monadQuery,
+    katanaQuery,
+  ];
+  const isLoading = requestedEnabled && queries.some((query) => query.isLoading);
   const isError = queries.some((q) => q.isError || q.isRefetchError || q.failureCount > 0);
 
   // Create stable dependency based on data update timestamps
   // This prevents unnecessary recalculations when queries array reference changes
   const dataUpdateKey = queries.map((q) => q.dataUpdatedAt).join(',');
-  const cacheWriteKey = queries.map((q) => `${q.dataUpdatedAt}:${q.isFetchedAfterMount ? 'fetched' : 'initial'}`).join(',');
-
-  useEffect(() => {
-    queries.forEach((query, index) => {
-      if (!query.data?.oracles?.length || !query.isSuccess || !query.isFetchedAfterMount) {
-        return;
-      }
-
-      const cacheKey = getOracleMetadataCacheKey(ALL_SUPPORTED_NETWORKS[index]);
-      const currentCachedMetadata = useApiResponseCache.getState().oracleMetadataByKey[cacheKey];
-      if (query.dataUpdatedAt <= (currentCachedMetadata?.updatedAt ?? 0)) {
-        return;
-      }
-
-      setCachedMetadata(cacheKey, query.data);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheWriteKey, setCachedMetadata]);
 
   // Merge all results into a single record
   const mergedRecord = useMemo(() => {
     const record: OracleMetadataRecord = {};
     for (const query of queries) {
-      const oracles = query.data?.oracles;
-      if (oracles) {
-        for (const oracle of oracles) {
-          if (oracle?.address && oracle.chainId != null) {
-            record[getOracleMetadataKey(oracle.chainId, oracle.address)] = oracle;
-          }
+      for (const oracle of Object.values(query.data)) {
+        if (oracle?.address && oracle.chainId != null) {
+          record[getOracleMetadataKey(oracle.chainId, oracle.address)] = oracle;
         }
       }
     }

--- a/src/stores/useApiResponseCache.ts
+++ b/src/stores/useApiResponseCache.ts
@@ -1,46 +1,29 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { OracleMetadataFile } from '@/hooks/useOracleMetadata';
-import { ALL_SUPPORTED_NETWORKS } from '@/utils/networks';
 import { clearPersistedApiResponses, type CachedApiResponse } from '@/utils/persistedApiResponseCache';
 import type { Market } from '@/utils/types';
 
 type ApiResponseCacheState = {
   marketDetailsByKey: Record<string, CachedApiResponse<Market>>;
-  oracleMetadataByKey: Record<string, CachedApiResponse<OracleMetadataFile>>;
 };
 
 type ApiResponseCacheActions = {
   clearCache: () => void;
   setMarketDetail: (key: string, data: Market) => void;
-  setOracleMetadata: (key: string, data: OracleMetadataFile) => void;
 };
 
 type ApiResponseCacheStore = ApiResponseCacheState & ApiResponseCacheActions;
 
 const MAX_MARKET_DETAILS_CACHE_ENTRIES = 100;
-const MAX_ORACLE_METADATA_CACHE_ENTRIES = ALL_SUPPORTED_NETWORKS.length;
 
 const DEFAULT_STATE: ApiResponseCacheState = {
   marketDetailsByKey: {},
-  oracleMetadataByKey: {},
 };
 
 const trimCacheEntries = <T>(entries: Record<string, CachedApiResponse<T>>, maxEntries: number): Record<string, CachedApiResponse<T>> => {
   const sortedEntries = Object.entries(entries).sort(([, left], [, right]) => right.updatedAt - left.updatedAt);
 
   return Object.fromEntries(sortedEntries.slice(0, maxEntries));
-};
-
-const sanitizeOracleMetadataCache = (
-  entries: Partial<Record<string, CachedApiResponse<OracleMetadataFile | null>>> = {},
-): Record<string, CachedApiResponse<OracleMetadataFile>> => {
-  return Object.fromEntries(
-    Object.entries(entries).filter((entry): entry is [string, CachedApiResponse<OracleMetadataFile>] => {
-      const [, cachedResponse] = entry;
-      return Array.isArray(cachedResponse?.data?.oracles) && cachedResponse.data.oracles.length > 0;
-    }),
-  );
 };
 
 export const useApiResponseCache = create<ApiResponseCacheStore>()(
@@ -62,23 +45,12 @@ export const useApiResponseCache = create<ApiResponseCacheStore>()(
             MAX_MARKET_DETAILS_CACHE_ENTRIES,
           ),
         })),
-      setOracleMetadata: (key, data) =>
-        set((state) => ({
-          oracleMetadataByKey: trimCacheEntries(
-            {
-              ...state.oracleMetadataByKey,
-              [key]: { data, updatedAt: Date.now() },
-            },
-            MAX_ORACLE_METADATA_CACHE_ENTRIES,
-          ),
-        })),
     }),
     {
       name: 'monarch_store_apiResponseCache',
-      version: 4,
+      version: 5,
       partialize: (state) => ({
         marketDetailsByKey: state.marketDetailsByKey,
-        oracleMetadataByKey: state.oracleMetadataByKey,
       }),
       migrate: (state) => {
         if (!state || typeof state !== 'object') {
@@ -89,7 +61,6 @@ export const useApiResponseCache = create<ApiResponseCacheStore>()(
 
         return {
           marketDetailsByKey: persistedState.marketDetailsByKey ?? DEFAULT_STATE.marketDetailsByKey,
-          oracleMetadataByKey: sanitizeOracleMetadataCache(persistedState.oracleMetadataByKey),
         };
       },
     },


### PR DESCRIPTION
## Summary

- move large per-chain oracle metadata from persisted Zustand/localStorage into the existing IndexedDB-backed API response cache
- migrate the localStorage cache to version 5 so existing oracle payloads are removed automatically
- add a validation rule requiring large API and metadata caches to use IndexedDB and be measured against WebKit storage limits

## Root cause

The Markets page persisted all supported-chain oracle metadata in one localStorage value. The current payload serializes to 2,829,351 characters / 5,658,702 UTF-16 bytes, exceeding WebKit’s 5 MiB localStorage quota by about 7.9%. Zustand propagated the synchronous quota exception and crashed the page.

## Validation

- pnpm exec ultracite fix src/hooks/useOracleMetadata.ts src/stores/useApiResponseCache.ts docs/VALIDATIONS.md
- pnpm exec ultracite check src/hooks/useOracleMetadata.ts src/stores/useApiResponseCache.ts docs/VALIDATIONS.md
- pnpm typecheck
- pnpm lint:check
- pnpm build:clean
- git diff --check

The production build, TypeScript, Biome, Ultracite, and whitespace checks passed. Automated Safari navigation was not run because Safari remote automation is disabled on the machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Oracle metadata is now stored in a persistent cache, improving reuse across sessions and reducing repeated network requests.
  * Cache readiness and loading states are handled more accurately across supported networks.

* **Bug Fixes**
  * Improved restoration and migration of cached market details.
  * Updated cache handling to better support large API responses within browser storage limits.

* **Documentation**
  * Added guidance for choosing persistent storage and measuring cached response sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->