### PR TITLE
Show capped Chainlink feed metadata

### DIFF
--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -256,7 +256,8 @@ export function FeedInspectionSection({
   const heartbeat = leg?.heartbeat ?? leg?.updateInterval ?? null;
   const deviationThreshold = leg?.deviationThreshold ?? leg?.updateSpread ?? null;
   const isChainlink = isChainlinkFeedLeg(leg);
-  const isMonarchVerified = isMonarchVerifiedFeed(leg) && !isCappedChainlinkFeed(leg);
+  const isCappedChainlink = isCappedChainlinkFeed(leg);
+  const isMonarchVerified = isMonarchVerifiedFeed(leg) && !isCappedChainlink;
   const formattedAnswer = answer != null && decimals != null ? formatOraclePrice(answer, decimals) : 'Unavailable';
 
   return (
@@ -303,7 +304,7 @@ export function FeedInspectionSection({
               value="No admin"
             />
           )}
-          {leg?.tier && !isMonarchVerified && (
+          {leg?.tier && !isMonarchVerified && !isCappedChainlink && (
             <DetailRow
               label={isChainlink ? 'Chainlink risk tier' : 'Risk tier'}
               value={`${leg.tier.toUpperCase()} risk`}

--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -10,7 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { MarketIdBadge } from '@/features/markets/components/market-id-badge';
 import { MarketIdentity, MarketIdentityMode } from '@/features/markets/components/market-identity';
 import { FeedTypeBadge } from '@/features/markets/components/oracle/MarketOracle/FeedTypeBadge';
-import { formatOracleDuration, formatOraclePrice, isMonarchVerifiedFeed } from '@/utils/oracle';
+import { formatOracleDuration, formatOraclePrice, isCappedChainlinkFeed, isMonarchVerifiedFeed } from '@/utils/oracle';
 import { getNetworkImg, getNetworkName } from '@/utils/networks';
 import { MARKETS_PAGE_SIZE, ORACLE_CONTRACTS_PAGE_SIZE } from '../feed-detail-constants';
 import { formatOptionalTimestamp, formatScannerTimestamp } from '../feed-detail-formatters';
@@ -61,7 +61,7 @@ export function FeedHero({
 }) {
   const networkName = getNetworkName(chainId) ?? `Chain ${chainId}`;
   const networkImg = getNetworkImg(chainId);
-  const isMonarchVerified = isMonarchVerifiedFeed(leg);
+  const isMonarchVerified = isMonarchVerifiedFeed(leg) && !isCappedChainlinkFeed(leg);
   const hasProviderBadge = !isMonarchVerified && Boolean(leg?.provider || leg?.vendor);
   const statValue = (value: string): string => (isStatsLoading ? 'Calculating' : value);
 
@@ -139,7 +139,7 @@ export function FeedMetadataSection({
 }) {
   const description = getDistinctFeedDescription(leg);
   const isVault = kind === 'vault';
-  const isMonarchVerified = isMonarchVerifiedFeed(leg);
+  const isMonarchVerified = isMonarchVerifiedFeed(leg) && !isCappedChainlinkFeed(leg);
 
   return (
     <SectionShell title={isVault ? 'Vault Conversion' : 'Feed Overview'}>
@@ -256,7 +256,7 @@ export function FeedInspectionSection({
   const heartbeat = leg?.heartbeat ?? leg?.updateInterval ?? null;
   const deviationThreshold = leg?.deviationThreshold ?? leg?.updateSpread ?? null;
   const isChainlink = isChainlinkFeedLeg(leg);
-  const isMonarchVerified = isMonarchVerifiedFeed(leg);
+  const isMonarchVerified = isMonarchVerifiedFeed(leg) && !isCappedChainlinkFeed(leg);
   const formattedAnswer = answer != null && decimals != null ? formatOraclePrice(answer, decimals) : 'Unavailable';
 
   return (

--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -183,6 +183,17 @@ export function FeedMetadataSection({
             }
           />
         )}
+        {leg?.underlyingFeed && (
+          <DetailRow
+            label="Underlying feed"
+            value={
+              <AddressIdentity
+                address={leg.underlyingFeed}
+                chainId={chainId}
+              />
+            }
+          />
+        )}
         {leg?.conversionSample && (
           <DetailRow
             label="Conversion sample"

--- a/src/features/feed-detail/components/feed-shared.tsx
+++ b/src/features/feed-detail/components/feed-shared.tsx
@@ -128,6 +128,14 @@ export function FeedProvenanceBadges({ leg }: { leg: FeedDependencyLeg | null })
   return (
     <>
       {isMonarchVerifiedFeed(leg) && <MonarchVerifiedBadge />}
+      {leg.feedSubtype === 'capped_chainlink' && (
+        <Badge
+          size="sm"
+          className="border border-blue-500/20 bg-blue-500/10 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300"
+        >
+          Capped Chainlink
+        </Badge>
+      )}
       {leg.noAdmin && (
         <Badge
           size="sm"

--- a/src/features/feed-detail/components/feed-shared.tsx
+++ b/src/features/feed-detail/components/feed-shared.tsx
@@ -12,6 +12,7 @@ import { FeedTypeBadge, getFeedTypeInfo } from '@/features/markets/components/or
 import {
   getChainlinkFeedUrl,
   getChronicleFeedUrl,
+  isCappedChainlinkFeed,
   isMonarchVerifiedFeed,
   mapProviderToVendor,
   OracleVendorIcons,
@@ -22,6 +23,7 @@ import { getFeedPairLabel, getFeedProviderLabel, type FeedDependencyLeg, type Fe
 
 export function getFeedVendorIcon(leg: FeedDependencyLeg | null): string {
   if (!leg) return '';
+  if (isCappedChainlinkFeed(leg)) return OracleVendorIcons[PriceFeedVendors.Chainlink];
   if (isMonarchVerifiedFeed(leg)) return '';
   const vendor = leg.provider ? mapProviderToVendor(leg.provider) : PriceFeedVendors.Unknown;
   return OracleVendorIcons[vendor] || '';
@@ -44,6 +46,10 @@ function getVendorUrl(leg: FeedDependencyLeg | null, chainId: number): string {
   const provider = leg.provider?.toLowerCase() ?? '';
   const baseAsset = leg.pair?.[0] ?? '';
   const quoteAsset = leg.pair?.[1] ?? '';
+
+  if (isCappedChainlinkFeed(leg)) {
+    return 'https://data.chain.link/';
+  }
 
   if (provider.includes('chronicle')) {
     return getChronicleFeedUrl(baseAsset, quoteAsset);
@@ -83,6 +89,7 @@ export function getDistinctFeedDescription(leg: FeedDependencyLeg | null): strin
 }
 
 export function isChainlinkFeedLeg(leg: FeedDependencyLeg | null): boolean {
+  if (isCappedChainlinkFeed(leg)) return true;
   const provider = getFeedProviderLabel(leg).toLowerCase();
   return provider.includes('chainlink') || Boolean(leg?.tier);
 }
@@ -127,8 +134,8 @@ export function FeedProvenanceBadges({ leg }: { leg: FeedDependencyLeg | null })
 
   return (
     <>
-      {isMonarchVerifiedFeed(leg) && <MonarchVerifiedBadge />}
-      {leg.feedSubtype === 'capped_chainlink' && (
+      {isMonarchVerifiedFeed(leg) && !isCappedChainlinkFeed(leg) && <MonarchVerifiedBadge />}
+      {isCappedChainlinkFeed(leg) && (
         <Badge
           size="sm"
           className="border border-blue-500/20 bg-blue-500/10 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300"

--- a/src/features/feed-detail/feed-detail-utils.ts
+++ b/src/features/feed-detail/feed-detail-utils.ts
@@ -7,7 +7,7 @@ import {
   type OracleOutput,
   type OracleOutputData,
 } from '@/hooks/useOracleMetadata';
-import { isMonarchVerifiedFeed } from '@/utils/oracle';
+import { isCappedChainlinkFeed, isMonarchVerifiedFeed } from '@/utils/oracle';
 import type { Market } from '@/utils/types';
 
 export type FeedDependencyKind = 'feed' | 'vault';
@@ -247,6 +247,10 @@ export function getFeedTitle(leg: FeedDependencyLeg | null, address: string): st
 }
 
 export function getFeedProviderLabel(leg: FeedDependencyLeg | null): string {
+  if (isCappedChainlinkFeed(leg)) {
+    return 'Chainlink';
+  }
+
   if (isMonarchVerifiedFeed(leg)) {
     return leg?.builtBy ?? 'Monarch verified';
   }

--- a/src/features/feed-detail/feed-detail-utils.ts
+++ b/src/features/feed-detail/feed-detail-utils.ts
@@ -22,6 +22,8 @@ export type FeedDependencyLeg = (EnrichedFeed | EnrichedVault) & {
   builtBy?: string;
   noAdmin?: boolean;
   feedType?: string;
+  feedSubtype?: string;
+  underlyingFeed?: string;
   decimals?: number;
   tier?: string;
   heartbeat?: number;

--- a/src/features/markets/components/oracle/MarketOracle/ChainlinkFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/ChainlinkFeedTooltip.tsx
@@ -11,6 +11,7 @@ import {
   detectFeedVendorFromMetadata,
   getChainlinkFeedUrl,
   getChronicleFeedUrl,
+  isCappedChainlinkFeed,
   OracleVendorIcons,
   PriceFeedVendors,
   type FeedFreshnessStatus,
@@ -51,12 +52,13 @@ export function ChainlinkFeedTooltip({ feed, chainId, feedFreshness }: Chainlink
   const baseAsset = assetPair.baseAsset;
   const quoteAsset = assetPair.quoteAsset;
   const isChronicle = vendor === PriceFeedVendors.Chronicle;
-  const feedTitle = isChronicle ? 'Chronicle Feed Details' : 'Chainlink Feed Details';
+  const isCappedChainlink = isCappedChainlinkFeed(feed);
+  const feedTitle = isChronicle ? 'Chronicle Feed Details' : isCappedChainlink ? 'Capped Chainlink Feed Details' : 'Chainlink Feed Details';
   const vendorLabel = isChronicle ? 'Chronicle' : 'Chainlink';
   const intervalValue = isChronicle ? (feed.updateInterval ?? feed.heartbeat) : (feed.heartbeat ?? null);
   const deviationValue = isChronicle ? (feed.updateSpread ?? feed.deviationThreshold) : (feed.deviationThreshold ?? null);
   const chronicleRiskTier = isChronicle ? feed.riskTier : null;
-  const chainlinkTier = isChronicle ? null : feed.tier;
+  const chainlinkTier = isChronicle || isCappedChainlink ? null : feed.tier;
 
   const vendorIcon = OracleVendorIcons[vendor] || OracleVendorIcons[PriceFeedVendors.Chainlink];
 
@@ -87,6 +89,17 @@ export function ChainlinkFeedTooltip({ feed, chainId, feedFreshness }: Chainlink
           {baseAsset} / {quoteAsset}
         </div>
       </div>
+
+      {isCappedChainlink && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge
+            size="sm"
+            className="border border-blue-500/20 bg-blue-500/10 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300"
+          >
+            Capped Chainlink
+          </Badge>
+        </div>
+      )}
 
       <FeedTypeSection feed={feed} />
 

--- a/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
@@ -15,6 +15,7 @@ import {
   formatOraclePrice,
   getFeedFreshnessStatus,
   getTruncatedAssetName,
+  isCappedChainlinkFeed,
   isMonarchVerifiedFeed,
   OracleVendorIcons,
   PriceFeedVendors,
@@ -89,7 +90,7 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
 
   const vendorIcon = OracleVendorIcons[vendor];
   const hasKnownVendorIcon = vendor !== PriceFeedVendors.Unknown && Boolean(vendorIcon);
-  const isMonarchVerified = isMonarchVerifiedFeed(feed);
+  const isMonarchVerified = isMonarchVerifiedFeed(feed) && !isCappedChainlinkFeed(feed);
   const feedAddressKey = feed.address.toLowerCase();
   const snapshot = feedSnapshotsByAddress?.[feedAddressKey];
   const directAnswer =

--- a/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
@@ -58,7 +58,7 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
         <div className="font-zen font-bold">{tooltipTitle}</div>
       </div>
 
-      {(isMonarchVerified || feed.noAdmin) && (
+      {(isMonarchVerified || feed.noAdmin || feed.feedSubtype === 'capped_chainlink') && (
         <div className="flex flex-wrap items-center gap-1.5">
           {isMonarchVerified && (
             <Badge
@@ -67,6 +67,14 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
             >
               <MonarchVerifiedIcon size={12} />
               Monarch verified
+            </Badge>
+          )}
+          {feed.feedSubtype === 'capped_chainlink' && (
+            <Badge
+              size="sm"
+              className="border border-blue-500/20 bg-blue-500/10 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300"
+            >
+              Capped Chainlink
             </Badge>
           )}
           {feed.noAdmin && (

--- a/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
@@ -6,7 +6,14 @@ import { MonarchVerifiedIcon } from '@/components/shared/monarch-verified-icon';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import etherscanLogo from '@/imgs/etherscan.png';
 import { getExplorerURL } from '@/utils/external';
-import { isMonarchVerifiedFeed, mapProviderToVendor, OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
+import {
+  isCappedChainlinkFeed,
+  isMonarchVerifiedFeed,
+  mapProviderToVendor,
+  OracleVendorIcons,
+  PriceFeedVendors,
+  type FeedFreshnessStatus,
+} from '@/utils/oracle';
 import { FeedTypeSection } from './FeedTypeSection';
 import { FeedFreshnessSection } from './FeedFreshnessSection';
 
@@ -34,11 +41,20 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
   const baseAsset = feed.pair[0] ?? 'Unknown';
   const quoteAsset = feed.pair[1] ?? 'Unknown';
   const customLinks = feed.links?.map(getSafeCustomLink).filter((link): link is { label: string; url: string } => link != null) ?? [];
-  const isMonarchVerified = isMonarchVerifiedFeed(feed);
+  const isCappedChainlink = isCappedChainlinkFeed(feed);
+  const isMonarchVerified = isMonarchVerifiedFeed(feed) && !isCappedChainlink;
 
-  const vendor = feed.provider ? mapProviderToVendor(feed.provider) : PriceFeedVendors.Unknown;
+  const vendor = isCappedChainlink
+    ? PriceFeedVendors.Chainlink
+    : feed.provider
+      ? mapProviderToVendor(feed.provider)
+      : PriceFeedVendors.Unknown;
   const vendorIcon = OracleVendorIcons[vendor] || OracleVendorIcons[PriceFeedVendors.Unknown];
-  const tooltipTitle = isMonarchVerified ? 'Monarch verified feed' : `${feed.provider ?? 'Price'} Feed`;
+  const tooltipTitle = isCappedChainlink
+    ? 'Capped Chainlink feed'
+    : isMonarchVerified
+      ? 'Monarch verified feed'
+      : `${feed.provider ?? 'Price'} Feed`;
 
   return (
     <div className="flex w-fit max-w-[22rem] flex-col gap-3">
@@ -58,7 +74,7 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
         <div className="font-zen font-bold">{tooltipTitle}</div>
       </div>
 
-      {(isMonarchVerified || feed.noAdmin || feed.feedSubtype === 'capped_chainlink') && (
+      {(isMonarchVerified || feed.noAdmin || isCappedChainlink) && (
         <div className="flex flex-wrap items-center gap-1.5">
           {isMonarchVerified && (
             <Badge
@@ -69,7 +85,7 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
               Monarch verified
             </Badge>
           )}
-          {feed.feedSubtype === 'capped_chainlink' && (
+          {isCappedChainlink && (
             <Badge
               size="sm"
               className="border border-blue-500/20 bg-blue-500/10 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300"

--- a/src/hooks/useOracleMetadata.ts
+++ b/src/hooks/useOracleMetadata.ts
@@ -42,9 +42,11 @@ export type EnrichedFeed = {
   updateInterval?: number; // Chronicle update cadence in seconds
   updateSpread?: number; // Chronicle deviation threshold percentage
   feedType?: OracleFeedType; // Scanner feed category: "market", "fundamental", "dex", "nav", or future categories
+  feedSubtype?: string; // Scanner subtype tag, e.g. "capped_chainlink"
   links?: Array<{ label: string; url: string }>;
   baseDiscountPerYear?: string; // Pendle base discount per year (raw 18-decimal value)
   innerOracle?: string; // Pendle inner oracle address
+  underlyingFeed?: string; // Source feed used by wrapper feeds
   pt?: string; // Pendle PT token address
   ptSymbol?: string; // Pendle PT token symbol
   pendleFeedKind?: string; // Pendle feed kind (e.g. "PendleChainlinkOracle", "LinearDiscount")

--- a/src/utils/oracle.ts
+++ b/src/utils/oracle.ts
@@ -104,6 +104,10 @@ export function isMonarchVerifiedProvider(provider: OracleFeedProvider | undefin
   return normalizedProvider === 'monarchverified' || normalizedProvider === 'monarch verified';
 }
 
+export function isCappedChainlinkFeed(feed: { feedSubtype?: string | undefined } | null | undefined): boolean {
+  return feed?.feedSubtype?.trim().toLowerCase() === 'capped_chainlink';
+}
+
 export function isMonarchVerifiedFeed(
   feed: { provider?: OracleFeedProvider | undefined; tier?: string | undefined } | null | undefined,
 ): boolean {
@@ -167,7 +171,11 @@ export function detectFeedVendorFromMetadata(feed: EnrichedFeed | null | undefin
     feed.baseDiscountPerYear != null ||
     feed.pt != null ||
     feed.ptSymbol != null;
-  const vendor = isPendleFeed ? PriceFeedVendors.Pendle : mapProviderToVendor(feed.provider);
+  const vendor = isPendleFeed
+    ? PriceFeedVendors.Pendle
+    : isCappedChainlinkFeed(feed)
+      ? PriceFeedVendors.Chainlink
+      : mapProviderToVendor(feed.provider);
 
   // Try to extract pair from feed.pair, or fallback to parsing description
   let baseAsset = 'Unknown';
@@ -253,6 +261,11 @@ function classifyEnrichedFeeds(feeds: (EnrichedFeed | null)[]): VendorInfo {
 
   for (const feed of feeds) {
     if (feed?.address) {
+      if (isCappedChainlinkFeed(feed)) {
+        coreVendors.add(PriceFeedVendors.Chainlink);
+        continue;
+      }
+
       if (isMonarchVerifiedFeed(feed)) {
         hasMonarchVerified = true;
         continue;


### PR DESCRIPTION
## Summary
- mirror the scanner `feedSubtype` and `underlyingFeed` fields in Monarch oracle metadata types
- show a Capped Chainlink badge in feed tooltips and feed detail provenance
- show the underlying feed link on feed detail pages when scanner metadata provides one

## Validation
Applied `docs/VALIDATIONS.md`: Universal Validation, React and TypeScript, Data and Domain Flows, UI and Accessibility.

## Verification
- `corepack pnpm exec ultracite fix src/hooks/useOracleMetadata.ts src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx src/features/feed-detail/feed-detail-utils.ts src/features/feed-detail/components/feed-shared.tsx src/features/feed-detail/components/feed-sections.tsx`
- `corepack pnpm exec ultracite check src/hooks/useOracleMetadata.ts src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx src/features/feed-detail/feed-detail-utils.ts src/features/feed-detail/components/feed-shared.tsx src/features/feed-detail/components/feed-sections.tsx`
- `corepack pnpm typecheck`
- `corepack pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feed details now show an “Underlying feed” row when available.
  - Added “Capped Chainlink” badges across feed details and market oracle tooltips.
- **Enhancements**
  - Capped Chainlink feeds are now categorized consistently (Chainlink labeling/iconography and tooltip titles).
  - Monarch verification and related risk-tier indicators are suppressed for capped Chainlink feeds, preventing misleading signals.
  - Feed subtype/underlying-feed metadata is now supported consistently across the relevant views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->