### PR TITLE
Fix vault history loading and native yield fallback

### DIFF
--- a/docs/VALIDATIONS.md
+++ b/docs/VALIDATIONS.md
@@ -89,6 +89,8 @@ Use this file at the end of non-trivial work. Do not front-load it at task start
 - Vault-scoped pages with configured cap or market IDs must use targeted market reads for first render; do not wait on the global market registry when the vault metadata already identifies the relevant markets.
 - Vault adapter selection must be cap-aware when a vault has multiple active adapters; do not let list order alone choose the adapter used for positions, activity, withdrawals, or settings.
 - Expensive queries must not start with placeholder dependency data that immediately invalidates the same query. Gate on prerequisite readiness, or use a stable query key that does not refetch equivalent work.
+- Vault analytics must keep chain lists and period boundaries stable after first resolution; background dependency updates must preserve rendered chart data instead of re-entering a cold skeleton.
+- When vault-native APY history is unavailable but share-price history exists, derive APY at the shared history-query boundary and label the actual sampling lookback.
 - Expensive enrichment queries derived from filtered, sorted, or paginated rows must wait for the inputs that can change those rows, such as USD price enrichment, before they start.
 - Periodic refreshes for RPC or API data must use React Query polling with background refetch disabled, or explicitly pause when `document.visibilityState` is hidden. Do not use raw `setInterval` for mounted data refresh unless hidden-tab behavior is handled.
 - Portfolio and position analysis must preserve transaction-discovered market IDs even when current on-chain balances are zero. Generic list-level hide settings must not remove those markets from summary or history inputs.

--- a/src/features/vault/components/vault-history-charts.tsx
+++ b/src/features/vault/components/vault-history-charts.tsx
@@ -13,7 +13,7 @@ import { useAppSettings } from '@/stores/useAppSettings';
 import { type ChartTimeframe, TIMEFRAME_CONFIG, useMarketDetailChartState } from '@/stores/useMarketDetailChartState';
 import { formatReadableTokenAmount } from '@/utils/balance';
 import { formatChartTime } from '@/utils/chart';
-import type { SupportedNetworks } from '@/utils/networks';
+import { supportsHistoricalStateRead, type SupportedNetworks } from '@/utils/networks';
 import { computeAnnualizedApyFromValueGrowth, formatRateAsPercentage, toDisplayRateFromApy } from '@/utils/rateMath';
 import type { TimeseriesOptions } from '@/utils/types';
 
