### PR TITLE
Display scalar oracle feeds natively

### DIFF
--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -275,12 +275,8 @@ export function FeedInspectionSection({
               value={<span className="tabular-nums">{leg.constantValue ?? formattedAnswer}×</span>}
             />
             <DetailRow
-              label="Onchain value"
-              value={
-                <span className="font-monospace text-xs">
-                  {answer?.toLocaleString('en-US') ?? '1,000,000,000,000'} ({decimals ?? leg.decimals ?? 12} decimals)
-                </span>
-              }
+              label="Decimals"
+              value={decimals ?? leg.decimals ?? 12}
             />
             {references.length > 0 && (
               <DetailRow

--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -263,58 +263,25 @@ export function FeedInspectionSection({
 
   if (leg?.feedType === 'constant') {
     return (
-      <SectionShell
-        title="How It Works"
-        detail="Balances oracle decimals without changing the price."
-      >
+      <SectionShell title="How It Works">
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)]">
-          <div className="max-w-2xl space-y-3 text-sm leading-relaxed text-secondary">
-            <p>
-              This contract is a fixed 1× multiplier. Morpho uses its 12 decimal places to balance the oracle scale, so the adapter changes
-              the math&apos;s units, not the price.
-            </p>
-            <p>Some configurations need it to keep the scale exponent non-negative and deployable.</p>
+          <div className="max-w-2xl text-sm leading-relaxed text-secondary">
+            <p>A fixed 1× multiplier. Its 12 decimal places keep Morpho&apos;s oracle scale valid without changing the price.</p>
           </div>
 
           <div>
             <DetailRow
-              label="Type"
-              value={<FeedTypeValue leg={leg} />}
+              label="Multiplier"
+              value={<span className="tabular-nums">{leg.constantValue ?? formattedAnswer}×</span>}
             />
             <DetailRow
-              label="Value"
-              value={<span className="tabular-nums">{leg.constantValue ?? formattedAnswer}</span>}
-            />
-            <DetailRow
-              label="Raw answer"
-              value={<span className="font-monospace text-xs">{answer?.toLocaleString('en-US') ?? '1,000,000,000,000'}</span>}
-            />
-            <DetailRow
-              label="Decimals"
-              value={decimals ?? leg.decimals ?? 12}
-            />
-            <DetailRow
-              label="Provider"
+              label="Onchain value"
               value={
-                <ProviderLink
-                  leg={leg}
-                  chainId={chainId}
-                  className="inline-flex items-center justify-end gap-1.5 text-primary no-underline hover:underline"
-                />
+                <span className="font-monospace text-xs">
+                  {answer?.toLocaleString('en-US') ?? '1,000,000,000,000'} ({decimals ?? leg.decimals ?? 12} decimals)
+                </span>
               }
             />
-            {leg.builtBy && (
-              <DetailRow
-                label="Built by"
-                value={leg.builtBy}
-              />
-            )}
-            {leg.noAdmin && (
-              <DetailRow
-                label="Admin controls"
-                value="No admin"
-              />
-            )}
             {references.length > 0 && (
               <DetailRow
                 label="References"

--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -264,16 +264,16 @@ export function FeedInspectionSection({
   if (leg?.feedType === 'constant') {
     return (
       <SectionShell
-        title="Constant Scale Adapter"
-        detail="Fixed-value input used for decimal scaling, not market pricing."
+        title="How It Works"
+        detail="Balances oracle decimals without changing the price."
       >
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)]">
           <div className="max-w-2xl space-y-3 text-sm leading-relaxed text-secondary">
             <p>
-              Morpho combines token and feed decimals into a scale factor. This adapter returns 1,000,000,000,000 with 12 decimals, which
-              normalizes to exactly 1. It corrects the scale calculation without changing the economic price.
+              This contract is a fixed 1× multiplier. Morpho uses its 12 decimal places to balance the oracle scale, so the adapter changes
+              the math&apos;s units, not the price.
             </p>
-            <p>Without this quote-side adapter, some oracle configurations would require a negative power of ten and could not deploy.</p>
+            <p>Some configurations need it to keep the scale exponent non-negative and deployable.</p>
           </div>
 
           <div>

--- a/src/features/feed-detail/components/feed-sections.tsx
+++ b/src/features/feed-detail/components/feed-sections.tsx
@@ -261,6 +261,72 @@ export function FeedInspectionSection({
   const references = getFeedReferenceLinks(leg);
   const formattedAnswer = answer != null && decimals != null ? formatOraclePrice(answer, decimals) : 'Unavailable';
 
+  if (leg?.feedType === 'constant') {
+    return (
+      <SectionShell
+        title="Constant Scale Adapter"
+        detail="Fixed-value input used for decimal scaling, not market pricing."
+      >
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)]">
+          <div className="max-w-2xl space-y-3 text-sm leading-relaxed text-secondary">
+            <p>
+              Morpho combines token and feed decimals into a scale factor. This adapter returns 1,000,000,000,000 with 12 decimals, which
+              normalizes to exactly 1. It corrects the scale calculation without changing the economic price.
+            </p>
+            <p>Without this quote-side adapter, some oracle configurations would require a negative power of ten and could not deploy.</p>
+          </div>
+
+          <div>
+            <DetailRow
+              label="Type"
+              value={<FeedTypeValue leg={leg} />}
+            />
+            <DetailRow
+              label="Value"
+              value={<span className="tabular-nums">{leg.constantValue ?? formattedAnswer}</span>}
+            />
+            <DetailRow
+              label="Raw answer"
+              value={<span className="font-monospace text-xs">{answer?.toLocaleString('en-US') ?? '1,000,000,000,000'}</span>}
+            />
+            <DetailRow
+              label="Decimals"
+              value={decimals ?? leg.decimals ?? 12}
+            />
+            <DetailRow
+              label="Provider"
+              value={
+                <ProviderLink
+                  leg={leg}
+                  chainId={chainId}
+                  className="inline-flex items-center justify-end gap-1.5 text-primary no-underline hover:underline"
+                />
+              }
+            />
+            {leg.builtBy && (
+              <DetailRow
+                label="Built by"
+                value={leg.builtBy}
+              />
+            )}
+            {leg.noAdmin && (
+              <DetailRow
+                label="Admin controls"
+                value="No admin"
+              />
+            )}
+            {references.length > 0 && (
+              <DetailRow
+                label="References"
+                value={<FeedReferenceLinks leg={leg} />}
+              />
+            )}
+          </div>
+        </div>
+      </SectionShell>
+    );
+  }
+
   return (
     <SectionShell title="Price, Last 24 Hours">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)]">

--- a/src/features/feed-detail/components/feed-shared.tsx
+++ b/src/features/feed-detail/components/feed-shared.tsx
@@ -131,7 +131,7 @@ export function FeedProvenanceBadges({ leg }: { leg: FeedDependencyLeg | null })
   return (
     <>
       {isMonarchVerifiedFeed(leg) && <MonarchVerifiedBadge />}
-      {leg.noAdmin && (
+      {leg.noAdmin && leg.feedType !== 'constant' && (
         <Badge
           size="sm"
           className="border border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300"

--- a/src/features/feed-detail/feed-detail-constants.ts
+++ b/src/features/feed-detail/feed-detail-constants.ts
@@ -11,4 +11,5 @@ export const FEED_TYPE_PAGE_COPY: Record<string, string> = {
   fundamental: 'A fundamental feed reports a protocol conversion rate or accounting relationship, not a traded spot price.',
   nav: 'A NAV feed reports net asset value based on assets, liabilities, reserves, or collateralization.',
   dex: 'A DEX feed derives price from onchain market structure such as a pool, TWAP, or Pendle market.',
+  constant: 'A constant feed returns a fixed value for oracle scale calculations rather than tracking a market price.',
 };

--- a/src/features/feed-detail/feed-detail-constants.ts
+++ b/src/features/feed-detail/feed-detail-constants.ts
@@ -11,5 +11,5 @@ export const FEED_TYPE_PAGE_COPY: Record<string, string> = {
   fundamental: 'A fundamental feed reports a protocol conversion rate or accounting relationship, not a traded spot price.',
   nav: 'A NAV feed reports net asset value based on assets, liabilities, reserves, or collateralization.',
   dex: 'A DEX feed derives price from onchain market structure such as a pool, TWAP, or Pendle market.',
-  constant: 'A constant feed returns a fixed value for oracle scale calculations rather than tracking a market price.',
+  constant: 'A scalar feed returns a fixed 1× multiplier used to balance oracle decimals.',
 };

--- a/src/features/feed-detail/feed-detail-utils.ts
+++ b/src/features/feed-detail/feed-detail-utils.ts
@@ -248,7 +248,7 @@ export function getFeedPairLabel(leg: FeedDependencyLeg | null): string {
 }
 
 export function getFeedTitle(leg: FeedDependencyLeg | null, address: string): string {
-  if (leg?.feedType === 'constant') return `Constant ${leg.constantValue ?? '1'}`;
+  if (leg?.feedType === 'constant') return 'Scalar';
   const pairLabel = getFeedPairLabel(leg);
   if (pairLabel !== 'Unknown pair') return pairLabel;
   if (leg?.description) return leg.description;

--- a/src/features/feed-detail/feed-detail-utils.ts
+++ b/src/features/feed-detail/feed-detail-utils.ts
@@ -22,6 +22,7 @@ export type FeedDependencyLeg = (EnrichedFeed | EnrichedVault) & {
   builtBy?: string;
   noAdmin?: boolean;
   feedType?: string;
+  constantValue?: string;
   decimals?: number;
   tier?: string;
   heartbeat?: number;
@@ -247,6 +248,7 @@ export function getFeedPairLabel(leg: FeedDependencyLeg | null): string {
 }
 
 export function getFeedTitle(leg: FeedDependencyLeg | null, address: string): string {
+  if (leg?.feedType === 'constant') return `Constant ${leg.constantValue ?? '1'}`;
   const pairLabel = getFeedPairLabel(leg);
   if (pairLabel !== 'Unknown pair') return pairLabel;
   if (leg?.description) return leg.description;

--- a/src/features/feed-detail/feed-detail-utils.ts
+++ b/src/features/feed-detail/feed-detail-utils.ts
@@ -260,6 +260,10 @@ export function getFeedProviderLabel(leg: FeedDependencyLeg | null): string {
     return leg?.builtBy ?? 'Monarch verified';
   }
 
+  if (leg?.feedType === 'constant') {
+    return leg.builtBy ?? leg.vendor ?? leg.provider ?? 'Unknown provider';
+  }
+
   return leg?.provider ?? leg?.vendor ?? 'Unknown provider';
 }
 

--- a/src/features/feed-detail/feed-view.tsx
+++ b/src/features/feed-detail/feed-view.tsx
@@ -74,6 +74,7 @@ export default function FeedContent() {
   }, [occurrences, representativeLeg]);
   const dependencyKind = representativeOccurrence?.kind ?? null;
   const isVaultDependency = dependencyKind === 'vault';
+  const isConstantFeed = representativeLeg?.feedType === 'constant';
   const isChainlinkFeed = isChainlinkFeedLeg(representativeLeg);
 
   const {
@@ -134,7 +135,7 @@ export default function FeedContent() {
     address: feedAddress,
     chainId,
     decimals: feedDecimals,
-    enabled: isRouteSupported && !oracleMetadataLoading && !isVaultDependency,
+    enabled: isRouteSupported && !oracleMetadataLoading && !isVaultDependency && !isConstantFeed,
   });
   const totalSupplyUsd = dependencies.reduce((sum, dependency) => sum + toFiniteNumber(dependency.market.state.supplyAssetsUsd), 0);
   const totalBorrowUsd = dependencies.reduce((sum, dependency) => sum + toFiniteNumber(dependency.market.state.borrowAssetsUsd), 0);

--- a/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
@@ -117,8 +117,8 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
     if (isConstantFeed) {
       return (
         <TooltipContent
-          title={`Constant ${feed.constantValue ?? '1'}`}
-          detail="Fixed-value scale adapter. Open the feed page for details."
+          title="Scalar"
+          detail="Fixed 1× multiplier used to balance oracle decimals."
         />
       );
     }
@@ -223,7 +223,7 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
       >
         {isConstantFeed ? (
           <div className="flex min-w-0 flex-1 items-center gap-1">
-            <span className="text-xs font-medium">Constant {feed.constantValue ?? '1'}</span>
+            <span className="text-xs font-medium">Scalar</span>
           </div>
         ) : showAssetPair ? (
           <div className="flex min-w-0 flex-1 items-center gap-1">

--- a/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
@@ -4,10 +4,12 @@ import type { Address } from 'viem';
 import { useReadContracts } from 'wagmi';
 import { chainlinkAggregatorV3Abi } from '@/abis/chainlink-aggregator-v3';
 import { MonarchVerifiedIcon } from '@/components/shared/monarch-verified-icon';
+import { TooltipContent } from '@/components/shared/tooltip-content';
 import { Tooltip } from '@/components/ui/tooltip';
 import Image from 'next/image';
 import { IoIosSwap } from 'react-icons/io';
 import { IoHelpCircleOutline } from 'react-icons/io5';
+import { LuEqual } from 'react-icons/lu';
 import type { FeedSnapshotByAddress } from '@/hooks/useFeedLastUpdatedByChain';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import {
@@ -90,6 +92,7 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
   const vendorIcon = OracleVendorIcons[vendor];
   const hasKnownVendorIcon = vendor !== PriceFeedVendors.Unknown && Boolean(vendorIcon);
   const isMonarchVerified = isMonarchVerifiedFeed(feed);
+  const isConstantFeed = feed.feedType === 'constant';
   const feedAddressKey = feed.address.toLowerCase();
   const snapshot = feedSnapshotsByAddress?.[feedAddressKey];
   const directAnswer =
@@ -111,6 +114,15 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
   });
 
   const getTooltipContent = () => {
+    if (isConstantFeed) {
+      return (
+        <TooltipContent
+          title={`Constant ${feed.constantValue ?? '1'}`}
+          detail="Fixed-value scale adapter. Open the feed page for details."
+        />
+      );
+    }
+
     switch (vendor) {
       case PriceFeedVendors.Chainlink:
       case PriceFeedVendors.Chronicle:
@@ -209,7 +221,11 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
         className="bg-hovered flex w-full cursor-pointer items-center justify-between rounded-sm px-2 py-1 hover:bg-opacity-80 gap-1 no-underline text-primary"
         onClick={(event) => event.stopPropagation()}
       >
-        {showAssetPair ? (
+        {isConstantFeed ? (
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <span className="text-xs font-medium">Constant {feed.constantValue ?? '1'}</span>
+          </div>
+        ) : showAssetPair ? (
           <div className="flex min-w-0 flex-1 items-center gap-1">
             <span className="max-w-[2.5rem] truncate whitespace-nowrap text-xs font-medium">{baseAsset}</span>
             <IoIosSwap
@@ -225,7 +241,12 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
         )}
 
         <div className="flex flex-shrink-0 items-center gap-1">
-          {isMonarchVerified ? (
+          {isConstantFeed ? (
+            <LuEqual
+              size={14}
+              className="flex-shrink-0 text-secondary"
+            />
+          ) : isMonarchVerified ? (
             <MonarchVerifiedIcon size={14} />
           ) : hasKnownVendorIcon ? (
             <Image

--- a/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedEntry.tsx
@@ -9,7 +9,6 @@ import { Tooltip } from '@/components/ui/tooltip';
 import Image from 'next/image';
 import { IoIosSwap } from 'react-icons/io';
 import { IoHelpCircleOutline } from 'react-icons/io5';
-import { LuEqual } from 'react-icons/lu';
 import type { FeedSnapshotByAddress } from '@/hooks/useFeedLastUpdatedByChain';
 import type { EnrichedFeed } from '@/hooks/useOracleMetadata';
 import {
@@ -118,7 +117,7 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
       return (
         <TooltipContent
           title="Scalar"
-          detail="Fixed 1× multiplier used to balance oracle decimals."
+          detail="Fixed 1× multiplier for oracle scaling."
         />
       );
     }
@@ -242,10 +241,7 @@ export function FeedEntry({ feed, chainId, feedSnapshotsByAddress }: FeedEntryPr
 
         <div className="flex flex-shrink-0 items-center gap-1">
           {isConstantFeed ? (
-            <LuEqual
-              size={14}
-              className="flex-shrink-0 text-secondary"
-            />
+            <span className="flex-shrink-0 text-xs tabular-nums text-secondary">1×</span>
           ) : isMonarchVerified ? (
             <MonarchVerifiedIcon size={14} />
           ) : hasKnownVendorIcon ? (

--- a/src/features/markets/components/oracle/MarketOracle/FeedTypeBadge.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedTypeBadge.tsx
@@ -38,6 +38,13 @@ export const FEED_TYPE_INFO: Record<KnownOracleFeedType, FeedTypeInfo> = {
     docsUrl: 'https://docs.monarchlend.xyz/docs/oracles-feed#nav-feed',
     badgeClassName: 'border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300',
   },
+  constant: {
+    label: 'Constant',
+    shortLabel: 'Constant',
+    description: 'Returns a fixed value for oracle scale calculations rather than tracking a market price.',
+    docsUrl: 'https://github.com/Steakhouse-Financial/steakhouse-oracles/blob/main/src/DummyFeed.sol',
+    badgeClassName: 'border border-gray-500/20 bg-gray-500/10 text-gray-700 dark:bg-gray-500/10 dark:text-gray-300',
+  },
 };
 
 const UNKNOWN_FEED_TYPE_INFO: FeedTypeInfo = {

--- a/src/features/markets/components/oracle/MarketOracle/FeedTypeBadge.tsx
+++ b/src/features/markets/components/oracle/MarketOracle/FeedTypeBadge.tsx
@@ -39,9 +39,9 @@ export const FEED_TYPE_INFO: Record<KnownOracleFeedType, FeedTypeInfo> = {
     badgeClassName: 'border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300',
   },
   constant: {
-    label: 'Constant',
-    shortLabel: 'Constant',
-    description: 'Returns a fixed value for oracle scale calculations rather than tracking a market price.',
+    label: 'Scalar',
+    shortLabel: 'Scalar',
+    description: 'Returns a fixed 1× multiplier used to balance oracle decimals.',
     docsUrl: 'https://github.com/Steakhouse-Financial/steakhouse-oracles/blob/main/src/DummyFeed.sol',
     badgeClassName: 'border border-gray-500/20 bg-gray-500/10 text-gray-700 dark:bg-gray-500/10 dark:text-gray-300',
   },

--- a/src/hooks/useOracleMetadata.ts
+++ b/src/hooks/useOracleMetadata.ts
@@ -22,7 +22,7 @@ import { createPersistedApiResponseKey } from '@/utils/persistedApiResponseCache
  */
 
 export type OracleFeedProvider = string | null;
-export type KnownOracleFeedType = 'market' | 'fundamental' | 'dex' | 'nav';
+export type KnownOracleFeedType = 'market' | 'fundamental' | 'dex' | 'nav' | 'constant';
 export type OracleFeedType = KnownOracleFeedType | (string & {});
 
 export type EnrichedFeed = {
@@ -42,6 +42,7 @@ export type EnrichedFeed = {
   updateInterval?: number; // Chronicle update cadence in seconds
   updateSpread?: number; // Chronicle deviation threshold percentage
   feedType?: OracleFeedType; // Scanner feed category: "market", "fundamental", "dex", "nav", or future categories
+  constantValue?: string;
   links?: Array<{ label: string; url: string }>;
   sourceUrls?: string[];
   baseDiscountPerYear?: string; // Pendle base discount per year (raw 18-decimal value)
@@ -141,6 +142,27 @@ export type OracleMetadataRecord = Record<string, OracleOutput>;
 export type OracleMetadataMap = Map<string, OracleOutput>;
 
 const ORACLE_GIST_BASE_URL = process.env.NEXT_PUBLIC_ORACLE_GIST_BASE_URL?.replace(/\/+$/, '');
+const STEAKHOUSE_DUMMY_FEED_ADDRESS = '0xc3866d726c204c0836e0677a31973c649888973d';
+
+// Existing cached scanner payloads classify this live contract as unknown. Normalize it at
+// metadata ingestion so every market and detail view receives the same feed semantics.
+const STEAKHOUSE_DUMMY_FEED_METADATA: Partial<EnrichedFeed> = {
+  description: 'Constant scale adapter for Morpho oracle decimals',
+  pair: [],
+  provider: 'Steakhouse',
+  vendor: 'Steakhouse Financial',
+  builtBy: 'Steakhouse Financial',
+  noAdmin: true,
+  decimals: 12,
+  feedType: 'constant',
+  constantValue: '1',
+  feedSubtype: 'morpho_scale_adapter',
+  oracleType: 'morpho_scale_adapter',
+  sourceUrls: [
+    'https://github.com/Steakhouse-Financial/steakhouse-oracles/blob/main/src/DummyFeed.sol',
+    'https://etherscan.io/address/0xc3866d726c204c0836e0677a31973c649888973d#code',
+  ],
+};
 
 export function getOracleMetadataKey(chainId: number, oracleAddress: string): string {
   return `${chainId}-${oracleAddress.toLowerCase()}`;
@@ -189,10 +211,46 @@ function transformToRecord(data: OracleMetadataFile | null | undefined): OracleM
   const record: OracleMetadataRecord = {};
   for (const oracle of data.oracles) {
     if (oracle?.address) {
-      record[oracle.address.toLowerCase()] = oracle;
+      record[oracle.address.toLowerCase()] = applyKnownFeedMetadata(oracle);
     }
   }
   return record;
+}
+
+function applyKnownFeedMetadata(oracle: OracleOutput): OracleOutput {
+  if (oracle.chainId !== 1) return oracle;
+
+  const applyToFeed = (feed: EnrichedFeed | null): EnrichedFeed | null => {
+    if (feed?.address.toLowerCase() !== STEAKHOUSE_DUMMY_FEED_ADDRESS) return feed;
+    return { ...feed, ...STEAKHOUSE_DUMMY_FEED_METADATA };
+  };
+  const applyToData = (oracleData: OracleOutputData | null): OracleOutputData | null => {
+    if (!oracleData) return null;
+    return {
+      ...oracleData,
+      baseFeedOne: applyToFeed(oracleData.baseFeedOne),
+      baseFeedTwo: applyToFeed(oracleData.baseFeedTwo),
+      quoteFeedOne: applyToFeed(oracleData.quoteFeedOne),
+      quoteFeedTwo: applyToFeed(oracleData.quoteFeedTwo),
+    };
+  };
+
+  if (oracle.type === 'standard') {
+    return { ...oracle, data: applyToData(oracle.data) as OracleOutputData };
+  }
+  if (oracle.type === 'meta') {
+    return {
+      ...oracle,
+      data: {
+        ...oracle.data,
+        oracleSources: {
+          primary: applyToData(oracle.data.oracleSources.primary),
+          backup: applyToData(oracle.data.oracleSources.backup),
+        },
+      },
+    };
+  }
+  return oracle;
 }
 
 /**

--- a/src/hooks/useOracleMetadata.ts
+++ b/src/hooks/useOracleMetadata.ts
@@ -147,7 +147,7 @@ const STEAKHOUSE_DUMMY_FEED_ADDRESS = '0xc3866d726c204c0836e0677a31973c649888973
 // Existing cached scanner payloads classify this live contract as unknown. Normalize it at
 // metadata ingestion so every market and detail view receives the same feed semantics.
 const STEAKHOUSE_DUMMY_FEED_METADATA: Partial<EnrichedFeed> = {
-  description: 'Constant scale adapter for Morpho oracle decimals',
+  description: 'Scalar adapter for Morpho oracle decimals',
   pair: [],
   provider: 'Steakhouse',
   vendor: 'Steakhouse Financial',

--- a/src/utils/oracle.ts
+++ b/src/utils/oracle.ts
@@ -727,6 +727,7 @@ export function checkFeedsPath(
  */
 function getEnrichedFeedPath(feed: EnrichedFeed | null): { base: string; quote: string } {
   if (!feed?.address) return { base: 'EMPTY', quote: 'EMPTY' };
+  if (feed.feedType === 'constant') return { base: 'EMPTY', quote: 'EMPTY' };
   if (feed.pair?.length === 2) return { base: feed.pair[0], quote: feed.pair[1] };
   return { base: 'Unknown', quote: 'Unknown' };
 }


### PR DESCRIPTION
## Summary

- render the Steakhouse adapter as a compact `Scalar` feed row with a `1×` value
- keep the market row compact and replace price-history/freshness UI with a scalar-specific detail section
- show only the useful facts: a short purpose statement, `1×` multiplier, `12` decimals, and references
- show `Steakhouse Financial` once and omit the redundant provider/builder and no-admin rows
- treat scalar feeds as no-ops in asset path matching, removing the false unknown-pair warning
- normalize the known live contract at metadata ingestion so the preview also works with cached scanner payloads

## Design

The tooltip, breadcrumb, page title, and type badge use the label `Scalar`; the compact market row pairs it with `1×`. The detail page explains that its 12 decimals keep Morpho's oracle scale valid without changing the price.

Preview route: `/feed/1/0xc3866d726c204c0836e0677a31973c649888973d`

Oracle metadata support was merged first in monarch-xyz/oracles#42.

## Classification notes

- `noAdmin` is optional metadata, not a default; it is intentionally hidden here because this immutable scalar does not need an admin-status callout
- the UI relies on scanner semantics instead of inferring from `answer == 1`
- an exact-bytecode scan of 555 indexed mainnet feeds found no other clone of this Steakhouse identity scalar
- two feeds describe themselves as constant oracles, but encode economic prices rather than a neutral 1× scale and should not receive the Scalar label

## Validation

- `npx ultracite fix`
- `npx ultracite check`
- `pnpm typecheck`
- `pnpm build`
- local browser verification at the exact feed detail route
- confirmed the simplified fields and provider label render, `No admin` is absent, and browser console errors are empty
