### PR TITLE
Show liquidated accounts in market liquidation tables

### DIFF
--- a/src/data-sources/monarch-api/market-detail.ts
+++ b/src/data-sources/monarch-api/market-detail.ts
@@ -311,6 +311,7 @@ const fetchMonarchLiquidationsWindow = async (
     hash: event.txHash,
     timestamp: toTimestamp(event.timestamp),
     liquidator: event.caller,
+    borrower: event.borrower,
     repaidAssets: event.repaidAssets,
     seizedAssets: event.seizedAssets,
     badDebtAssets: event.badDebtAssets,

--- a/src/data-sources/morpho-api/market-liquidations.ts
+++ b/src/data-sources/morpho-api/market-liquidations.ts
@@ -9,6 +9,9 @@ type MorphoAPILiquidationItem = {
   hash: string;
   timestamp: number;
   type: string; // Should be 'MarketLiquidation'
+  user: {
+    address: string;
+  };
   data: {
     repaidAssets: string;
     seizedAssets: string;
@@ -69,6 +72,7 @@ export const fetchMorphoMarketLiquidations = async (
         hash: item.hash,
         timestamp: item.timestamp,
         liquidator: item.data.liquidator,
+        borrower: item.user.address,
         repaidAssets: item.data.repaidAssets,
         seizedAssets: item.data.seizedAssets,
         badDebtAssets: item.data.badDebtAssets,

--- a/src/features/market-detail/components/liquidations-table.tsx
+++ b/src/features/market-detail/components/liquidations-table.tsx
@@ -61,6 +61,7 @@ export function LiquidationsTable({ chainId, market }: LiquidationsTableProps) {
             <TableHeader>
               <TableRow>
                 <TableHead className="text-left">LIQUIDATOR</TableHead>
+                <TableHead className="text-left">LIQUIDATED ACCOUNT</TableHead>
                 <TableHead className="text-right">REPAID ({market?.loanAsset?.symbol ?? 'Loan'})</TableHead>
                 <TableHead className="text-right">SEIZED ({market?.collateralAsset?.symbol ?? 'Collateral'})</TableHead>
                 <TableHead className="text-right">BAD DEBT ({market?.loanAsset?.symbol ?? 'Loan'})</TableHead>
@@ -72,7 +73,7 @@ export function LiquidationsTable({ chainId, market }: LiquidationsTableProps) {
               {liquidations.length === 0 && !isLoading ? (
                 <TableRow>
                   <TableCell
-                    colSpan={6}
+                    colSpan={7}
                     className="text-center text-gray-400"
                   >
                     No liquidations found for this market
@@ -82,6 +83,7 @@ export function LiquidationsTable({ chainId, market }: LiquidationsTableProps) {
                 liquidations.map((liquidation: MarketLiquidationTransaction) => {
                   const hasBadDebt = BigInt(liquidation.badDebtAssets) !== BigInt(0);
                   const isLiquidatorAddress = liquidation.liquidator?.startsWith('0x');
+                  const isBorrowerAddress = liquidation.borrower?.startsWith('0x');
 
                   return (
                     <TableRow key={`${liquidation.hash}-${liquidation.repaidAssets}`}>
@@ -95,6 +97,18 @@ export function LiquidationsTable({ chainId, market }: LiquidationsTableProps) {
                           />
                         ) : (
                           <span>{liquidation.liquidator}</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {isBorrowerAddress ? (
+                          <AccountIdentity
+                            address={liquidation.borrower as Address}
+                            chainId={chainId}
+                            variant="compact"
+                            linkTo="profile"
+                          />
+                        ) : (
+                          <span>{liquidation.borrower}</span>
                         )}
                       </TableCell>
                       <TableCell className="text-sm">

--- a/src/graphql/morpho-api-queries.ts
+++ b/src/graphql/morpho-api-queries.ts
@@ -382,6 +382,9 @@ export const marketLiquidationsQuery = `
         hash: txHash
         timestamp
         type
+        user {
+          address
+        }
         data {
           ... on MarketTransactionLiquidationData {
             repaidAssets

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -345,6 +345,7 @@ export type MarketLiquidationTransaction = {
   hash: string;
   timestamp: number;
   liquidator: string;
+  borrower: string;
   repaidAssets: string;
   seizedAssets: string;
   badDebtAssets: string;


### PR DESCRIPTION
## Summary
- add the liquidated borrower account beside the liquidator in every market liquidation table
- carry borrower addresses through both Monarch and Morpho API liquidation mappers
- reuse the existing account identity link for borrower profiles

## Validation
- npx ultracite fix
- npx ultracite check
- pnpm typecheck
- live Monarch liquidation fetch confirmed borrower mapping
- live Morpho liquidation fetch confirmed transaction user mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Liquidated Account** column to market liquidation tables.
  * Liquidation records now display the borrower’s account address alongside the liquidator and repayment details.
  * Borrower information is included across supported market data sources and API results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->