### PR TITLE
Expand Pendle token coverage to Monad and Optimism

### DIFF
--- a/src/hooks/queries/useTokensQuery.ts
+++ b/src/hooks/queries/useTokensQuery.ts
@@ -19,6 +19,14 @@ const localTokensWithSource: ERC20Token[] = supportedTokens.map((token) => ({
   ...token,
   source: 'local',
 }));
+const PENDLE_SUPPORTED_NETWORKS = [
+  SupportedNetworks.Mainnet,
+  SupportedNetworks.Optimism,
+  SupportedNetworks.Base,
+  SupportedNetworks.Arbitrum,
+  SupportedNetworks.HyperEVM,
+  SupportedNetworks.Monad,
+] as const;
 const TOKEN_METADATA_STALE_TIME = 30 * 60 * 1000;
 const TOKEN_METADATA_REFETCH_INTERVAL = 30 * 60 * 1000;
 
@@ -28,8 +36,13 @@ async function fetchPendleAssets(chainId: number): Promise<PendleAsset[]> {
     throw new Error(`Failed to fetch Pendle assets for chain ${chainId}: ${response.status}`);
   }
 
-  const data = (await response.json()) as PendleAsset[];
-  return z.array(PendleAssetSchema).parse(data);
+  const data = z.array(z.unknown()).parse(await response.json());
+  const assets: PendleAsset[] = [];
+  for (const item of data) {
+    const parsedAsset = PendleAssetSchema.safeParse(item);
+    if (parsedAsset.success) assets.push(parsedAsset.data);
+  }
+  return assets;
 }
 
 function convertPendleAssetToToken(asset: PendleAsset, chainId: SupportedNetworks): ERC20Token {
@@ -56,19 +69,13 @@ export const useTokensQuery = () => {
   const query = useQuery({
     queryKey: ['tokens'],
     queryFn: async () => {
-      const [mainnetAssets, baseAssets, arbitrumAssets, hyperevmAssets] = await Promise.all([
-        fetchPendleAssets(SupportedNetworks.Mainnet),
-        fetchPendleAssets(SupportedNetworks.Base),
-        fetchPendleAssets(SupportedNetworks.Arbitrum),
-        fetchPendleAssets(SupportedNetworks.HyperEVM),
-      ]);
-
-      const pendleTokens = [
-        ...mainnetAssets.map((a) => convertPendleAssetToToken(a, SupportedNetworks.Mainnet)),
-        ...baseAssets.map((a) => convertPendleAssetToToken(a, SupportedNetworks.Base)),
-        ...arbitrumAssets.map((a) => convertPendleAssetToToken(a, SupportedNetworks.Arbitrum)),
-        ...hyperevmAssets.map((a) => convertPendleAssetToToken(a, SupportedNetworks.HyperEVM)),
-      ];
+      const assetsByNetwork = await Promise.all(
+        PENDLE_SUPPORTED_NETWORKS.map(async (network) => {
+          const assets = await fetchPendleAssets(network);
+          return assets.map((asset) => convertPendleAssetToToken(asset, network));
+        }),
+      );
+      const pendleTokens = assetsByNetwork.flat();
 
       const filteredPendleTokens = pendleTokens.filter((pendleToken) => {
         return !pendleToken.networks.some((pendleNetwork) =>


### PR DESCRIPTION
## Summary
- add Monad and Optimism to the Pendle-backed token metadata networks
- consolidate per-network fetching around one explicit supported-network list
- isolate malformed Pendle asset records so valid metadata still loads

## Live API audit
- confirmed the current Pendle API overlap with Monarch is Ethereum, Optimism, Base, Arbitrum, HyperEVM, and Monad
- confirmed 25 additional Optimism assets and 31 additional Monad assets after local-token deduplication at validation time

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- git diff --check
- live Pendle API response/schema audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Pendle token discovery across all supported networks.
  * Added support for partially valid token responses, allowing valid assets to remain available when individual entries are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->