@@ -82,6 +82,16 @@ function formatChangePercent(value: number | null): string {
   if (value === null || !Number.isFinite(value)) return '--';
 
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+function formatRateLookback(seconds: number | null | undefined): string {
+  if (!seconds) return '';
+
+  const hours = seconds / (60 * 60);
+  if (hours < 24) return ` (${hours.toLocaleString('en-US', { maximumFractionDigits: 1 })}h)`;
+
+  const days = hours / 24;
+  return ` (${days.toLocaleString('en-US', { maximumFractionDigits: 1 })}d)`;
 }
 
 function MetricSummary({ items }: { items: MetricSummaryItem[] }) {
@@ -316,13 +326,14 @@ export function VaultHistoryCharts({ vaultAddress, chainId, assetDecimals, asset
 
     return ((lastPoint.value - firstPoint.value) / firstPoint.value) * 100;
   }, [sharePrice]);
-  const isMorphoSupported = supportsMorphoApi(chainId);
+  const canLoadNativeYield = supportsMorphoApi(chainId) || supportsHistoricalStateRead(chainId);
   const isInitialLoading = assetDecimals === undefined || (isLoading && !data);
   const isUpdating = isFetching && !isInitialLoading;
   const rateLabel = isAprDisplay ? 'APR' : 'APY';
   const periodLabel = TIMEFRAME_CONFIG[selectedTimeframe].label;
   const impliedRate = impliedApy === null ? Number.NaN : toDisplayRateFromApy(impliedApy, isAprDisplay);
   const currentRate = nativeRate.at(-1)?.value ?? Number.NaN;
+  const nativeRateLookback = formatRateLookback(data?.nativeApyLookbackSeconds);
 
   if (mode === 'share-price') {
     return (
@@ -355,11 +366,11 @@ export function VaultHistoryCharts({ vaultAddress, chainId, assetDecimals, asset
 
   return (
     <div className="space-y-4">
-      {isMorphoSupported ? (
+      {canLoadNativeYield ? (
         <MetricChart
           title="Native yield"
-          metricLabel={`${rateLabel} (6h)`}
-          name={`Native ${rateLabel} (6h)`}
+          metricLabel={`${rateLabel}${nativeRateLookback}`}
+          name={`Native ${rateLabel}${nativeRateLookback}`}
           data={nativeRate}
           average={nativeRateAverage}
           yDomain={nativeRateDomain}
@@ -369,7 +380,7 @@ export function VaultHistoryCharts({ vaultAddress, chainId, assetDecimals, asset
             <MetricSummary
               items={[
                 { label: `${periodLabel} realized ${rateLabel}`, value: formatPercent(impliedRate) },
-                { label: `Current ${rateLabel} (6h)`, value: formatPercent(currentRate) },
+                { label: `Current ${rateLabel}${nativeRateLookback}`, value: formatPercent(currentRate) },
               ]}
             />
           }

--- a/src/features/vault/vault-view.tsx
+++ b/src/features/vault/vault-view.tsx
@@ -123,9 +123,12 @@ function VaultAdapterPositionDetail({
       })),
     [marketAllocations],
   );
+  // Keep the period snapshot query anchored; a new array on every live vault update
+  // would recalculate its time-based block estimate and restart the chart.
+  const positionChainIds = useMemo(() => [chainId], [chainId]);
 
   const { positions, isPositionsLoading, isEarningsLoading, actualBlockData, snapshotsByChain, loadingStates } =
-    useUserPositionsSummaryData(adapterAddress, period, [chainId], {
+    useUserPositionsSummaryData(adapterAddress, period, positionChainIds, {
       enabled: hasAdapterPositionTarget && marketHints.length > 0,
       marketHints,
       showEmpty: true,

--- a/src/hooks/queries/useVaultHistoryQuery.ts
+++ b/src/hooks/queries/useVaultHistoryQuery.ts
@@ -5,7 +5,10 @@ import { fetchMorphoVaultV2History } from '@/data-sources/morpho-api/vault-histo
 import { fetchRpcVaultHistory } from '@/data-sources/rpc/vault-history';
 import { TIMEFRAME_CONFIG, type ChartTimeframe } from '@/stores/useMarketDetailChartState';
 import { supportsHistoricalStateRead, type SupportedNetworks } from '@/utils/networks';
+import { computeAnnualizedApySeriesFromValueGrowth, getLatestSeriesIntervalSeconds } from '@/utils/rateMath';
 import type { TimeseriesOptions } from '@/utils/types';
+
+const NATIVE_APY_API_LOOKBACK_SECONDS = 6 * 60 * 60;
 
 const API_INTERVAL_BY_TIMEFRAME: Record<ChartTimeframe, TimeseriesOptions['interval']> = {
   '1d': 'HOUR',
@@ -23,6 +26,7 @@ export type VaultHistoryPoint = {
 
 export type VaultHistory = {
   nativeApy: VaultHistoryPoint[];
+  nativeApyLookbackSeconds: number | null;
   sharePrice: VaultHistoryPoint[];
   sharePriceSource: 'morpho-api' | 'none' | 'rpc';
   totalAssets: VaultHistoryPoint[];
@@ -68,7 +72,7 @@ export function useVaultHistoryQuery({
         chainId,
         options: { ...timeRange, interval: API_INTERVAL_BY_TIMEFRAME[timeframe] },
       });
-      const nativeApy = (morphoHistory?.nativeApy ?? []).map((point) => ({
+      const apiNativeApy = (morphoHistory?.nativeApy ?? []).map((point) => ({
         timestamp: point.timestamp,
         value: point.value,
       }));
@@ -82,10 +86,12 @@ export function useVaultHistoryQuery({
       }));
       const hasApiSharePrice = sharePrice.length >= 2;
       const hasApiTotalAssets = apiTotalAssets.length >= 2;
+      const hasApiNativeApy = apiNativeApy.length >= 2;
 
       if (hasApiSharePrice && hasApiTotalAssets) {
         return {
-          nativeApy,
+          nativeApy: hasApiNativeApy ? apiNativeApy : computeAnnualizedApySeriesFromValueGrowth(sharePrice),
+          nativeApyLookbackSeconds: hasApiNativeApy ? NATIVE_APY_API_LOOKBACK_SECONDS : getLatestSeriesIntervalSeconds(sharePrice),
           sharePrice,
           sharePriceSource: 'morpho-api',
           totalAssets: apiTotalAssets,
@@ -95,7 +101,12 @@ export function useVaultHistoryQuery({
 
       if (!supportsHistoricalStateRead(chainId)) {
         return {
-          nativeApy,
+          nativeApy: hasApiNativeApy ? apiNativeApy : computeAnnualizedApySeriesFromValueGrowth(sharePrice),
+          nativeApyLookbackSeconds: hasApiNativeApy
+            ? NATIVE_APY_API_LOOKBACK_SECONDS
+            : hasApiSharePrice
+              ? getLatestSeriesIntervalSeconds(sharePrice)
+              : null,
           sharePrice,
           sharePriceSource: hasApiSharePrice ? 'morpho-api' : 'none',
           totalAssets: apiTotalAssets,
@@ -112,10 +123,19 @@ export function useVaultHistoryQuery({
         startTimestamp: timeRange.startTimestamp,
         vaultAddress,
       });
+      const resolvedSharePrice = hasApiSharePrice ? sharePrice : rpcHistory.sharePrice;
+      // Morpho can omit V2 history for an otherwise supported chain. Share-price
+      // growth is the canonical on-chain fallback for the vault's native yield.
+      const resolvedNativeApy = hasApiNativeApy ? apiNativeApy : computeAnnualizedApySeriesFromValueGrowth(resolvedSharePrice);
 
       return {
-        nativeApy,
-        sharePrice: hasApiSharePrice ? sharePrice : rpcHistory.sharePrice,
+        nativeApy: resolvedNativeApy,
+        nativeApyLookbackSeconds: hasApiNativeApy
+          ? NATIVE_APY_API_LOOKBACK_SECONDS
+          : resolvedNativeApy.length >= 2
+            ? getLatestSeriesIntervalSeconds(resolvedSharePrice)
+            : null,
+        sharePrice: resolvedSharePrice,
         sharePriceSource: hasApiSharePrice ? 'morpho-api' : rpcHistory.sharePrice.length >= 2 ? 'rpc' : 'none',
         totalAssets: hasApiTotalAssets ? apiTotalAssets : rpcHistory.totalAssets,
         totalAssetsSource: hasApiTotalAssets ? 'morpho-api' : rpcHistory.totalAssets.length >= 2 ? 'rpc' : 'none',

--- a/src/utils/rateMath.ts
+++ b/src/utils/rateMath.ts
@@ -1,6 +1,11 @@
 const APY_RATIO_SCALE = 1_000_000_000n;
 const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
 
+export type TimestampedValue = {
+  timestamp: number;
+  value: number;
+};
+
 export const toScaledRatio = (numerator: bigint, denominator: bigint): number | null => {
   if (denominator <= 0n) return null;
   const scaledRatio = (numerator * APY_RATIO_SCALE) / denominator;
@@ -102,6 +107,41 @@ export function computeAnnualizedApyFromValueGrowth({
   const annualizedApy = (currentValue / pastValue) ** annualizationFactor - 1;
 
   return Number.isFinite(annualizedApy) ? annualizedApy : null;
+}
+
+export function computeAnnualizedApySeriesFromValueGrowth(points: readonly TimestampedValue[]): TimestampedValue[] {
+  const annualizedApy: TimestampedValue[] = [];
+  let previousPoint: TimestampedValue | undefined;
+
+  for (const currentPoint of points) {
+    if (!previousPoint) {
+      previousPoint = currentPoint;
+      continue;
+    }
+
+    const value = computeAnnualizedApyFromValueGrowth({
+      currentValue: currentPoint.value,
+      pastValue: previousPoint.value,
+      periodSeconds: currentPoint.timestamp - previousPoint.timestamp,
+    });
+
+    if (value !== null) {
+      annualizedApy.push({ timestamp: currentPoint.timestamp, value });
+    }
+
+    previousPoint = currentPoint;
+  }
+
+  return annualizedApy;
+}
+
+export function getLatestSeriesIntervalSeconds(points: readonly TimestampedValue[]): number | null {
+  const currentPoint = points.at(-1);
+  const previousPoint = points.at(-2);
+  if (!currentPoint || !previousPoint) return null;
+
+  const intervalSeconds = currentPoint.timestamp - previousPoint.timestamp;
+  return intervalSeconds > 0 ? intervalSeconds : null;
 }
 
 export function computeAnnualizedApyFromGrowth({


### PR DESCRIPTION
## Summary

- stabilize vault position-history query inputs so the exposure chart does not restart during live vault updates
- derive native APY from canonical share-price history when Morpho does not index a V2 vault
- display the actual APY sampling lookback and add regression validation rules

## Root cause

- the vault page passed a new chain ID array on each render, which caused the time-based snapshot query boundary to drift and repeatedly reset the exposure chart to its loading state
- Morpho returns NOT_FOUND for some V2 vaults on otherwise supported chains, leaving native yield empty even when historical share-price data is available through RPC

## Validation

- npx ultracite fix and npx ultracite check
- pnpm typecheck
- pnpm build
- focused annualized rate-math verification
- browser verification on the reported Base vault across 1D, 7D, and 30D periods
- confirmed the exposure chart remains mounted through live refreshes and native yield renders with its actual lookback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical native-yield charts now load on more supported networks.
  * APY can be calculated from share-price history when native APY data is unavailable.
  * APY calculations now include the relevant sampling lookback.

* **Improvements**
  * Native-yield labels display the actual lookback period in hours or days.
  * Vault position summaries remain stable during live updates.
  * Historical analytics preserve chart data and period boundaries during background refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->