### PR TITLE
Surface oracle pricing mechanisms and references

### DIFF
--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -9,8 +9,16 @@ import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { MarketIdBadge } from '@/features/markets/components/market-id-badge';
 import { MarketIdentity, MarketIdentityMode } from '@/features/markets/components/market-identity';
+import { FeedMechanismBadge } from '@/features/markets/components/oracle/MarketOracle/FeedMechanismBadge';
 import { FeedTypeBadge } from '@/features/markets/components/oracle/MarketOracle/FeedTypeBadge';
-import { formatOracleDuration, formatOraclePrice, isMonarchVerifiedFeed } from '@/utils/oracle';
+import {
+  formatOracleDuration,
+  formatOraclePrice,
+  formatPendleOracleType,
+  getFeedMechanism,
+  getFeedReferenceLinks,
+  isMonarchVerifiedFeed,
+} from '@/utils/oracle';
 import { getNetworkImg, getNetworkName } from '@/utils/networks';
 import { MARKETS_PAGE_SIZE, ORACLE_CONTRACTS_PAGE_SIZE } from '../feed-detail-constants';
 import { formatOptionalTimestamp, formatScannerTimestamp } from '../feed-detail-formatters';
@@ -31,6 +39,8 @@ import {
   DependencyTypeValue,
   DetailRow,
   FeedProvenanceBadges,
+  FeedMechanismValue,
+  FeedReferenceLinks,
   FeedTypeValue,
   getDistinctFeedDescription,
   isChainlinkFeedLeg,
@@ -83,6 +93,7 @@ export function FeedHero({
               feedType={leg?.feedType}
               showUnknown
             />
+            <FeedMechanismBadge mechanism={getFeedMechanism(leg)} />
             <FeedProvenanceBadges leg={leg} />
           </div>
 
@@ -246,6 +257,8 @@ export function FeedInspectionSection({
   const deviationThreshold = leg?.deviationThreshold ?? leg?.updateSpread ?? null;
   const isChainlink = isChainlinkFeedLeg(leg);
   const isMonarchVerified = isMonarchVerifiedFeed(leg);
+  const mechanism = getFeedMechanism(leg);
+  const references = getFeedReferenceLinks(leg);
   const formattedAnswer = answer != null && decimals != null ? formatOraclePrice(answer, decimals) : 'Unavailable';
 
   return (
@@ -262,6 +275,35 @@ export function FeedInspectionSection({
             label="Type"
             value={<FeedTypeValue leg={leg} />}
           />
+          {mechanism && (
+            <DetailRow
+              label="Pricing mechanism"
+              value={<FeedMechanismValue leg={leg} />}
+            />
+          )}
+          {mechanism?.parameterLabel && mechanism.parameterValue && (
+            <DetailRow
+              label={mechanism.parameterLabel}
+              value={mechanism.parameterValue}
+            />
+          )}
+          {leg?.pendleOracleType && (
+            <DetailRow
+              label="Pricing path"
+              value={formatPendleOracleType(leg.pendleOracleType)}
+            />
+          )}
+          {leg?.underlyingFeed && (
+            <DetailRow
+              label="Underlying feed"
+              value={
+                <AddressIdentity
+                  address={leg.underlyingFeed}
+                  chainId={chainId}
+                />
+              }
+            />
+          )}
           {!isMonarchVerified && (
             <DetailRow
               label="Provider"
@@ -328,6 +370,12 @@ export function FeedInspectionSection({
             label="Decimals"
             value={decimals ?? leg?.decimals ?? 'Unknown'}
           />
+          {references.length > 0 && (
+            <DetailRow
+              label="References"
+              value={<FeedReferenceLinks leg={leg} />}
+            />
+          )}
         </div>
       </div>
     </SectionShell>

--- a/src/features/feed-detail/components/feed-shared.tsx
+++ b/src/features/feed-detail/components/feed-shared.tsx
@@ -240,12 +240,13 @@ export function FeedMechanismValue({ leg }: { leg: FeedDependencyLeg | null }) {
           />
         }
       >
-        <span
+        <button
+          type="button"
           className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-secondary transition-colors hover:bg-hovered hover:text-primary"
           aria-label={`${mechanism.label} pricing description`}
         >
           <LuInfo className="h-3.5 w-3.5" />
-        </span>
+        </button>
       </Tooltip>
     </div>
   );

--- a/src/features/feed-detail/components/feed-shared.tsx
+++ b/src/features/feed-detail/components/feed-shared.tsx
@@ -8,10 +8,13 @@ import { Badge } from '@/components/ui/badge';
 import { Tooltip } from '@/components/ui/tooltip';
 import { TooltipContent } from '@/components/shared/tooltip-content';
 import { useStyledToast } from '@/hooks/useStyledToast';
+import { FeedMechanismBadge } from '@/features/markets/components/oracle/MarketOracle/FeedMechanismBadge';
 import { FeedTypeBadge, getFeedTypeInfo } from '@/features/markets/components/oracle/MarketOracle/FeedTypeBadge';
 import {
   getChainlinkFeedUrl,
   getChronicleFeedUrl,
+  getFeedMechanism,
+  getFeedReferenceLinks,
   isMonarchVerifiedFeed,
   mapProviderToVendor,
   OracleVendorIcons,
@@ -207,13 +210,65 @@ export function FeedTypeValue({ leg }: { leg: FeedDependencyLeg | null }) {
           />
         }
       >
+        <Link
+          href={feedTypeInfo.docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-secondary transition-colors hover:bg-hovered hover:text-primary"
+          aria-label={`Read ${feedTypeInfo.label} feed docs`}
+        >
+          <ExternalLinkIcon className="h-3.5 w-3.5" />
+        </Link>
+      </Tooltip>
+    </div>
+  );
+}
+
+export function FeedMechanismValue({ leg }: { leg: FeedDependencyLeg | null }) {
+  const mechanism = getFeedMechanism(leg);
+  if (!mechanism) return null;
+
+  return (
+    <div className="inline-flex items-center justify-end gap-1.5">
+      <FeedMechanismBadge mechanism={mechanism} />
+      <Tooltip
+        content={
+          <TooltipContent
+            title={`${mechanism.label} pricing`}
+            detail={mechanism.description}
+            className="max-w-xs"
+          />
+        }
+      >
         <span
           className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-secondary transition-colors hover:bg-hovered hover:text-primary"
-          aria-label={`${feedTypeInfo.label} feed description`}
+          aria-label={`${mechanism.label} pricing description`}
         >
           <LuInfo className="h-3.5 w-3.5" />
         </span>
       </Tooltip>
+    </div>
+  );
+}
+
+export function FeedReferenceLinks({ leg }: { leg: FeedDependencyLeg | null }) {
+  const references = getFeedReferenceLinks(leg);
+  if (references.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap justify-end gap-x-3 gap-y-1">
+      {references.map((reference) => (
+        <Link
+          key={reference.url}
+          href={reference.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-primary no-underline hover:underline"
+        >
+          {reference.label}
+          <ExternalLinkIcon className="h-3 w-3" />
+        </Link>
+      ))}
     </div>
   );
 }

--- a/src/features/feed-detail/feed-detail-utils.ts
+++ b/src/features/feed-detail/feed-detail-utils.ts
@@ -35,6 +35,15 @@ export type FeedDependencyLeg = (EnrichedFeed | EnrichedVault) & {
   asset?: string;
   assetSymbol?: string;
   oracleType?: string;
+  pendleFeedKind?: string;
+  pendleOracleType?: string;
+  twapDuration?: number;
+  baseDiscountPerYear?: string;
+  discountPercentageBps?: number;
+  feedSubtype?: string;
+  underlyingFeed?: string;
+  links?: Array<{ label: string; url: string }>;
+  sourceUrls?: string[];
   pair?: [string, string] | [];
 };
 

--- a/src/features/markets/components/oracle/MarketOracle/FeedMechanismBadge.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedMechanismBadge.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@/components/ui/badge';
+import { FEED_MECHANISM_INFO, type FeedMechanism, type FeedMechanismKind } from '@/utils/oracle';
+
+const BADGE_CLASS_NAME = 'border border-violet-500/20 bg-violet-500/10 text-violet-700 dark:bg-violet-500/10 dark:text-violet-300';
+
+type FeedMechanismBadgeProps = {
+  mechanism: FeedMechanism | FeedMechanismKind | null | undefined;
+  className?: string;
+};
+
+export function FeedMechanismBadge({ mechanism, className }: FeedMechanismBadgeProps) {
+  if (!mechanism) return null;
+
+  const label = typeof mechanism === 'string' ? FEED_MECHANISM_INFO[mechanism].shortLabel : mechanism.label;
+
+  return (
+    <Badge
+      size="sm"
+      className={`${BADGE_CLASS_NAME} ${className ?? ''}`}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/src/features/markets/components/oracle/MarketOracle/FeedTypeSection.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedTypeSection.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { IoHelpCircleOutline } from 'react-icons/io5';
 import { useGlobalModal } from '@/contexts/GlobalModalContext';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
+import { getFeedMechanism } from '@/utils/oracle';
+import { FeedMechanismBadge } from './FeedMechanismBadge';
 import { FeedTypeBadge, getFeedTypeInfo } from './FeedTypeBadge';
 import { FeedTypesModal } from './FeedTypesModal';
 
@@ -11,8 +13,9 @@ type FeedTypeSectionProps = {
 
 export function FeedTypeSection({ feed }: FeedTypeSectionProps) {
   const { toggleModal, closeModal } = useGlobalModal();
+  const mechanism = getFeedMechanism(feed);
 
-  if (!feed.feedType) return null;
+  if (!feed.feedType && !mechanism) return null;
 
   const info = getFeedTypeInfo(feed.feedType);
 
@@ -20,8 +23,9 @@ export function FeedTypeSection({ feed }: FeedTypeSectionProps) {
     <div className="rounded-sm border border-gray-200/40 bg-hovered p-3 dark:border-gray-600/20">
       <div className="flex items-center justify-between gap-3 font-zen text-sm">
         <span className="text-gray-600 dark:text-gray-400">Feed Type:</span>
-        <div className="flex items-center gap-1">
+        <div className="flex flex-wrap items-center justify-end gap-1">
           <FeedTypeBadge feedType={feed.feedType} />
+          <FeedMechanismBadge mechanism={mechanism} />
           <button
             onClick={(event) => {
               event.preventDefault();
@@ -35,21 +39,29 @@ export function FeedTypeSection({ feed }: FeedTypeSectionProps) {
             }}
             className="cursor-pointer text-gray-500 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
             type="button"
-            aria-label="Learn about feed types"
+            aria-label="Learn about feed types and pricing mechanisms"
           >
             <IoHelpCircleOutline size={14} />
           </button>
         </div>
       </div>
-      <p className="mt-2 font-zen text-xs text-gray-600 dark:text-gray-400">{info.description}</p>
-      <Link
-        href={info.docsUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="mt-2 inline-flex font-zen text-xs font-medium text-primary no-underline hover:underline"
-      >
-        Read docs
-      </Link>
+      {feed.feedType && <p className="mt-2 font-zen text-xs text-gray-600 dark:text-gray-400">{info.description}</p>}
+      {mechanism && (
+        <p className="mt-1 font-zen text-xs text-gray-600 dark:text-gray-400">
+          <span className="font-medium text-gray-700 dark:text-gray-300">Mechanism: </span>
+          {mechanism.description}
+        </p>
+      )}
+      {feed.feedType && (
+        <Link
+          href={info.docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-flex font-zen text-xs font-medium text-primary no-underline hover:underline"
+        >
+          Read {info.label} feed docs
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/features/markets/components/oracle/MarketOracle/FeedTypeSection.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedTypeSection.tsx
@@ -21,29 +21,38 @@ export function FeedTypeSection({ feed }: FeedTypeSectionProps) {
 
   return (
     <div className="rounded-sm border border-gray-200/40 bg-hovered p-3 dark:border-gray-600/20">
-      <div className="flex items-center justify-between gap-3 font-zen text-sm">
-        <span className="text-gray-600 dark:text-gray-400">Feed Type:</span>
-        <div className="flex flex-wrap items-center justify-end gap-1">
-          <FeedTypeBadge feedType={feed.feedType} />
-          <FeedMechanismBadge mechanism={mechanism} />
-          <button
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              toggleModal(
-                <FeedTypesModal
-                  isOpen
-                  onClose={() => closeModal()}
-                />,
-              );
-            }}
-            className="cursor-pointer text-gray-500 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
-            type="button"
-            aria-label="Learn about feed types and pricing mechanisms"
-          >
-            <IoHelpCircleOutline size={14} />
-          </button>
+      <div className="flex items-start gap-2 font-zen text-sm">
+        <div className="min-w-0 flex-1 space-y-1.5">
+          {feed.feedType && (
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-gray-600 dark:text-gray-400">Feed Type:</span>
+              <FeedTypeBadge feedType={feed.feedType} />
+            </div>
+          )}
+          {mechanism && (
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-gray-600 dark:text-gray-400">Mechanism:</span>
+              <FeedMechanismBadge mechanism={mechanism} />
+            </div>
+          )}
         </div>
+        <button
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            toggleModal(
+              <FeedTypesModal
+                isOpen
+                onClose={() => closeModal()}
+              />,
+            );
+          }}
+          className="mt-0.5 cursor-pointer text-gray-500 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+          type="button"
+          aria-label="Learn about feed types and pricing mechanisms"
+        >
+          <IoHelpCircleOutline size={14} />
+        </button>
       </div>
       {feed.feedType && <p className="mt-2 font-zen text-xs text-gray-600 dark:text-gray-400">{info.description}</p>}
       {mechanism && (

--- a/src/features/markets/components/oracle/MarketOracle/FeedTypesModal.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedTypesModal.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import { ExternalLinkIcon } from '@radix-ui/react-icons';
 import { Modal, ModalBody, ModalHeader } from '@/components/common/Modal';
+import { FEED_MECHANISM_INFO, type FeedMechanismKind } from '@/utils/oracle';
+import { FeedMechanismBadge } from './FeedMechanismBadge';
 import { FEED_TYPE_INFO, FeedTypeBadge } from './FeedTypeBadge';
 
 type FeedTypesModalProps = {
@@ -18,15 +20,14 @@ export function FeedTypesModal({ isOpen, onClose }: FeedTypesModalProps) {
     >
       <ModalHeader
         title="Feed Types"
-        description="Scanner categories for how each oracle feed derives its price"
+        description="How a feed is classified and how its price is produced"
         onClose={onClose}
       />
 
       <ModalBody>
         <div className="space-y-4">
           <p className="text-sm text-secondary">
-            Feed type is separate from provider. A Chainlink, Compound, Redstone, Pendle, or other provider feed can still belong to a
-            different pricing category.
+            Provider identifies who publishes a feed. Type and mechanism describe what it reports and how the price is produced.
           </p>
 
           <div className="space-y-3">
@@ -51,6 +52,28 @@ export function FeedTypesModal({ isOpen, onClose }: FeedTypesModalProps) {
                   </Link>
                 </div>
                 <p className="mt-2 text-sm text-secondary">{info.description}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <h3 className="text-sm font-medium text-primary">Pricing mechanisms</h3>
+          </div>
+
+          <div className="divide-y divide-border rounded-sm border border-border">
+            {Object.entries(FEED_MECHANISM_INFO).map(([mechanism, info]) => (
+              <div
+                key={mechanism}
+                className="grid gap-2 p-3 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-start"
+              >
+                <div className="flex items-center gap-2">
+                  <FeedMechanismBadge mechanism={mechanism as FeedMechanismKind} />
+                  <span className="text-xs text-secondary sm:hidden">{info.label}</span>
+                </div>
+                <div>
+                  <h4 className="hidden text-sm font-medium text-primary sm:block">{info.label}</h4>
+                  <p className="text-sm text-secondary sm:mt-1">{info.description}</p>
+                </div>
               </div>
             ))}
           </div>

--- a/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
@@ -6,7 +6,14 @@ import { MonarchVerifiedIcon } from '@/components/shared/monarch-verified-icon';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import etherscanLogo from '@/imgs/etherscan.png';
 import { getExplorerURL } from '@/utils/external';
-import { isMonarchVerifiedFeed, mapProviderToVendor, OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
+import {
+  getFeedReferenceLinks,
+  isMonarchVerifiedFeed,
+  mapProviderToVendor,
+  OracleVendorIcons,
+  PriceFeedVendors,
+  type FeedFreshnessStatus,
+} from '@/utils/oracle';
 import { FeedTypeSection } from './FeedTypeSection';
 import { FeedFreshnessSection } from './FeedFreshnessSection';
 
@@ -16,24 +23,10 @@ type GeneralFeedTooltipProps = {
   feedFreshness?: FeedFreshnessStatus;
 };
 
-function getSafeCustomLink(link: { label: string; url: string }): { label: string; url: string } | null {
-  const label = link.label.trim();
-  const candidate = link.url.trim();
-  if (!label || !candidate) return null;
-
-  try {
-    const url = new URL(candidate);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-    return { label, url: url.toString() };
-  } catch {
-    return null;
-  }
-}
-
 export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeedTooltipProps) {
   const baseAsset = feed.pair[0] ?? 'Unknown';
   const quoteAsset = feed.pair[1] ?? 'Unknown';
-  const customLinks = feed.links?.map(getSafeCustomLink).filter((link): link is { label: string; url: string } => link != null) ?? [];
+  const referenceLinks = getFeedReferenceLinks(feed);
   const isMonarchVerified = isMonarchVerifiedFeed(feed);
 
   const vendor = feed.provider ? mapProviderToVendor(feed.provider) : PriceFeedVendors.Unknown;
@@ -118,7 +111,7 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
       {/* External Links */}
       <div className="border-t border-gray-200/30 pt-3 dark:border-gray-600/20">
         <div className="mb-2 font-zen text-sm font-medium text-gray-700 dark:text-gray-300">View on:</div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href={getExplorerURL(feed.address as Address, chainId)}
             target="_blank"
@@ -134,9 +127,9 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
             />
             Explorer
           </Link>
-          {customLinks.map((link) => (
+          {referenceLinks.map((link) => (
             <Link
-              key={`${link.label}-${link.url}`}
+              key={link.url}
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/GeneralFeedTooltip.tsx
@@ -6,14 +6,7 @@ import { MonarchVerifiedIcon } from '@/components/shared/monarch-verified-icon';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import etherscanLogo from '@/imgs/etherscan.png';
 import { getExplorerURL } from '@/utils/external';
-import {
-  getFeedReferenceLinks,
-  isMonarchVerifiedFeed,
-  mapProviderToVendor,
-  OracleVendorIcons,
-  PriceFeedVendors,
-  type FeedFreshnessStatus,
-} from '@/utils/oracle';
+import { isMonarchVerifiedFeed, mapProviderToVendor, OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
 import { FeedTypeSection } from './FeedTypeSection';
 import { FeedFreshnessSection } from './FeedFreshnessSection';
 
@@ -26,7 +19,6 @@ type GeneralFeedTooltipProps = {
 export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeedTooltipProps) {
   const baseAsset = feed.pair[0] ?? 'Unknown';
   const quoteAsset = feed.pair[1] ?? 'Unknown';
-  const referenceLinks = getFeedReferenceLinks(feed);
   const isMonarchVerified = isMonarchVerifiedFeed(feed);
 
   const vendor = feed.provider ? mapProviderToVendor(feed.provider) : PriceFeedVendors.Unknown;
@@ -111,7 +103,7 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
       {/* External Links */}
       <div className="border-t border-gray-200/30 pt-3 dark:border-gray-600/20">
         <div className="mb-2 font-zen text-sm font-medium text-gray-700 dark:text-gray-300">View on:</div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2">
           <Link
             href={getExplorerURL(feed.address as Address, chainId)}
             target="_blank"
@@ -127,17 +119,6 @@ export function GeneralFeedTooltip({ feed, chainId, feedFreshness }: GeneralFeed
             />
             Explorer
           </Link>
-          {referenceLinks.map((link) => (
-            <Link
-              key={link.url}
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bg-hovered flex items-center gap-1 rounded-sm px-3 py-2 text-xs font-medium text-primary no-underline transition-all duration-200 hover:bg-opacity-80"
-            >
-              {link.label}
-            </Link>
-          ))}
         </div>
       </div>
     </div>

--- a/src/features/markets/components/oracle/MarketOracle/PendleFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/PendleFeedTooltip.tsx
@@ -1,11 +1,10 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { Address } from 'viem';
-import { formatUnits } from 'viem';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import etherscanLogo from '@/imgs/etherscan.png';
 import { getExplorerURL } from '@/utils/external';
-import { OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
+import { getFeedReferenceLinks, OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
 import { FeedTypeSection } from './FeedTypeSection';
 import { FeedFreshnessSection } from './FeedFreshnessSection';
 
@@ -15,19 +14,12 @@ type PendleFeedTooltipProps = {
   feedFreshness?: FeedFreshnessStatus;
 };
 
-function formatDiscountPerYear(raw: string): string {
-  if (!/^\d+$/.test(raw)) return '—';
-  const formatted = formatUnits(BigInt(raw), 18);
-  const percent = Number(formatted) * 100;
-  return `${percent.toFixed(2)}%`;
-}
-
 export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTooltipProps) {
   const baseAsset = feed.pair[0] ?? 'Unknown';
   const quoteAsset = feed.pair[1] ?? 'Unknown';
   const pendleFeedKind = feed.pendleFeedKind;
-  const isLinearDiscount = pendleFeedKind?.toLowerCase() === 'lineardiscount';
-  const typeLabel = isLinearDiscount ? 'Linear Discount' : pendleFeedKind;
+  const typeLabel = pendleFeedKind?.toLowerCase() === 'lineardiscount' ? 'Linear Discount' : pendleFeedKind;
+  const referenceLinks = getFeedReferenceLinks(feed);
 
   const vendorIcon = OracleVendorIcons[PriceFeedVendors.Pendle];
 
@@ -58,20 +50,12 @@ export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTo
       <FeedTypeSection feed={feed} />
 
       {/* Pendle Specific Data */}
-      {(typeLabel != null || feed.baseDiscountPerYear != null) && (
+      {typeLabel != null && (
         <div className="space-y-2 border-t border-gray-200/30 pt-3 dark:border-gray-600/20">
-          {typeLabel != null && (
-            <div className="flex justify-between font-zen text-sm">
-              <span className="text-gray-600 dark:text-gray-400">Pendle Model:</span>
-              <span className="font-medium">{typeLabel}</span>
-            </div>
-          )}
-          {feed.baseDiscountPerYear != null && (
-            <div className="flex justify-between font-zen text-sm">
-              <span className="text-gray-600 dark:text-gray-400">Base Discount:</span>
-              <span className="font-medium">{formatDiscountPerYear(feed.baseDiscountPerYear)}</span>
-            </div>
-          )}
+          <div className="flex justify-between font-zen text-sm">
+            <span className="text-gray-600 dark:text-gray-400">Pendle Model:</span>
+            <span className="font-medium">{typeLabel}</span>
+          </div>
         </div>
       )}
 
@@ -80,7 +64,7 @@ export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTo
       {/* External Links */}
       <div className="border-t border-gray-200/30 pt-3 dark:border-gray-600/20">
         <div className="mb-2 font-zen text-sm font-medium text-gray-700 dark:text-gray-300">View on:</div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href={getExplorerURL(feed.address as Address, chainId)}
             target="_blank"
@@ -96,6 +80,17 @@ export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTo
             />
             Etherscan
           </Link>
+          {referenceLinks.map((link) => (
+            <Link
+              key={link.url}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-hovered flex items-center gap-1 rounded-sm px-3 py-2 text-xs font-medium text-primary no-underline transition-all duration-200 hover:bg-opacity-80"
+            >
+              {link.label}
+            </Link>
+          ))}
         </div>
       </div>
     </div>

--- a/src/features/markets/components/oracle/MarketOracle/PendleFeedTooltip.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/PendleFeedTooltip.tsx
@@ -4,7 +4,7 @@ import type { Address } from 'viem';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import etherscanLogo from '@/imgs/etherscan.png';
 import { getExplorerURL } from '@/utils/external';
-import { getFeedReferenceLinks, OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
+import { OracleVendorIcons, PriceFeedVendors, type FeedFreshnessStatus } from '@/utils/oracle';
 import { FeedTypeSection } from './FeedTypeSection';
 import { FeedFreshnessSection } from './FeedFreshnessSection';
 
@@ -19,7 +19,6 @@ export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTo
   const quoteAsset = feed.pair[1] ?? 'Unknown';
   const pendleFeedKind = feed.pendleFeedKind;
   const typeLabel = pendleFeedKind?.toLowerCase() === 'lineardiscount' ? 'Linear Discount' : pendleFeedKind;
-  const referenceLinks = getFeedReferenceLinks(feed);
 
   const vendorIcon = OracleVendorIcons[PriceFeedVendors.Pendle];
 
@@ -64,7 +63,7 @@ export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTo
       {/* External Links */}
       <div className="border-t border-gray-200/30 pt-3 dark:border-gray-600/20">
         <div className="mb-2 font-zen text-sm font-medium text-gray-700 dark:text-gray-300">View on:</div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2">
           <Link
             href={getExplorerURL(feed.address as Address, chainId)}
             target="_blank"
@@ -80,17 +79,6 @@ export function PendleFeedTooltip({ feed, chainId, feedFreshness }: PendleFeedTo
             />
             Etherscan
           </Link>
-          {referenceLinks.map((link) => (
-            <Link
-              key={link.url}
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bg-hovered flex items-center gap-1 rounded-sm px-3 py-2 text-xs font-medium text-primary no-underline transition-all duration-200 hover:bg-opacity-80"
-            >
-              {link.label}
-            </Link>
-          ))}
         </div>
       </div>
     </div>

--- a/src/hooks/useOracleMetadata.ts
+++ b/src/hooks/useOracleMetadata.ts
@@ -43,12 +43,18 @@ export type EnrichedFeed = {
   updateSpread?: number; // Chronicle deviation threshold percentage
   feedType?: OracleFeedType; // Scanner feed category: "market", "fundamental", "dex", "nav", or future categories
   links?: Array<{ label: string; url: string }>;
+  sourceUrls?: string[];
   baseDiscountPerYear?: string; // Pendle base discount per year (raw 18-decimal value)
+  discountPercentageBps?: number; // Fixed discount applied to an underlying feed, in basis points
+  feedSubtype?: string;
   innerOracle?: string; // Pendle inner oracle address
+  underlyingFeed?: string;
   pt?: string; // Pendle PT token address
   ptSymbol?: string; // Pendle PT token symbol
   pendleFeedKind?: string; // Pendle feed kind (e.g. "PendleChainlinkOracle", "LinearDiscount")
   pendleFeedSubtype?: string; // Pendle subtype (e.g. "SparkLinearDiscountOracle")
+  pendleOracleType?: string; // Pendle pricing path (e.g. "PT_TO_ASSET")
+  twapDuration?: number; // Time-weighted average window in seconds
   oracleType?: string;
 };
 

--- a/src/utils/oracle.ts
+++ b/src/utils/oracle.ts
@@ -187,7 +187,7 @@ export type FeedMechanism = {
 
 type FeedMechanismMetadata = Pick<
   EnrichedFeed,
-  'baseDiscountPerYear' | 'discountPercentageBps' | 'feedSubtype' | 'oracleType' | 'pendleFeedKind' | 'twapDuration'
+  'baseDiscountPerYear' | 'discountPercentageBps' | 'feedSubtype' | 'oracleType' | 'pendleFeedKind' | 'pendleFeedSubtype' | 'twapDuration'
 >;
 
 function formatPercent(value: number): string {
@@ -219,8 +219,9 @@ export function getFeedMechanism(feed: FeedMechanismMetadata | null | undefined)
   }
 
   const pendleFeedKind = feed.pendleFeedKind?.replace(/[-_\s]+/g, '').toLowerCase();
+  const pendleFeedSubtype = feed.pendleFeedSubtype?.replace(/[-_\s]+/g, '').toLowerCase();
   const feedSubtype = feed.feedSubtype?.trim().toLowerCase();
-  if (pendleFeedKind === 'lineardiscount' || feedSubtype === 'discounted') {
+  if (pendleFeedKind === 'lineardiscount' || pendleFeedSubtype?.includes('lineardiscount') || feedSubtype === 'discounted') {
     const annualDiscount = formatBaseDiscountPerYear(feed.baseDiscountPerYear);
     const fixedDiscount =
       feed.discountPercentageBps != null && Number.isFinite(feed.discountPercentageBps)

--- a/src/utils/oracle.ts
+++ b/src/utils/oracle.ts
@@ -149,6 +149,176 @@ export type FeedVendorResult = {
   };
 };
 
+export type FeedMechanismKind = 'twap' | 'linear' | 'capped';
+
+export type FeedMechanismInfo = {
+  label: string;
+  shortLabel: string;
+  description: string;
+};
+
+export const FEED_MECHANISM_INFO: Record<FeedMechanismKind, FeedMechanismInfo> = {
+  twap: {
+    label: 'TWAP',
+    shortLabel: 'TWAP',
+    description:
+      'Averages onchain market prices over time. Shorter windows react faster but are more sensitive to large trades in thin markets.',
+  },
+  linear: {
+    label: 'Linear or fixed discount',
+    shortLabel: 'Discount',
+    description:
+      'Applies a deterministic discount instead of tracking trades. This resists direct market manipulation but can diverge from market value.',
+  },
+  capped: {
+    label: 'Capped',
+    shortLabel: 'Capped',
+    description: 'Limits the reported price or collateralization ratio to a configured upper bound.',
+  },
+};
+
+export type FeedMechanism = {
+  kind: FeedMechanismKind;
+  label: string;
+  description: string;
+  parameterLabel?: string;
+  parameterValue?: string;
+};
+
+type FeedMechanismMetadata = Pick<
+  EnrichedFeed,
+  'baseDiscountPerYear' | 'discountPercentageBps' | 'feedSubtype' | 'oracleType' | 'pendleFeedKind' | 'twapDuration'
+>;
+
+function formatPercent(value: number): string {
+  return `${value.toLocaleString('en-US', { maximumFractionDigits: 2 })}%`;
+}
+
+function formatBaseDiscountPerYear(raw: string | undefined): string | null {
+  if (!raw || !/^\d+$/.test(raw)) return null;
+
+  const percent = Number(formatUnits(BigInt(raw), 18)) * 100;
+  return Number.isFinite(percent) ? formatPercent(percent) : null;
+}
+
+export function getFeedMechanism(feed: FeedMechanismMetadata | null | undefined): FeedMechanism | null {
+  if (!feed) return null;
+
+  // Scanner fields are the source of truth because providers such as Ojo can expose
+  // Pendle pricing mechanics without using Pendle-specific classification fields.
+  if (feed.twapDuration != null) {
+    const duration = Number.isFinite(feed.twapDuration) && feed.twapDuration >= 0 ? formatOracleDuration(feed.twapDuration) : null;
+    return {
+      kind: 'twap',
+      label: duration ? `TWAP · ${duration}` : 'TWAP',
+      description: duration
+        ? `Averages onchain market prices over ${duration}. Shorter windows react faster but are more sensitive to large trades in thin markets.`
+        : FEED_MECHANISM_INFO.twap.description,
+      ...(duration ? { parameterLabel: 'TWAP window', parameterValue: duration } : {}),
+    };
+  }
+
+  const pendleFeedKind = feed.pendleFeedKind?.replace(/[-_\s]+/g, '').toLowerCase();
+  const feedSubtype = feed.feedSubtype?.trim().toLowerCase();
+  if (pendleFeedKind === 'lineardiscount' || feedSubtype === 'discounted') {
+    const annualDiscount = formatBaseDiscountPerYear(feed.baseDiscountPerYear);
+    const fixedDiscount =
+      feed.discountPercentageBps != null && Number.isFinite(feed.discountPercentageBps)
+        ? formatPercent(feed.discountPercentageBps / 100)
+        : null;
+
+    if (annualDiscount) {
+      return {
+        kind: 'linear',
+        label: `Linear · ${annualDiscount}/yr`,
+        description: `Applies a ${annualDiscount} annual discount toward par. It does not track market trades and can diverge from market value.`,
+        parameterLabel: 'Base discount per year',
+        parameterValue: annualDiscount,
+      };
+    }
+
+    if (fixedDiscount) {
+      return {
+        kind: 'linear',
+        label: `Discount · ${fixedDiscount}`,
+        description: `Applies a fixed ${fixedDiscount} discount to the underlying feed instead of tracking market trades.`,
+        parameterLabel: 'Fixed discount',
+        parameterValue: fixedDiscount,
+      };
+    }
+
+    return {
+      kind: 'linear',
+      label: 'Linear discount',
+      description: FEED_MECHANISM_INFO.linear.description,
+    };
+  }
+
+  const oracleType = feed.oracleType?.trim().toLowerCase();
+  if (oracleType?.startsWith('capped_') || feedSubtype === 'capped_chainlink') {
+    return {
+      kind: 'capped',
+      label: 'Capped',
+      description: FEED_MECHANISM_INFO.capped.description,
+    };
+  }
+
+  return null;
+}
+
+export function formatPendleOracleType(value: string): string {
+  const [source, target] = value.split('_TO_');
+  if (!source || !target) return value.replaceAll('_', ' ');
+
+  const targetLabel = target === 'ASSET' ? 'asset' : target;
+  return `${source} to ${targetLabel}`;
+}
+
+export type FeedReferenceLink = {
+  label: string;
+  url: string;
+};
+
+type FeedReferenceMetadata = Pick<EnrichedFeed, 'links' | 'sourceUrls'>;
+
+function normalizeFeedReference(label: string, candidate: string): FeedReferenceLink | null {
+  const normalizedLabel = label.trim();
+  const normalizedCandidate = candidate.trim();
+  if (!normalizedLabel || !normalizedCandidate) return null;
+
+  try {
+    const url = new URL(normalizedCandidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return { label: normalizedLabel, url: url.toString() };
+  } catch {
+    return null;
+  }
+}
+
+export function getFeedReferenceLinks(feed: FeedReferenceMetadata | null | undefined): FeedReferenceLink[] {
+  if (!feed) return [];
+
+  const references = new Map<string, FeedReferenceLink>();
+  for (const link of feed.links ?? []) {
+    const reference = normalizeFeedReference(link.label, link.url);
+    if (reference) references.set(reference.url, reference);
+  }
+
+  for (const sourceUrl of feed.sourceUrls ?? []) {
+    let label = 'Reference';
+    try {
+      label = new URL(sourceUrl).hostname.replace(/^www\./, '');
+    } catch {
+      // Invalid URLs are discarded by normalizeFeedReference below.
+    }
+
+    const reference = normalizeFeedReference(label, sourceUrl);
+    if (reference && !references.has(reference.url)) references.set(reference.url, reference);
+  }
+
+  return Array.from(references.values());
+}
+
 /**
  * Detect feed vendor from enriched metadata (primary method)
  * Use this when oracle metadata is available from useOracleMetadata hook


### PR DESCRIPTION
## Summary

- detect TWAP, discount, and capped pricing mechanisms from scanner-native metadata fields
- show compact mechanism badges and explanations in market oracle tooltips and the feed classification guide
- add mechanism parameters, pricing paths, underlying feeds, type documentation, and labeled source references to feed detail pages
- validate and deduplicate scanner `links` and `sourceUrls`, accepting only HTTP(S) destinations

## UI

- keeps feed category and pricing mechanism visually distinct
- uses progressive density: compact badges in headers, short explanations in tooltips, exact parameters on dedicated feed pages
- keeps the mechanism guide to one compact comparison list
- verified at desktop and 390px mobile widths

## Validation

- `npx ultracite fix`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- live mainnet scanner validation for TWAP, discount, capped, and reference-link shapes
- verified all Monarch feed-type anchors and incident-feed reference URLs return successfully

Closes #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pricing mechanism badges, labels, descriptions, and parameters to feed details and market oracle views.
  * Added support for TWAP, linear discount, capped, and Pendle feed classifications.
  * Added Pendle oracle metadata and improved display of underlying feeds.
  * Added validated, deduplicated external reference links with readable source labels.
  * Updated feed type and mechanism documentation modals and tooltips.
  * Improved layout and wrapping for feed metadata and external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->