### PR TITLE
Recognize mGLO on Robinhood

### DIFF
--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -584,7 +584,10 @@ const supportedTokens = [
     symbol: 'mGLO',
     img: require('../imgs/tokens/mglo.png') as string,
     decimals: 18,
-    networks: [{ chain: base, address: '0xFCc9Cc1209651Ed8867332d6F664CF82743A2584' }],
+    networks: [
+      { chain: base, address: '0xFCc9Cc1209651Ed8867332d6F664CF82743A2584' },
+      { chain: robinhood, address: '0xFEd493F38c1aAcb4EA4e6A11F8b9287849EE0096' },
+    ],
     protocol: {
       name: 'Midas',
     },


### PR DESCRIPTION
## Summary

- add the official Robinhood Chain deployment to the existing mGLO token entry
- reuse the existing mGLO artwork and Midas protocol metadata

## Verification

- Midas registry: https://docs.midas.app/resources/smart-contracts-registry
- Blockscout: https://robinhoodchain.blockscout.com/token/0xfed493f38c1aacb4ea4e6a11f8b9287849ee0096
- `npm run tokens:verify-metadata`
- `pnpm check`
- `npx ultracite check src/utils/tokens.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the mGLO token on the Robinhood network, alongside its existing Base network support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->