### PR TITLE
Improve market identity token display

### DIFF
--- a/src/components/shared/token-icon.tsx
+++ b/src/components/shared/token-icon.tsx
@@ -119,10 +119,26 @@ export function TokenIcon({
     />
   );
   const trigger = renderTrigger?.(fallbackIcon) ?? fallbackIcon;
+  const tokenSource = 'This token is not recognized by Monarch';
+  const detail = customTooltipDetail || (showTokenSource ? tokenSource : undefined);
+  const secondaryDetail = customTooltipDetail && showTokenSource ? tokenSource : undefined;
 
-  if (disableTooltip || !renderTrigger || !symbol) {
+  if (disableTooltip || !symbol) {
     return trigger;
   }
 
-  return <Tooltip content={<TooltipContent title={customTooltipTitle ?? symbol} />}>{trigger}</Tooltip>;
+  return (
+    <Tooltip
+      content={
+        <TooltipContent
+          icon={fallbackIcon}
+          title={customTooltipTitle ?? symbol}
+          detail={detail}
+          secondaryDetail={secondaryDetail}
+        />
+      }
+    >
+      {trigger}
+    </Tooltip>
+  );
 }

--- a/src/features/markets/components/market-identity.tsx
+++ b/src/features/markets/components/market-identity.tsx
@@ -1,6 +1,7 @@
 import { MarketIdBadge } from '@/features/markets/components/market-id-badge';
 import OracleVendorBadge from '@/features/markets/components/oracle-vendor-badge';
 import { TokenIcon } from '@/components/shared/token-icon';
+import { useAppSettings } from '@/stores/useAppSettings';
 import { getTruncatedAssetName } from '@/utils/oracle';
 import type { Market, TokenInfo } from '@/utils/types';
 
@@ -41,10 +42,16 @@ export function MarketIdentity({
   showExplorerLink = false,
   wide = false,
 }: MarketIdentityProps) {
+  const showFullTokenSymbols = useAppSettings((state) => state.showFullTokenSymbols);
+  const shouldShowFullSymbols = showFullTokenSymbols && mode !== MarketIdentityMode.Minimum && mode !== MarketIdentityMode.Badge;
   const lltv = (Number(market.lltv) / 1e16).toFixed(0);
-  const loanSymbol = getTruncatedAssetName(market.loanAsset.symbol);
+  const loanSymbol = shouldShowFullSymbols ? market.loanAsset.symbol : getTruncatedAssetName(market.loanAsset.symbol);
   const collateralAsset = (market.collateralAsset as TokenInfo | null) ?? null;
-  const collateralSymbol = collateralAsset ? getTruncatedAssetName(collateralAsset.symbol) : 'Idle Market';
+  const collateralSymbol = collateralAsset
+    ? shouldShowFullSymbols
+      ? collateralAsset.symbol
+      : getTruncatedAssetName(collateralAsset.symbol)
+    : 'Idle Market';
 
   // Badge mode: show ID - icon - LLTV% or just symbol
   if (mode === MarketIdentityMode.Badge) {


### PR DESCRIPTION
## Summary

- Show the existing token tooltip for unrecognized-token fallback icons when a symbol is available.
- Include the full token symbol, market role, and recognition status in that tooltip.
- Make non-compact `MarketIdentity` modes (`Focused` and `Normal`) respect the persisted **Show Full Token Symbols** setting.
- Keep compact `Minimum` and `Badge` modes truncated to protect dense layouts.

## Why

Unrecognized tokens rendered as gray fallback icons without the hover behavior available to recognized tokens. Separately, `MarketIdentity` always truncated symbols, so the display preference did not affect position-market identities.

This moves both behaviors into their shared component boundaries, keeping icon interactions consistent and avoiding table-specific workarounds.

## Validation

- `npx ultracite fix`
- `npx ultracite check`
- `pnpm check`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer tooltip details for tokens without images, including fallback icons and token source information.
  * Added an option to display full token symbols in market identities.

* **Improvements**
  * Preserved existing abbreviated symbol behavior when full symbols are not enabled.
  * Improved token tooltip availability and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->