### PR TITLE
Improve token symbol display and tooltips

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -330,7 +330,7 @@ GraphQL errors: No retry
 **Persisted to localStorage (11 stores):**
 | Store | Key | Purpose |
 |-------|-----|---------|
-| `useAppSettings` | `monarch_store_appSettings` | Permit2, ETH, APR display |
+| `useAppSettings` | `monarch_store_appSettings` | Permit2, ETH, rate and token-symbol display |
 | `useMarketPreferences` | `monarch_store_marketPreferences` | Sort, filters, columns |
 | `useTrustedVaults` | `monarch_store_trustedVaults` | User's vault whitelist |
 | `useBlacklistedMarkets` | `monarch_store_blacklistedMarkets` | Custom blacklist |

--- a/src/components/shared/token-icon.tsx
+++ b/src/components/shared/token-icon.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ReactElement, type ReactNode } from 'react';
 import { Tooltip } from '@/components/ui/tooltip';
 import Image from 'next/image';
 import { ExternalLinkIcon } from '@radix-ui/react-icons';
@@ -20,6 +20,7 @@ type TokenIconProps = {
   showExplorerLink?: boolean;
   showTokenSource?: boolean;
   disableTooltip?: boolean;
+  renderTrigger?: (icon: ReactNode) => ReactElement;
 };
 
 export function TokenIcon({
@@ -30,9 +31,11 @@ export function TokenIcon({
   opacity,
   customTooltipTitle,
   customTooltipDetail,
+  symbol,
   showExplorerLink = false,
   showTokenSource = true,
   disableTooltip = false,
+  renderTrigger,
 }: TokenIconProps) {
   const { findToken } = useTokensQuery();
   const token = useMemo(() => findToken(address, chainId), [address, chainId, findToken]);
@@ -51,6 +54,7 @@ export function TokenIcon({
         unoptimized
       />
     );
+    const trigger = renderTrigger?.(img) ?? img;
 
     const title = customTooltipTitle ?? token.symbol;
 
@@ -88,7 +92,7 @@ export function TokenIcon({
     const secondaryDetail = customTooltipDetail && showTokenSource ? tokenSource : undefined;
 
     if (disableTooltip) {
-      return img;
+      return trigger;
     }
 
     return (
@@ -103,15 +107,22 @@ export function TokenIcon({
           />
         }
       >
-        {img}
+        {trigger}
       </Tooltip>
     );
   }
 
-  return (
+  const fallbackIcon = (
     <div
       className="rounded-full bg-gray-300 dark:bg-gray-700"
       style={{ width, height }}
     />
   );
+  const trigger = renderTrigger?.(fallbackIcon) ?? fallbackIcon;
+
+  if (disableTooltip || !renderTrigger || !symbol) {
+    return trigger;
+  }
+
+  return <Tooltip content={<TooltipContent title={customTooltipTitle ?? symbol} />}>{trigger}</Tooltip>;
 }

--- a/src/features/markets/components/table/market-table-body.tsx
+++ b/src/features/markets/components/table/market-table-body.tsx
@@ -131,7 +131,6 @@ export function MarketTableBody({
   return (
     <TableBody className="text-sm">
       {currentEntries.map((item) => {
-        const collatToShow = item.collateralAsset.symbol.slice(0, 6).concat(item.collateralAsset.symbol.length > 6 ? '...' : '');
         const isStared = starredMarkets.includes(item.uniqueKey);
         const marketKey = getMetricsKey(item.morphoBlue.chain.id, item.uniqueKey);
         const metrics = metricsMap.get(marketKey);
@@ -206,7 +205,7 @@ export function MarketTableBody({
                 dataLabel="Collateral"
                 asset={item.collateralAsset.address}
                 chainId={item.morphoBlue.chain.id}
-                symbol={collatToShow}
+                symbol={item.collateralAsset.symbol}
               />
               <TableCell
                 data-label="Oracle"

--- a/src/features/markets/components/table/market-table-utils.tsx
+++ b/src/features/markets/components/table/market-table-utils.tsx
@@ -2,6 +2,7 @@ import { ArrowDownIcon, ArrowUpIcon, ExternalLinkIcon } from '@radix-ui/react-ic
 import { TableHead, TableCell } from '@/components/ui/table';
 import { TokenIcon } from '@/components/shared/token-icon';
 import { EstimatedValueTooltip } from '@/components/shared/estimated-value-tooltip';
+import { useAppSettings } from '@/stores/useAppSettings';
 import { formatBalance, formatReadable } from '@/utils/balance';
 import { getAssetURL } from '@/utils/external';
 import type { SortColumn } from '../constants';
@@ -33,7 +34,8 @@ export function HTSortable({ label, sortColumn, titleOnclick, sortDirection, tar
 }
 
 export function TDAsset({ asset, chainId, symbol, dataLabel }: { asset: string; chainId: number; symbol: string; dataLabel?: string }) {
-  const displayedSymbol = symbol.length > 5 ? `${symbol.slice(0, 5)}...` : symbol;
+  const showFullTokenSymbols = useAppSettings((state) => state.showFullTokenSymbols);
+  const displayedSymbol = showFullTokenSymbols || symbol.length <= 5 ? symbol : `${symbol.slice(0, 5)}...`;
 
   return (
     <TableCell

--- a/src/features/markets/components/table/market-table-utils.tsx
+++ b/src/features/markets/components/table/market-table-utils.tsx
@@ -1,9 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon, ExternalLinkIcon } from '@radix-ui/react-icons';
 import { TableHead, TableCell } from '@/components/ui/table';
-import { Tooltip } from '@/components/ui/tooltip';
 import { TokenIcon } from '@/components/shared/token-icon';
 import { EstimatedValueTooltip } from '@/components/shared/estimated-value-tooltip';
-import { TooltipContent } from '@/components/shared/tooltip-content';
 import { formatBalance, formatReadable } from '@/utils/balance';
 import { getAssetURL } from '@/utils/external';
 import type { SortColumn } from '../constants';
@@ -36,20 +34,6 @@ export function HTSortable({ label, sortColumn, titleOnclick, sortDirection, tar
 
 export function TDAsset({ asset, chainId, symbol, dataLabel }: { asset: string; chainId: number; symbol: string; dataLabel?: string }) {
   const displayedSymbol = symbol.length > 5 ? `${symbol.slice(0, 5)}...` : symbol;
-  const assetLink = (
-    <a
-      className="group flex items-center gap-0.5 no-underline hover:underline"
-      href={getAssetURL(asset, chainId)}
-      target="_blank"
-      onClick={(e) => e.stopPropagation()}
-      rel="noopener"
-    >
-      <p className="text-sm whitespace-nowrap">{displayedSymbol}</p>
-      <p className="opacity-0 group-hover:opacity-100">
-        <ExternalLinkIcon className="h-3 w-3" />
-      </p>
-    </a>
-  );
 
   return (
     <TableCell
@@ -64,8 +48,22 @@ export function TDAsset({ asset, chainId, symbol, dataLabel }: { asset: string; 
           width={16}
           height={16}
           symbol={symbol}
+          renderTrigger={(icon) => (
+            <a
+              className="group flex items-center gap-1 no-underline hover:underline"
+              href={getAssetURL(asset, chainId)}
+              target="_blank"
+              onClick={(e) => e.stopPropagation()}
+              rel="noopener"
+            >
+              {icon}
+              <p className="text-sm whitespace-nowrap">{displayedSymbol}</p>
+              <p className="opacity-0 group-hover:opacity-100">
+                <ExternalLinkIcon className="h-3 w-3" />
+              </p>
+            </a>
+          )}
         />
-        {displayedSymbol === symbol ? assetLink : <Tooltip content={<TooltipContent title={symbol} />}>{assetLink}</Tooltip>}
       </div>
     </TableCell>
   );

--- a/src/features/markets/components/table/market-table-utils.tsx
+++ b/src/features/markets/components/table/market-table-utils.tsx
@@ -1,7 +1,9 @@
 import { ArrowDownIcon, ArrowUpIcon, ExternalLinkIcon } from '@radix-ui/react-icons';
 import { TableHead, TableCell } from '@/components/ui/table';
+import { Tooltip } from '@/components/ui/tooltip';
 import { TokenIcon } from '@/components/shared/token-icon';
 import { EstimatedValueTooltip } from '@/components/shared/estimated-value-tooltip';
+import { TooltipContent } from '@/components/shared/tooltip-content';
 import { formatBalance, formatReadable } from '@/utils/balance';
 import { getAssetURL } from '@/utils/external';
 import type { SortColumn } from '../constants';
@@ -33,6 +35,22 @@ export function HTSortable({ label, sortColumn, titleOnclick, sortDirection, tar
 }
 
 export function TDAsset({ asset, chainId, symbol, dataLabel }: { asset: string; chainId: number; symbol: string; dataLabel?: string }) {
+  const displayedSymbol = symbol.length > 5 ? `${symbol.slice(0, 5)}...` : symbol;
+  const assetLink = (
+    <a
+      className="group flex items-center gap-0.5 no-underline hover:underline"
+      href={getAssetURL(asset, chainId)}
+      target="_blank"
+      onClick={(e) => e.stopPropagation()}
+      rel="noopener"
+    >
+      <p className="text-sm whitespace-nowrap">{displayedSymbol}</p>
+      <p className="opacity-0 group-hover:opacity-100">
+        <ExternalLinkIcon className="h-3 w-3" />
+      </p>
+    </a>
+  );
+
   return (
     <TableCell
       data-label={dataLabel ?? symbol}
@@ -47,18 +65,7 @@ export function TDAsset({ asset, chainId, symbol, dataLabel }: { asset: string; 
           height={16}
           symbol={symbol}
         />
-        <a
-          className="group flex items-center gap-0.5 no-underline hover:underline"
-          href={getAssetURL(asset, chainId)}
-          target="_blank"
-          onClick={(e) => e.stopPropagation()}
-          rel="noopener"
-        >
-          <p className="text-sm whitespace-nowrap">{symbol.length > 5 ? `${symbol.slice(0, 5)}...` : symbol}</p>
-          <p className="opacity-0 group-hover:opacity-100">
-            <ExternalLinkIcon className="h-3 w-3" />
-          </p>
-        </a>
+        {displayedSymbol === symbol ? assetLink : <Tooltip content={<TooltipContent title={symbol} />}>{assetLink}</Tooltip>}
       </div>
     </TableCell>
   );

--- a/src/modals/settings/monarch-settings/panels/DisplayPanel.tsx
+++ b/src/modals/settings/monarch-settings/panels/DisplayPanel.tsx
@@ -10,7 +10,8 @@ import { useChartPalette } from '@/stores/useChartPalette';
 import { SettingToggleItem } from '../SettingItem';
 
 export function DisplayPanel() {
-  const { isAprDisplay, setIsAprDisplay, showFullRewardAPY, setShowFullRewardAPY } = useAppSettings();
+  const { isAprDisplay, setIsAprDisplay, showFullRewardAPY, setShowFullRewardAPY, showFullTokenSymbols, setShowFullTokenSymbols } =
+    useAppSettings();
   const { palette: selectedPalette, setPalette } = useChartPalette();
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -40,6 +41,14 @@ export function DisplayPanel() {
             />
           )}
         </div>
+        <Divider />
+        <SettingToggleItem
+          title="Show Full Token Symbols"
+          description="Display complete token symbols in market tables instead of shortening them."
+          selected={showFullTokenSymbols}
+          onChange={setShowFullTokenSymbols}
+          ariaLabel="Toggle full token symbols"
+        />
       </div>
 
       <div className="flex flex-col gap-4 rounded bg-surface p-4">

--- a/src/stores/useAppSettings.ts
+++ b/src/stores/useAppSettings.ts
@@ -11,6 +11,7 @@ type AppSettingsState = {
   // Display settings
   showUnwhitelistedMarkets: boolean;
   showFullRewardAPY: boolean;
+  showFullTokenSymbols: boolean;
   isAprDisplay: boolean;
 
   // UI dismissals
@@ -34,6 +35,7 @@ type AppSettingsActions = {
   setUseEth: (use: boolean) => void;
   setShowUnwhitelistedMarkets: (show: boolean) => void;
   setShowFullRewardAPY: (show: boolean) => void;
+  setShowFullTokenSymbols: (show: boolean) => void;
   setIsAprDisplay: (isApr: boolean) => void;
   setSpecialBundlerWarningAcknowledged: (warningStorageKey: string, acknowledged: boolean) => void;
   setShowDeveloperOptions: (show: boolean) => void;
@@ -64,6 +66,7 @@ export const useAppSettings = create<AppSettingsStore>()(
       useEth: false,
       showUnwhitelistedMarkets: false,
       showFullRewardAPY: true,
+      showFullTokenSymbols: false,
       isAprDisplay: false,
       specialBundlerWarningAcknowledgements: {},
       showDeveloperOptions: false,
@@ -76,6 +79,7 @@ export const useAppSettings = create<AppSettingsStore>()(
       setUseEth: (use) => set({ useEth: use }),
       setShowUnwhitelistedMarkets: (show) => set({ showUnwhitelistedMarkets: show }),
       setShowFullRewardAPY: (show) => set({ showFullRewardAPY: show }),
+      setShowFullTokenSymbols: (show) => set({ showFullTokenSymbols: show }),
       setIsAprDisplay: (isApr) => set({ isAprDisplay: isApr }),
       setSpecialBundlerWarningAcknowledged: (warningStorageKey, acknowledged) =>
         set((state) => ({


### PR DESCRIPTION
## What changed

- preserve the full collateral symbol at the market-table boundary
- keep long symbols truncated in the dense table layout
- make the icon and symbol one shared tooltip trigger, so both surfaces show the same existing token information
- show the full symbol in a simple tooltip for unrecognized tokens
- apply the same behavior to any asset rendered by the shared TDAsset cell
- add a persisted Display setting that shows complete Loan and Collateral symbols in market tables

## Why

Long collateral symbols were truncated before reaching the shared table cell, so users could not discover the full token symbol without leaving the page.

## Impact

The default table width and visual density stay unchanged. Recognized tokens retain the existing rich token tooltip, while unrecognized tokens expose their full symbol. The icon and symbol no longer produce competing tooltip experiences. Users who prefer complete labels can enable Display → Show Full Token Symbols.

## Validation

- `npx ultracite fix`
- `npx ultracite check`
- `pnpm check`
- `pnpm build`

Visual browser verification was not available because no in-app browser session was connected. The combined icon and symbol remain one focusable asset link and use the existing Radix-backed tooltip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token icons now allow customizing the tooltip trigger and external-link display, including better fallback behavior.
  * Added a display option to show full token symbols (Appearance → Show Full Token Symbols).

* **Bug Fixes**
  * Market collateral symbols now render consistently in listings, aligning with the new token-symbol display setting (full vs truncated).

* **Documentation**
  * Updated the technical overview wording to reflect token-symbol display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->