### PR TITLE
fix: allow sell-backed full deleverage close

### DIFF
--- a/src/hooks/useDeleverageQuote.ts
+++ b/src/hooks/useDeleverageQuote.ts
@@ -15,6 +15,7 @@ type UseDeleverageQuoteParams = {
   withdrawCollateralAmount: bigint;
   currentBorrowAssets: bigint;
   currentBorrowShares: bigint;
+  isFullClose: boolean;
   slippageBps: number;
   loanTokenAddress: string;
   loanTokenDecimals: number;
@@ -40,7 +41,7 @@ export type DeleverageQuote = {
  *
  * Routes:
  * - ERC4626: `withdrawCollateralAmount -> previewRedeem`, then apply the slippage buffer to that conversion
- * - Swap: Velora SELL quote for repay preview and Velora BUY quote for max collateral to close debt
+ * - Swap: Velora SELL quote for repay preview/full close and Velora BUY quote for partial close bounds
  */
 export function useDeleverageQuote({
   chainId,
@@ -48,6 +49,7 @@ export function useDeleverageQuote({
   withdrawCollateralAmount,
   currentBorrowAssets,
   currentBorrowShares,
+  isFullClose,
   slippageBps,
   loanTokenAddress,
   loanTokenDecimals,
@@ -126,9 +128,10 @@ export function useDeleverageQuote({
       LEVERAGE_SWAP_ROUTE_POLICY_KEY,
       bufferedBorrowAssets.toString(),
       slippageBps,
+      isFullClose,
       userAddress ?? null,
     ],
-    enabled: route?.kind === 'swap' && bufferedBorrowAssets > 0n && !!userAddress,
+    enabled: route?.kind === 'swap' && !isFullClose && bufferedBorrowAssets > 0n && !!userAddress,
     queryFn: async () => {
       const buyRoute = await fetchVeloraPriceRoute({
         srcToken: collateralTokenAddress,
@@ -189,19 +192,25 @@ export function useDeleverageQuote({
   const maxCollateralForDebtRepay = useMemo(() => {
     if (!route || currentBorrowAssets <= 0n) return 0n;
     if (route.kind === 'swap') {
-      if (!userAddress || swapMaxCollateralForDebtQuery.error) return 0n;
+      if (!userAddress) return 0n;
+      // The explicit close sells all collateral, so the executable SELL quote is authoritative.
+      // Requiring a separate exact-output BUY route can reject closes that the SELL route fully covers.
+      if (isFullClose) return canCurrentSellCloseDebt ? withdrawCollateralAmount : 0n;
+      if (swapMaxCollateralForDebtQuery.error) return 0n;
       return swapMaxCollateralForDebtQuery.data?.maxCollateralForDebtRepay ?? 0n;
     }
     return rawRouteRepayAmount >= bufferedBorrowAssets ? withdrawCollateralAmount : 0n;
   }, [
     route,
     currentBorrowAssets,
+    isFullClose,
+    canCurrentSellCloseDebt,
+    withdrawCollateralAmount,
     swapMaxCollateralForDebtQuery.data,
     swapMaxCollateralForDebtQuery.error,
     userAddress,
     rawRouteRepayAmount,
     bufferedBorrowAssets,
-    withdrawCollateralAmount,
   ]);
 
   const closeRouteRequiresResolution = useMemo(() => {
@@ -226,7 +235,8 @@ export function useDeleverageQuote({
     if (!route || currentBorrowAssets <= 0n) return false;
 
     if (route.kind === 'swap') {
-      if (!userAddress || swapMaxCollateralForDebtQuery.error) return false;
+      if (!userAddress) return false;
+      if (!isFullClose && swapMaxCollateralForDebtQuery.error) return false;
       return canCurrentSellCloseDebt && currentBorrowShares > 0n && maxCollateralForDebtRepay > 0n;
     }
 
@@ -235,6 +245,7 @@ export function useDeleverageQuote({
     route,
     currentBorrowAssets,
     userAddress,
+    isFullClose,
     swapMaxCollateralForDebtQuery.error,
     canCurrentSellCloseDebt,
     currentBorrowShares,
@@ -267,7 +278,7 @@ export function useDeleverageQuote({
       if (closeRouteResolutionFailed) {
         return 'Failed to resolve the exact full-close collateral bound. Refresh the quote and try again.';
       }
-      if (canCurrentSellCloseDebt && currentBorrowShares > 0n && swapMaxCollateralForDebtQuery.error) {
+      if (!isFullClose && canCurrentSellCloseDebt && currentBorrowShares > 0n && swapMaxCollateralForDebtQuery.error) {
         return 'Failed to resolve the exact full-close collateral bound. Refresh the quote and try again.';
       }
       const routeError = withdrawCollateralAmount > 0n ? swapRepayQuoteQuery.error : null;
@@ -281,6 +292,7 @@ export function useDeleverageQuote({
     route,
     userAddress,
     withdrawCollateralAmount,
+    isFullClose,
     closeRouteResolutionFailed,
     canCurrentSellCloseDebt,
     currentBorrowShares,

--- a/src/modals/leverage/components/adjust-leverage-position.tsx
+++ b/src/modals/leverage/components/adjust-leverage-position.tsx
@@ -281,6 +281,7 @@ export function AdjustLeveragePosition({
       action === 'deleverage' && !addedCapitalBlocksDeleverage && !hasInvalidPositionData ? withdrawCollateralAmount : 0n,
     currentBorrowAssets: action === 'deleverage' && !addedCapitalBlocksDeleverage ? currentBorrowAssets : 0n,
     currentBorrowShares: action === 'deleverage' && !addedCapitalBlocksDeleverage ? currentBorrowShares : 0n,
+    isFullClose: action === 'deleverage' && effectiveTargetLtvBps === 0n,
     loanTokenAddress: market.loanAsset.address,
     loanTokenDecimals: market.loanAsset.decimals,
     collateralTokenAddress: market.collateralAsset.address,


### PR DESCRIPTION
## Summary

- skip the Velora exact-output BUY-bound request when the user explicitly selects a full close
- use the execution-authoritative SELL quote to enable repay-by-shares when its slippage-adjusted output covers buffered debt
- preserve the existing BUY-bound behavior for partial deleverage and the existing execution-time SELL validation

## Root cause

Full close was blocked on a separate exact-output BUY quote used to estimate the minimum collateral bound. Velora can fail or return an unusable high-impact BUY route even when selling all collateral produces enough loan assets to close the debt.

## Validation

- `npx ultracite fix`
- `npx ultracite check`
- `pnpm typecheck`
- `pnpm build`
- live Ethereum USDC/strUSD reproduction: the sell-backed full-close Bundler3 call simulated successfully; the prior debt-dust fallback reverted with `insufficient collateral`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-position close calculations for swap-based deleveraging.
  * Full closes can now proceed when a BUY quote is unavailable, using SELL quote information instead.
  * Preserved existing quote resolution behavior for partial position reductions.
  * Improved handling of loading states, errors, route availability, and collateral limits during deleveraging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->